### PR TITLE
fix(dgraph): Correct Dgraph Query Generation for Attribute Constraints

### DIFF
--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -414,7 +414,7 @@ class DgraphTranspiler(Tier0Transpiler):
 
     def _create_filter_expression(self, constraint: AttributeConstraintDict) -> str:
         """Create a filter expression for a single constraint."""
-        field_name = self._v(constraint["id"])
+        field_name = self._v(constraint["id"].replace("biolink:", ""))
         value = constraint["value"]
         operator = constraint["operator"]
         is_negated = constraint.get("not", False)

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -89,6 +89,35 @@ SIMPLE_QGRAPH: QueryGraphDict = qg({
     },
 })
 
+SIMPLE_QGRAPH_GT_NOT: QueryGraphDict = qg({
+    "nodes": {
+        "n0": {
+            "ids": ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"],
+        },
+        "n1": {},
+    },
+    "edges": {
+        "e0": {
+            "subject": "n0",
+            "object": "n1",
+            "predicates": ["biolink:has_phenotype"],
+            "attribute_constraints": [
+                {
+                    "id": "biolink:has_total",
+                    "operator": ">",
+                    "value": 2,
+                },
+                {
+                    "id": "biolink:has_total",
+                    "operator": ">",
+                    "value": 4,
+                    "not": True,
+                },
+            ],
+        }
+    },
+})
+
 SIMPLE_QGRAPH_MULTIPLE_IDS: QueryGraphDict = qg({
     "nodes": {
         "n0": {"ids": ["CHEBI:3125", "CHEBI:53448"], "constraints": []},
@@ -600,6 +629,23 @@ EXP_SIMPLE = dedent("""
             }
         }
     }
+}
+""").strip()
+
+EXP_SIMPLE_GT_NOT = dedent("""
+{
+  q0_node_n0(func: eq(id, ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"])) @cascade(id, ~subject) {
+    expand(Node)
+    out_edges_e0: ~subject
+      @filter(eq(predicate_ancestors, "has_phenotype") AND
+        gt(has_total, "2") AND
+        NOT(gt(has_total, "4"))) @cascade(predicate, object) {
+      expand(Edge) { sources expand(Source) }
+      node_n1: object @cascade(id) {
+        expand(Node)
+      }
+    }
+  }
 }
 """).strip()
 
@@ -1121,6 +1167,7 @@ DGRAPH_FLOATING_OBJECT_QUERY_TWO_CATEGORIES = dedent("""
 
 CASES: list[QueryCase] = [
     QueryCase("simple-one", SIMPLE_QGRAPH, EXP_SIMPLE),
+    QueryCase("simple-gt-not", SIMPLE_QGRAPH_GT_NOT, EXP_SIMPLE_GT_NOT),
     QueryCase("simple-multiple-ids", SIMPLE_QGRAPH_MULTIPLE_IDS, EXP_SIMPLE_MULTIPLE_IDS),
     QueryCase("simple-reverse", SIMPLE_REVERSE_QGRAPH, EXP_SIMPLE_REVERSE),
     QueryCase("two-hop", TWO_HOP_QGRAPH, EXP_TWO_HOP),


### PR DESCRIPTION
The transpiler was not stripping the `biolink:` prefix from attribute constraint IDs, resulting in invalid field names in the Dgraph query (e.g., `biolink:has_total` instead of the correct `has_total`)

The `_create_filter_expression` method in `transpiler.py` has been updated to correctly remove the `biolink:` prefix from the constraint id.

A new unit test has been added to `test_transpiler.py` to validate the fix, ensuring that queries with both standard and negated attribute constraints are generated correctly.
