### PR TITLE
QGX: Symmetric predicate handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,16 @@ dbs = 'task dbs:stop && task dbs:start'
 jaeger = 'task jaeger:stop && task jaeger:start'
 
 launch = 'retriever'
-'launch:debug' = 'DEBUG=true LOG_LEVEL=TRACE JOB__LOOKUP__TIMEOUT=-1 WORKERS=1 retriever'
+'launch:debug' = """
+    DEBUG=true \
+    LOG_LEVEL=TRACE \
+    JOB__LOOKUP__TIER0_TIMEOUT=-1 \
+    JOB__LOOKUP__TIER1_TIMEOUT=-1 \
+    JOB__LOOKUP__TIER2_TIMEOUT=-1 \
+    JOB__METAKG__TIMEOUT=-1 \
+    WORKERS=1 \
+    retriever
+"""
 
 start = 'task dbs && task launch'
 dev = 'task dbs && task launch:debug'

--- a/src/retriever/data_tiers/tier_manager.py
+++ b/src/retriever/data_tiers/tier_manager.py
@@ -15,14 +15,14 @@ from retriever.data_tiers.tier_1.elasticsearch.driver import ElasticSearchDriver
 from retriever.data_tiers.tier_1.elasticsearch.transpiler import ElasticsearchTranspiler
 from retriever.types.trapi_pydantic import TierNumber
 
