### PR TITLE
Add KPs to retriever

### DIFF
--- a/packages/server/config/api_list.yaml
+++ b/packages/server/config/api_list.yaml
@@ -103,6 +103,8 @@ include:
   # not accessible by team or api-specific endpoints
   ## Notes: robokop contains most of these APIs' contents
   ##        it doesn't cover: cam-kp, genome-alliance, monarch-kg, icees-kg, viral-proteome
+  - id: a9d6ee341d8ea4c7d3ae9ed0941cb274
+    name: Automat-binding-db(Trapi v1.5.0)
   - id: 7ab0209ea8590341d8e5d0166cac3d2f
     name: Automat-cam-kp(Trapi v1.5.0)
   - id: f82c01b15c46e024212c1a3271aaef0b
@@ -135,8 +137,14 @@ include:
     name: Automat-panther(Trapi v1.5.0)
   - id: 1f057c53d42694686369f0e542f965c6
     name: Automat-pharos(Trapi v1.5.0)
+  - id: 61b41c5d9b90eb8ad16e037f9a87d593
+    name: Automat-reactome(Trapi v1.5.0)
   - id: 4f9c8853b721ef1f14ecee6d92fc19b5
     name: Automat-robokop(Trapi v1.5.0)
+  - id: 7984a621a28c109c5c09f65fed0e7ea7
+    name: Automat-string-db(Trapi v1.5.0)
+  - id: dde0552a37fc136526216148ff7594a0
+    name: Automat-ubergraph(Trapi v1.5.0)
   - id: 2aca41fc6c3dc426ec6583d42603be02
     name: Automat-viral-proteome(Trapi v1.5.0)
   # TRAPI (Translator standard) APIs: COHD

--- a/packages/server/config/api_list.yaml
+++ b/packages/server/config/api_list.yaml
@@ -127,4 +127,8 @@ include:
   # not accessible by team or api-specific endpoints
   - id: 23f770568b92b7a82063989b3ddd9706
     name: Connections Hypothesis Provider API
+  # TRAPI (Translator standard) APIs: MolePro
+  # not accessible by team or api-specific endpoints
+  - id: 1901bab8d33bb70b124f400ec1cfdba3
+    name: MolePro
 exclude: [] # if adding exclude remove these square brackets

--- a/packages/server/config/api_list.yaml
+++ b/packages/server/config/api_list.yaml
@@ -101,8 +101,6 @@ include:
     name: Text Mining Targeted Association API
   # TRAPI (Translator standard) APIs: Automat
   # not accessible by team or api-specific endpoints
-  # Notes: We don't ingest the following:
-  # - Automat-robokop: seems to repeat a lot of data that is in the other APIs
   - id: f82c01b15c46e024212c1a3271aaef0b
     name: Automat-ctd(Trapi v1.5.0)
   - id: 673b9fc76973dfa5fe3ed151fdbfc807
@@ -129,6 +127,8 @@ include:
     name: Automat-panther(Trapi v1.5.0)
   - id: 1f057c53d42694686369f0e542f965c6
     name: Automat-pharos(Trapi v1.5.0)
+  - id: 4f9c8853b721ef1f14ecee6d92fc19b5
+    name: Automat-robokop(Trapi v1.5.0)
   - id: 2aca41fc6c3dc426ec6583d42603be02
     name: Automat-viral-proteome(Trapi v1.5.0)
   # TRAPI (Translator standard) APIs: COHD

--- a/packages/server/config/api_list.yaml
+++ b/packages/server/config/api_list.yaml
@@ -101,15 +101,40 @@ include:
     name: Text Mining Targeted Association API
   # TRAPI (Translator standard) APIs: Automat
   # not accessible by team or api-specific endpoints
-  ## Notes: not including APIs covered by robokop's contents
+  ## Notes: robokop contains most of these APIs' contents
+  ##        it doesn't cover: cam-kp, genome-alliance, monarch-kg, icees-kg, viral-proteome
   - id: 7ab0209ea8590341d8e5d0166cac3d2f
     name: Automat-cam-kp(Trapi v1.5.0)
+  - id: f82c01b15c46e024212c1a3271aaef0b
+    name: Automat-ctd(Trapi v1.5.0)
+  - id: 673b9fc76973dfa5fe3ed151fdbfc807
+    name: Automat-drug-central(Trapi v1.5.0)
   - id: b4c868db33b95b4890faeeefd5800552
     name: Automat-genome-alliance(Trapi v1.5.0)
