### PR TITLE
Use DINGO metadata as OperationTable source (fix #35)

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -33,7 +33,9 @@ job:
     tier1_timeout: 10 # Time in seconds before a tier 1 query should time out, set to -1 to disable.
     tier2_timeout: 300 # Time in seconds before a tier 2 query should time out, set to -1 to disable.
   metakg:
-    timeout: 10  # Time in seconds before a job should time out, set to -1 to disable.
+    retries: 3  # Number of times to retry obtaining DINGO metadata.
+    acquire_timeout: 30 # Time in seconds until a metadata call should time out, set to -1 to disable.
+    timeout: 10 # Time in seconds before a job should time out, set to -1 to disable.
     build_time: -1 # Time in seconds before MetaKG should be rebuilt. Set to -1 to only build at start.
   ttl: 2592000  # Time in seconds for job state to remain after it was last touched
   ttl_max: 31536000 # Time in seconds after which job state is cleared, regardless of last touch
@@ -59,8 +61,9 @@ mongo:
   flood_batch_size: 1000 #  Batch size for basic mongo inserts.
 tier0:
   backend: dgraph
-  metakg_file: data/rtx-kg2-metakg.json
-  backend_infores: infores:automat-robokop
+  metakg_url:
+    https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json
+  backend_infores: infores:dogpark-tier0
   neo4j:
     query_timeout: 3600  # Time in seconds before a neo4j query should time out.
     connect_retries: 5 # Number of retries before declaring a connection failure.
@@ -81,8 +84,9 @@ tier0:
     grpc_max_receive_message_length: -1 # gRPC max receive message length in bytes (-1 for unlimited).
 tier1:
   backend: elasticsearch
-  metakg_file: data/rtx-kg2-metakg.json
-  backend_infores: infores:rtx-kg2
+  metakg_url:
+    https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json
+  backend_infores: infores:dogpark-tier1
   elasticsearch:
     query_timeout: 180  # Time in seconds before a Elasticsearch query should time out.
     connect_retries: 5 # Number of retries before declaring a connection failure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "ruamel-yaml>=0.18.14",
     "pydantic-core>=2.33.1",
     "orjson>=3.11.2",
-    "aiofiles>=24.1.0",
     "zstandard>=0.24.0",
     "ormsgpack>=1.10.0",
     "uvloop>=0.21.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,12 @@ echo "✅ All set!"
         -d \
         -p 6379:6379 \
         --ulimit memlock=-1 \
-        docker.dragonflydb.io/dragonflydb/dragonfly
+        docker.dragonflydb.io/dragonflydb/dragonfly:v1.35.0
 """
 'dragonfly:stop' = 'echo "stopping dragonfly..." && docker rm --force test-dragonfly'
 dragonfly = 'task dragonfly:stop && task dragonfly:start'
 
-'mongo:start' = 'echo "starting mongodb..." && docker run --name test-mongodb -p 27017:27017 -d mongodb/mongodb-community-server:latest'
+'mongo:start' = 'echo "starting mongodb..." && docker run --name test-mongodb -p 27017:27017 -d mongodb/mongodb-community-server:7.0-ubuntu2204'
 'mongo:stop' = 'echo "stopping mongodb..." && docker rm -f test-mongodb'
 mongo = 'task mongo:stop && task mongo:start'
 
@@ -123,7 +123,7 @@ dbs = 'task dbs:stop && task dbs:start'
         -p 16686:16686 \
         -p 4317:4317 \
         -p 4318:4318 \
-        jaegertracing/all-in-one:latest
+        jaegertracing/all-in-one:1.75.0
 """
 'jaeger:stop' = 'echo "stopping jaeger..." && docker rm --force test-jaeger'
 'jaeger:open' = 'python -m webbrowser http://localhost:16686'

--- a/src/retriever/config/general.py
+++ b/src/retriever/config/general.py
@@ -1,8 +1,7 @@
 import warnings
-from pathlib import Path
 from typing import Annotated, ClassVar, override
 
-from pydantic import AfterValidator, BaseModel, Field, FilePath, SecretStr
+from pydantic import AfterValidator, BaseModel, Field, SecretStr
 from pydantic_file_secrets import FileSecretsSettingsSource, SettingsConfigDict
 from pydantic_settings import (
     BaseSettings,
@@ -142,6 +141,15 @@ class LookupSettings(BaseModel):
 class MetaKGSettings(BaseModel):
     """Settings pertaining to metakg queries."""
 
+    retries: Annotated[
+        int, Field(description="Number of times to retry obtaining DINGO metadata.")
+    ] = 3
+    acquire_timeout: Annotated[
+        int,
+        Field(
+            description="Time in seconds until a metadata call should time out, set to -1 to disable."
+        ),
+    ] = 30
     timeout: Annotated[
         int,
         Field(
@@ -215,8 +223,8 @@ class Tier1Settings(BaseModel):
     """Settings concern Tier 1 abstraction layers."""
 
     backend: str = "elasticsearch"
-    metakg_file: FilePath = Path("data/rtx-kg2-metakg.json")
-    backend_infores: str = "infores:rtx-kg2"
+    metakg_url: str = "https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json"
+    backend_infores: str = "infores:dogpark-tier1"
     elasticsearch: ElasticSearchSettings = ElasticSearchSettings()
 
 
@@ -286,8 +294,8 @@ class Tier0Settings(BaseModel):
     """Settings concern Tier 0 abstraction layers."""
 
     backend: str = "dgraph"
-    metakg_file: FilePath = Path("data/rtx-kg2-metakg.json")
-    backend_infores: str = "infores:automat-robokop"
+    metakg_url: str = "https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json"
+    backend_infores: str = "infores:dogpark-tier0"
     neo4j: Neo4jSettings = Neo4jSettings()
     dgraph: DgraphSettings = DgraphSettings()
 

--- a/src/retriever/types/dingo.py
+++ b/src/retriever/types/dingo.py
@@ -1,0 +1,115 @@
+from typing import NotRequired, TypedDict
+
+from pydantic import TypeAdapter
+
+from retriever.types.trapi import (
+    BiolinkEntity,
+    BiolinkPredicate,
+    Infores,
+    QualifierTypeID,
+)
+
+DistributionInfo = TypedDict(
+    "DistributionInfo",
+    {
+        "@id": str,
+        "@type": str,
+        "contentUrl": str,
+        "encodingFormat": str,
+        "description": str,
+    },
+)
+"""Information expressing how to obtain the KGX files."""
+
+
+class LicenseInfo(TypedDict):
+    """Information expressing usage license."""
+
+    terms_of_use_url: NotRequired[str]
+    license_name: NotRequired[str]
+    license_url: NotRequired[str]
+
+
+class SourceInfo(TypedDict):
+    """Information about a knowledge source."""
+
+    id: str
+    name: str
+    description: str
+    license: LicenseInfo | str
+    url: list[str]
+    version: str
+
+
+class NodeInfo(TypedDict):
+    """Information about a class of nodes present in the knowledge."""
+
+    category: list[BiolinkEntity]
+    count: int
+    id_prefixes: dict[str, int]
+    attributes: dict[str, int]
+
+
+class NodeSummary(TypedDict):
+    """A summary of all nodes present in the knowledge."""
+
+    total_count: int
+    id_prefixes: dict[str, int]
+    attributes: dict[str, int]
+
+
+class EdgeInfo(TypedDict):
+    """Information about a class of edges present in the knowledge."""
+
+    subject_category: list[BiolinkEntity]
+    predicate: BiolinkPredicate
+    object_category: list[BiolinkEntity]
+    count: int
+    primary_knowledge_sources: dict[Infores, int]
+    qualifiers: dict[QualifierTypeID, int]
+    attributes: dict[str, int]
+    subject_id_prefixes: dict[str, int]
+    object_id_prefixes: dict[str, int]
+
+
+class EdgeSummary(TypedDict):
+    """A summary of all edges present in the knowledge."""
+
+    total_count: int
+    predicates: dict[BiolinkPredicate, int]
+    primary_knowledge_sources: dict[Infores, int]
+    predicates_by_knowledge_source: dict[Infores, dict[BiolinkPredicate, int]]
+    qualifiers: dict[QualifierTypeID, int]
+    attributes: dict[str, int]
+
+
+class SchemaInfo(TypedDict):
+    """Information about the given knowledge schema."""
+
+    nodes: list[NodeInfo]
+    nodes_summary: NodeSummary
+    edges: list[EdgeInfo]
+    edges_summary: EdgeSummary
+
+
+DINGOMetadata = TypedDict(
+    "DINGOMetadata",
+    {
+        "@id": str,
+        "@type": str,
+        "name": str,
+        "description": str,
+        "license": str,
+        "url": str,
+        "version": str,
+        "dateCreated": str,
+        "biolinkVersion": str,
+        "babelVersion": str,
+        "distribution": list[DistributionInfo],
+        "isBasedOn": list[SourceInfo],
+        "schema": SchemaInfo,
+    },
+)
+"""Metadata pertaining to a given DINGO ingest file."""
+
+DINGO_ADAPTER = TypeAdapter(DINGOMetadata)

--- a/src/retriever/utils/calls.py
+++ b/src/retriever/utils/calls.py
@@ -12,10 +12,21 @@ USER_AGENT = f"Retriever/{CONFIG.instance_env} Python/{version}"
 
 def get_callback_client() -> httpx.AsyncClient:
     """Get a client with appropriate settings for making callbacks."""
-    callback_transport = httpx.AsyncHTTPTransport(retries=CONFIG.job.callback.retries)
+    transport = httpx.AsyncHTTPTransport(retries=CONFIG.job.callback.retries)
     return httpx.AsyncClient(
         timeout=CONFIG.job.callback.timeout,
-        transport=callback_transport,
+        transport=transport,
+        follow_redirects=True,
+        headers={"user-agent": f"Retriever/{CONFIG.instance_env} Python/{version}"},
+    )
+
+
+def get_metadata_client() -> httpx.AsyncClient:
+    """Get a client with appropriate settings for obtaining outside metadata."""
+    transport = httpx.AsyncHTTPTransport(retries=CONFIG.job.callback.retries)
+    return httpx.AsyncClient(
+        timeout=CONFIG.job.metakg.acquire_timeout,
+        transport=transport,
         follow_redirects=True,
         headers={"user-agent": f"Retriever/{CONFIG.instance_env} Python/{version}"},
     )

--- a/src/retriever/utils/trapi.py
+++ b/src/retriever/utils/trapi.py
@@ -354,6 +354,8 @@ def meta_qualifier_meets_constraints(
             q_type, q_val = qualifier.qualifier_type_id, qualifier.qualifier_value
             if q_type in meta_qualifiers:
                 expanded_vals = biolink.get_descendant_values(q_type, q_val)
+                if not len(meta_qualifiers[QualifierTypeID(q_type)]):
+                    continue
                 if expanded_vals & set(meta_qualifiers[QualifierTypeID(q_type)]):
                     continue
                 else:

--- a/uv.lock
+++ b/uv.lock
@@ -3,15 +3,6 @@ revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
-name = "aiofiles"
-version = "24.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
-]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1980,7 +1971,6 @@ name = "retriever"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiofiles" },
     { name = "aiohttp" },
     { name = "bmt" },
     { name = "cachetools" },
@@ -2033,7 +2023,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.9.0" },
     { name = "bmt", specifier = ">=1.4.6" },
     { name = "cachetools", specifier = ">=5.3.1" },


### PR DESCRIPTION
Ingests the DINGO metadata to use for building the OperationTable. Presently, this is somewhat of a hack: it pulls directly from the merged Tier 0 metadata for both Tier 1 and 0. For now this is fine; Tier 0 contains all Tier 1 resources. 

In the very near future, however, we'll need to migrate to pulling the metakg from our backends instead, to avoid any problems with the ingest hosting changing, etc.