-BACKEND_DRIVERS = dict[str, DatabaseDriver](
-    elasticsearch=ElasticSearchDriver(),
-    dgraph=DgraphGrpcDriver(),
+BACKEND_DRIVERS = dict[str, type[DatabaseDriver]](
+    elasticsearch=ElasticSearchDriver,
+    dgraph=DgraphGrpcDriver,
 )
 
-TRANSPILERS = dict[str, Transpiler](
-    elasticsearch=ElasticsearchTranspiler(),
-    dgraph=DgraphTranspiler(),
+TRANSPILERS = dict[str, type[Transpiler]](
+    elasticsearch=ElasticsearchTranspiler,
+    dgraph=DgraphTranspiler,
 )
 
 QUERY_HANDLERS = dict[str, type[Tier0Query]](
@@ -33,9 +33,9 @@ QUERY_HANDLERS = dict[str, type[Tier0Query]](
 def get_driver(tier: TierNumber) -> DatabaseDriver:
     """Get the configured driver for the given tier."""
     if tier == 0:
-        return BACKEND_DRIVERS[CONFIG.tier0.backend]
+        return BACKEND_DRIVERS[CONFIG.tier0.backend]()
     elif tier == 1:
-        return BACKEND_DRIVERS[CONFIG.tier1.backend]
+        return BACKEND_DRIVERS[CONFIG.tier1.backend]()
     else:
         raise NotImplementedError(f"Tier {tier} is not yet implemented.")
 
@@ -43,9 +43,9 @@ def get_driver(tier: TierNumber) -> DatabaseDriver:
 def get_transpiler(tier: TierNumber) -> Transpiler:
     """Get the configured transpiler for the given tier."""
     if tier == 0:
-        return TRANSPILERS[CONFIG.tier0.backend]
+        return TRANSPILERS[CONFIG.tier0.backend]()
     elif tier == 1:
-        return TRANSPILERS[CONFIG.tier1.backend]
+        return TRANSPILERS[CONFIG.tier1.backend]()
     else:
         raise NotImplementedError(f"Tier {tier} is not yet implemented.")
 

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -620,6 +620,8 @@ class QueryGraphExecutor:
             self.job_log.info(
                 f"QGX timeout is {'disabled' if self.timeout < 0 else f'{self.timeout}s'}."
             )
+            if self.timeout < 0:
+                return
             await asyncio.sleep(self.timeout)
             self.job_log.error("QGX hit timeout, attempting wrapup...")
             self.terminate = True

--- a/src/retriever/lookup/subquery.py
+++ b/src/retriever/lookup/subquery.py
@@ -1,13 +1,17 @@
 import asyncio
 import math
 import time
+from typing import Any
 
 from opentelemetry import trace
 from reasoner_pydantic import QueryGraph
 
 from retriever.data_tiers import tier_manager
+from retriever.data_tiers.base_transpiler import Transpiler
 from retriever.lookup.branch import Branch
+from retriever.types.general import BackendResult
 from retriever.types.trapi import (
+    BiolinkPredicate,
     Infores,
     KnowledgeGraphDict,
     LogEntryDict,
@@ -15,10 +19,149 @@ from retriever.types.trapi import (
     QNodeDict,
     QueryGraphDict,
 )
+from retriever.utils import biolink
 from retriever.utils.logs import TRAPILogger
-from retriever.utils.trapi import append_aggregator_source, normalize_kgraph
+from retriever.utils.trapi import (
+    append_aggregator_source,
+    normalize_kgraph,
+)
 
 tracer = trace.get_tracer("lookup.execution.tracer")
+
+
+def make_payloads(
+    branch: Branch, qg: QueryGraph, job_log: TRAPILogger
+) -> tuple[list[QueryGraphDict], list[Transpiler], list[Any]]:
+    """Convert the existing branch edge to query payloads.
+
+    Produces multiple if symmetric predicates are present.
+    """
+    edge_id = branch.current_edge
+    current_edge = QEdgeDict(**qg.edges[edge_id].model_dump())
+    subject_node = QNodeDict(**qg.nodes[current_edge["subject"]].model_dump())
+    object_node = QNodeDict(**qg.nodes[current_edge["object"]].model_dump())
+    if not branch.reversed:
+        subject_node["ids"] = [branch.input_curie]
+    else:
+        object_node["ids"] = [branch.input_curie]
+
+    qgraph = QueryGraphDict(
+        nodes={
+            current_edge["subject"]: subject_node,
+            current_edge["object"]: object_node,
+        },
+        edges={edge_id: current_edge},
+    )
+
+    subject_info = (
+        subject_node.get("ids", None) or subject_node.get("categories", []) or []
+    )
+    if "biolink:NamedThing" in subject_info:
+        subject_info = ["biolink:NamedThing"]
+    object_info = (
+        object_node.get("ids", None) or object_node.get("categories", []) or []
+    )
+    if "biolink:NamedThing" in object_info:
+        object_info = ["biolink:NamedThing"]
+    predicate_info = current_edge.get("predicates", ["biolink:related_to"]) or [
+        "biolink:related_to"
+    ]
+    if "biolink:related_to" in predicate_info:
+        predicate_info = ["biolink:related_to"]
+    job_log.debug(
+        f"Subquerying Tier 1 for {subject_info} -{predicate_info}-> {object_info}..."
+    )
+
+    # Check the symmetric predicate case
+    symmetrics = list[BiolinkPredicate]()
+    for predicate in current_edge.get("predicates") or [
+        BiolinkPredicate("biolink:related_to")
+    ]:
+        if biolink.is_symmetric(str(predicate)):
+            symmetrics.append(predicate)
+
+    transpiler = tier_manager.get_transpiler(1)
+    query_payload = transpiler.process_qgraph(qgraph)
+    job_log.trace(str(query_payload))
+    qgraphs = [qgraph]
+    queries = [query_payload]
+    transpilers = [transpiler]  # keep transpilers in case they store anything
+
+    if len(symmetrics):
+        symmetrics_info = (
+            symmetrics
+            if "biolink:related_to" not in symmetrics
+            else ["biolink:related_to"]
+        )
+        job_log.debug("Symmetric predicates found, adding reverse subquery.")
+        job_log.debug(
+            f"Subquerying Tier 1 for {object_info} -{symmetrics_info}-> {subject_info}..."
+        )
+        reverse_edge = QEdgeDict(
+            subject=current_edge["subject"],
+            object=current_edge["object"],
+            predicates=current_edge.get(
+                "predicates", [BiolinkPredicate("biolink:related_to")]
+            ),
+        )
+        if qualifiers := current_edge.get("qualifier_constraints"):
+            reverse_edge["qualifier_constraints"] = (
+                biolink.reverse_qualifier_constraints(qualifiers)
+            )
+        # BUG: doesn't reverse attribute constraints. But this is vanishingly unlikely.
+        reverse_qg = QueryGraphDict(
+            nodes={
+                current_edge["subject"]: object_node,
+                current_edge["object"]: subject_node,
+            },
+            edges={edge_id: reverse_edge},
+        )
+        transpiler = tier_manager.get_transpiler(1)  # Transpiler isn't singleton
+        reverse_query_payload = transpiler.process_qgraph(reverse_qg)
+        qgraphs.append(reverse_qg)
+        queries.append(reverse_query_payload)
+        transpilers.append(transpiler)
+
+    return qgraphs, transpilers, queries
+
+
+async def run_queries(
+    qgraphs: list[QueryGraphDict],
+    transpilers: list[Transpiler],
+    query_payloads: list[Any],
+    job_log: TRAPILogger,
+) -> list[BackendResult]:
+    """Given a set of query payloads, run them and combine their results."""
+    query_driver = tier_manager.get_driver(1)
+
+    subqueries = [
+        asyncio.create_task(query_driver.run_query(payload))
+        for payload in query_payloads
+    ]
+
+    response_records = await asyncio.gather(*subqueries, return_exceptions=True)
+    results = list[BackendResult]()
+    for i, record in enumerate(response_records):
+        if isinstance(record, Exception):
+            continue  # Exception will come from driver, which should have logged.
+        result = transpilers[i].convert_results(qgraphs[i], record)
+
+        # Add Retriever to the provenance chain
+        for edge_id, edge in result["knowledge_graph"]["edges"].items():
+            try:
+                append_aggregator_source(edge, Infores("infores:retriever"))
+            except ValueError:
+                job_log.warning(f"Edge f{edge_id} has an invalid provenance chain.")
+
+        results.append(result)
+
+    # Have to do this for each
+    for result in results:
+        normalize_kgraph(
+            result["knowledge_graph"], result["results"], result["auxiliary_graphs"]
+        )
+
+    return results
 
 
 @tracer.start_as_current_span("subquery")
@@ -36,73 +179,26 @@ async def subquery(
         job_log: TRAPILogger = TRAPILogger(job_id)
         start = time.time()
 
-        transpiler = tier_manager.get_transpiler(1)
-        query_driver = tier_manager.get_driver(1)
-
         # branch comes in execution direction
         # edge it refers to is in query direction
+        qgraphs, transpilers, query_payloads = make_payloads(branch, qg, job_log)
+        results = await run_queries(qgraphs, transpilers, query_payloads, job_log)
 
-        edge_id = branch.current_edge
-        current_edge = QEdgeDict(**qg.edges[edge_id].model_dump())
-        subject_node = QNodeDict(**qg.nodes[current_edge["subject"]].model_dump())
-        object_node = QNodeDict(**qg.nodes[current_edge["object"]].model_dump())
-        if not branch.reversed:
-            subject_node["ids"] = [branch.input_curie]
-        else:
-            object_node["ids"] = [branch.input_curie]
-
-        qgraph = QueryGraphDict(
-            nodes={
-                current_edge["subject"]: subject_node,
-                current_edge["object"]: object_node,
-            },
-            edges={edge_id: current_edge},
-        )
-
-        query_payload = transpiler.process_qgraph(qgraph)
-        job_log.trace(str(query_payload))
-
-        subject_info = (
-            subject_node.get("ids", None) or subject_node.get("categories", []) or []
-        )
-        if "biolink:NamedThing" in subject_info:
-            subject_info = ["biolink:NamedThing"]
-        object_info = (
-            object_node.get("ids", None) or object_node.get("categories", []) or []
-        )
-        if "biolink:NamedThing" in object_info:
-            object_info = ["biolink:NamedThing"]
-        predicate_info = current_edge.get("predicates", ["biolink:related_to"]) or [
-            "biolink:related_to"
-        ]
-        if "biolink:related_to" in predicate_info:
-            predicate_info = ["biolink:related_to"]
-        job_log.debug(
-            f"Subquerying Tier 1 for {subject_info} -{predicate_info}-> {object_info}..."
-        )
-
-        response_record = await query_driver.run_query(query_payload)
-
-        result = transpiler.convert_results(qgraph, response_record)
-
-        # Add Retriever to the provenance chain
-        for edge_id, edge in result["knowledge_graph"]["edges"].items():
-            try:
-                append_aggregator_source(edge, Infores("infores:retriever"))
-            except ValueError:
-                job_log.warning(f"Edge f{edge_id} has an invalid provenance chain.")
-
+        kg = results[0]["knowledge_graph"]
+        if len(results) > 1:
+            for result in results[1:]:
+                # We can only do this because we can guarantee both graphs are disjoint,
+                # except for nodes, but any two nodes that are the same ID should be
+                # exactly the same.
+                # update_kgraph() should be used in all other cases
+                kg["nodes"].update(result["knowledge_graph"]["nodes"])
+                kg["edges"].update(result["knowledge_graph"]["edges"])
         end = time.time()
         job_log.debug(
-            f"Subquery got {len(result['knowledge_graph']['edges'])} records in {math.ceil((end - start) * 1000)}ms"
+            f"Subquery got {len(kg['edges'])} records in {math.ceil((end - start) * 1000)}ms"
         )
 
-        # Have to do this for each
-        normalize_kgraph(
-            result["knowledge_graph"], result["results"], result["auxiliary_graphs"]
-        )
-
-        return result["knowledge_graph"], job_log.get_logs()
+        return kg, job_log.get_logs()
 
     except asyncio.CancelledError:
         return KnowledgeGraphDict(nodes={}, edges={}), []

--- a/src/retriever/metakg/metakg.py
+++ b/src/retriever/metakg/metakg.py
@@ -1,7 +1,5 @@
 import asyncio
 import itertools
-import math
-import time
 from typing import NamedTuple
 
 import aiofiles
@@ -207,7 +205,6 @@ class MetaKGManager:
 
         Returns None if any QEdge is unsupported by the current operation table.
         """
-        start = time.time()
         plan = OperationPlan()
         unsupported_qedges = list[QEdgeID]()
         for qedge_id, qedge in qgraph.edges.items():
@@ -216,9 +213,6 @@ class MetaKGManager:
                 unsupported_qedges.append(QEdgeID(qedge_id))
             plan[QEdgeID(qedge_id)] = operations
 
-        end = time.time()
-        duration_ms = math.ceil((end - start) * 1000)
-        print(f"operation plan took {duration_ms}ms")
         if len(unsupported_qedges) > 0:
             return unsupported_qedges
         return plan


### PR DESCRIPTION
- Adds symmetric predicate handling to the existing subquery method.
- Fixes an issue where we were re-using transpilers (which should not be done)
- Removes an erroneous print statement
- Fixes an issue with QGX misinterpreting timeout introduced by #59
- Updates the `task dev` so it uses the new timeout settings