+  - id: eef72049e4e01c020b7799f711e0e65b
+    name: Automat-gtex(Trapi v1.5.0)
+  - id: 759df287a21c30cd514df323be02a84b
+    name: Automat-gtopdb(Trapi v1.5.0)
+  - id: 349fed5531c094c33f10c071efe9d0de
+    name: Automat-gwas-catalog(Trapi v1.5.0)
+  - id: a5fe24f987331b58191e67598118f369
+    name: Automat-hetionet(Trapi v1.5.0)
+  - id: 8671309d2b94e413a4c1f9a9f82e4660
+    name: Automat-hgnc(Trapi v1.5.0)
+  - id: 0a1c0f46f4950b82b1aa7dad27aad10a
+    name: Automat-hmdb(Trapi v1.5.0)
+  - id: cb7a43d444cb3dcbe8e3c78d314334cf
+    name: Automat-human-goa(Trapi v1.5.0)
   - id: c64d583402f21cc85810d33befe49c86
     name: Automat-icees-kg(Trapi v1.5.0)
+  - id: b4023595664163e0aec5e825da150e16
+    name: Automat-intact(Trapi v1.5.0)
   - id: 6b88f83127513bd350e6962218ea84f4
     name: Automat-monarchinitiative(Trapi v1.5.0)
+  - id: 3f78d3fb8a7a577fbc7cc0a913ac3fc5
+    name: Automat-panther(Trapi v1.5.0)
+  - id: 1f057c53d42694686369f0e542f965c6
+    name: Automat-pharos(Trapi v1.5.0)
   - id: 4f9c8853b721ef1f14ecee6d92fc19b5
     name: Automat-robokop(Trapi v1.5.0)
   - id: 2aca41fc6c3dc426ec6583d42603be02

--- a/packages/server/config/api_list.yaml
+++ b/packages/server/config/api_list.yaml
@@ -101,32 +101,15 @@ include:
     name: Text Mining Targeted Association API
   # TRAPI (Translator standard) APIs: Automat
   # not accessible by team or api-specific endpoints
-  - id: f82c01b15c46e024212c1a3271aaef0b
-    name: Automat-ctd(Trapi v1.5.0)
-  - id: 673b9fc76973dfa5fe3ed151fdbfc807
-    name: Automat-drug-central(Trapi v1.5.0)
-  - id: eef72049e4e01c020b7799f711e0e65b
-    name: Automat-gtex(Trapi v1.5.0)
-  - id: 759df287a21c30cd514df323be02a84b
-    name: Automat-gtopdb(Trapi v1.5.0)
-  - id: 349fed5531c094c33f10c071efe9d0de
-    name: Automat-gwas-catalog(Trapi v1.5.0)
-  - id: a5fe24f987331b58191e67598118f369
-    name: Automat-hetionet(Trapi v1.5.0)
-  - id: 8671309d2b94e413a4c1f9a9f82e4660
-    name: Automat-hgnc(Trapi v1.5.0)
-  - id: 0a1c0f46f4950b82b1aa7dad27aad10a
-    name: Automat-hmdb(Trapi v1.5.0)
-  - id: cb7a43d444cb3dcbe8e3c78d314334cf
-    name: Automat-human-goa(Trapi v1.5.0)
+  ## Notes: not including APIs covered by robokop's contents
+  - id: 7ab0209ea8590341d8e5d0166cac3d2f
+    name: Automat-cam-kp(Trapi v1.5.0)
+  - id: b4c868db33b95b4890faeeefd5800552
+    name: Automat-genome-alliance(Trapi v1.5.0)
   - id: c64d583402f21cc85810d33befe49c86
     name: Automat-icees-kg(Trapi v1.5.0)
-  - id: b4023595664163e0aec5e825da150e16
-    name: Automat-intact(Trapi v1.5.0)
-  - id: 3f78d3fb8a7a577fbc7cc0a913ac3fc5
-    name: Automat-panther(Trapi v1.5.0)
-  - id: 1f057c53d42694686369f0e542f965c6
-    name: Automat-pharos(Trapi v1.5.0)
+  - id: 6b88f83127513bd350e6962218ea84f4
+    name: Automat-monarchinitiative(Trapi v1.5.0)
   - id: 4f9c8853b721ef1f14ecee6d92fc19b5
     name: Automat-robokop(Trapi v1.5.0)
   - id: 2aca41fc6c3dc426ec6583d42603be02


### PR DESCRIPTION
Discuss before merging! @tokebe @maximusunc 

In this PR, I've adjusted the list of Automat KPs:
* added robokop
* made extra adjustments. If we don't want these, I can revert the most recent commit
    * removed the APIs that robokop covers
    * added KPs that robokop doesn't cover (icees-kg, viral-proteome were kept from the original list in retriever):
        * cam-kp
        * genome-alliance
        * monarch-kg

I had issues running retriever, so I did integration testing with BTE. BTE seemed to work with all the added KPs. 
* I set INSTANCE_ENV=test
* These APIs have `sri_testing_data` endpoints, for example edges...which was awesome for my testing! However, I noticed that I couldn't find some of the example edges that I queried for, @maximusunc. 