### PR TITLE
feat(tier0): Implement Subclassing

### DIFF
--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -109,7 +109,9 @@ class DgraphTranspiler(Tier0Transpiler):
     _reverse_node_map: dict[str, QNodeID]
     _reverse_edge_map: dict[str, QEdgeID]
 
-    def __init__(self, version: str | None = None, subclassing_enabled: bool = True) -> None:
+    def __init__(
+        self, version: str | None = None, subclassing_enabled: bool = True
+    ) -> None:
         """Initialize a Transpiler instance.
 
         Args:
@@ -865,14 +867,22 @@ class DgraphTranspiler(Tier0Transpiler):
 
             # Case 1: ID -> predicate -> ID
             if self._node_has_ids(source_node) and self._node_has_ids(target_node):
-                query += self._build_subclass_form_b(ctx, normalized_edge_id)  # A' -> predicate -> B
-                query += self._build_subclass_form_c(ctx, normalized_edge_id)  # A -> predicate -> B'
-                query += self._build_subclass_form_d(ctx, normalized_edge_id)  # A' -> predicate -> B'
+                query += self._build_subclass_form_b(
+                    ctx, normalized_edge_id
+                )  # A' -> predicate -> B
+                query += self._build_subclass_form_c(
+                    ctx, normalized_edge_id
+                )  # A -> predicate -> B'
+                query += self._build_subclass_form_d(
+                    ctx, normalized_edge_id
+                )  # A' -> predicate -> B'
             # Case 2: ID -> predicate -> CAT (only when target is filtered by categories, not IDs)
             elif (
                 self._node_has_ids(source_node)
                 and self._node_has_categories(target_node)
-                and not self._node_has_ids(target_node)  # ensure target is not ID-filtered
+                and not self._node_has_ids(
+                    target_node
+                )  # ensure target is not ID-filtered
             ):
                 query += self._build_subclass_form_b(ctx, normalized_edge_id)
 
@@ -902,7 +912,9 @@ class DgraphTranspiler(Tier0Transpiler):
         target_filter = self._build_node_filter(ctx.target_node)
         if target_filter:
             query += f" @filter({target_filter})"
-        query += self._build_node_cascade_clause(ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id})
+        query += self._build_node_cascade_clause(
+            ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id}
+        )
         query += " { " + self._add_standard_node_fields() + " } } } "
         return query
 
@@ -928,7 +940,9 @@ class DgraphTranspiler(Tier0Transpiler):
         target_filter = self._build_node_filter(ctx.target_node)
         if target_filter:
             query += f" @filter({target_filter})"
-        query += self._build_node_cascade_clause(ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id})
+        query += self._build_node_cascade_clause(
+            ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id}
+        )
         query += " { " + self._add_standard_node_fields() + " } } } "
         return query
 
@@ -954,7 +968,9 @@ class DgraphTranspiler(Tier0Transpiler):
         target_filter = self._build_node_filter(ctx.target_node)
         if target_filter:
             query += f" @filter({target_filter})"
-        query += self._build_node_cascade_clause(ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id})
+        query += self._build_node_cascade_clause(
+            ctx.target_id, ctx.edges, ctx.visited | {ctx.target_id}
+        )
         query += " { " + self._add_standard_node_fields() + " } } } } "
         return query
 

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -912,7 +912,11 @@ class DgraphTranspiler(Tier0Transpiler):
         # First traverse original predicate1 to B'
         pred_edge_filter = self._build_edge_filter(ctx.edge)
         pred_filter_clause = f" @filter({pred_edge_filter})" if pred_edge_filter else ""
-        query = f"{alias}: ~{ctx.edge_direction == 'out' and self._v('subject') or self._v('object')}{pred_filter_clause} @cascade({self._v('predicate')}, {ctx.edge_direction == 'out' and self._v('object') or self._v('subject')}) {{ "
+        query = (
+            f"{alias}: ~{self._v('subject') if ctx.edge_direction == 'out' else self._v('object')}"
+            f"{pred_filter_clause} @cascade({self._v('predicate')}, "
+            f"{self._v('object') if ctx.edge_direction == 'out' else self._v('subject')}) {{ "
+        )
         query += self._add_standard_edge_fields()
 
         # Then from B', traverse subclass_of to B (reverse on object side)

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -868,8 +868,12 @@ class DgraphTranspiler(Tier0Transpiler):
                 query += self._build_subclass_form_b(ctx, normalized_edge_id)  # A' -> predicate -> B
                 query += self._build_subclass_form_c(ctx, normalized_edge_id)  # A -> predicate -> B'
                 query += self._build_subclass_form_d(ctx, normalized_edge_id)  # A' -> predicate -> B'
-            # Case 2: ID -> predicate -> CAT
-            elif self._node_has_ids(source_node) and self._node_has_categories(target_node):
+            # Case 2: ID -> predicate -> CAT (only when target is filtered by categories, not IDs)
+            elif (
+                self._node_has_ids(source_node)
+                and self._node_has_categories(target_node)
+                and not self._node_has_ids(target_node)  # ensure target is not ID-filtered
+            ):
                 query += self._build_subclass_form_b(ctx, normalized_edge_id)
 
         return query

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -899,7 +899,7 @@ class DgraphTranspiler(Tier0Transpiler):
         # No constraints on subclass edge; use only subclass_of filter
         subclass_filter_clause = f" @filter({self._subclass_edge_filter()})"
         # A' -> subclass_of -> A (reverse)
-        query = f"{alias}: ~{self._v('object')}{subclass_filter_clause} @cascade({self._v('predicate')},{self._v('subject')} ) {{ "
+        query = f"{alias}: ~{self._v('object')}{subclass_filter_clause} @cascade({self._v('predicate')}, {self._v('subject')}) {{ "
         query += self._add_standard_edge_fields()
         # Now from A', traverse the original predicate1 to B with original edge filters
         # Emit child node with original constraints preserved for target B

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -270,7 +270,9 @@ class DgraphTranspiler(Tier0Transpiler):
 
         # Return the node_id with the maximum pinnedness score
         # Use node_id as tiebreaker for deterministic ordering
-        return max(pinnedness_scores, key=lambda nid: (pinnedness_scores[nid], -ord(nid[-1])))
+        return max(
+            pinnedness_scores, key=lambda nid: (pinnedness_scores[nid], -ord(nid[-1]))
+        )
 
     # --- Pinnedness Algorithm Methods ---
 

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -494,7 +494,7 @@ class DgraphTranspiler(Tier0Transpiler):
 
     def _create_filter_expression(self, constraint: AttributeConstraintDict) -> str:
         """Create a filter expression for a single constraint."""
-        field_name = self._v(constraint["name"].replace("biolink:", ""))
+        field_name = self._v(constraint["id"].replace("biolink:", ""))
         value = constraint["value"]
         operator = constraint["operator"]
         is_negated = constraint.get("not", False)

--- a/src/retriever/utils/trapi.py
+++ b/src/retriever/utils/trapi.py
@@ -313,7 +313,6 @@ def prune_kg(
     edges_to_check = list(bound_edges)
     while len(edges_to_check) > 0:
         edge_id = edges_to_check.pop()
-
         # Avoid infinite loops if edge and aux graph reference each other
         if edge_id in checked_edges:
             continue
@@ -339,6 +338,15 @@ def prune_kg(
         # But attribute value is generally of type Any
         for aux_graph_id in cast(list[AuxGraphID], edge_aux_graphs["value"]):
             edges_to_check.extend(edge for edge in aux_graphs[aux_graph_id]["edges"])
+
+    # Backfill: bound_nodes may have grown via edge endpoints / support graphs
+    missing_nodes = [curie for curie in bound_nodes if curie not in kgraph["nodes"]]
+    if missing_nodes:
+        job_log.warning(
+            f"KG Pruning: {len(missing_nodes)} bound nodes missing from kgraph (from edge endpoints); backfilling placeholders."
+        )
+        for curie in missing_nodes:
+            kgraph["nodes"][curie] = NodeDict(categories=[], attributes=[])
 
     prior_edge_count = len(kgraph["edges"])
     prior_node_count = len(kgraph["nodes"])

--- a/tests/data_tiers/tier_0/dgraph/test_driver.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver.py
@@ -765,12 +765,12 @@ async def test_simple_one_query_live_http() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vG_id, "NCBIGene:11276")) @cascade(vG_id, ~vG_subject) {
-            expand(vG_Node)
-            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "located_in")) @cascade(vG_predicate, vG_object) {
-                expand(vG_Edge) { vG_sources expand(vG_Source) }
-                node_n0: vG_object @filter(eq(vG_id, "GO:0031410")) @cascade(vG_id) {
-                    expand(vG_Node)
+        q0_node_n1(func: eq(vF_id, "NCBIGene:11276")) @cascade(vF_id, out_edges_e0) {
+            expand(vF_Node)
+            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "located_in")) @cascade(vF_predicate, vF_object) {
+                expand(vF_Edge) { vF_sources expand(vF_Source) }
+                node_n0: vF_object @filter(eq(vF_id, "GO:0031410")) @cascade(vF_id) {
+                    expand(vF_Node)
                 }
             }
         }
@@ -904,12 +904,12 @@ async def test_simple_one_query_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vG_id, "NCBIGene:11276")) @cascade(vG_id, ~vG_subject) {
-            expand(vG_Node)
-            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "located_in")) @cascade(vG_predicate, vG_object) {
-                expand(vG_Edge) { vG_sources expand(vG_Source) }
-                node_n0: vG_object @filter(eq(vG_id, "GO:0031410")) @cascade(vG_id) {
-                    expand(vG_Node)
+        q0_node_n1(func: eq(vF_id, "NCBIGene:11276")) @cascade(vF_id, out_edges_e0) {
+            expand(vF_Node)
+            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "located_in")) @cascade(vF_predicate, vF_object) {
+                expand(vF_Edge) { vF_sources expand(vF_Source) }
+                node_n0: vF_object @filter(eq(vF_id, "GO:0031410")) @cascade(vF_id) {
+                    expand(vF_Node)
                 }
             }
         }
@@ -986,12 +986,12 @@ async def test_simple_reverse_query_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, ~vG_subject) {
-            expand(vG_Node)
-            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "has_phenotype")) @cascade(vG_predicate, vG_object) {
-                expand(vG_Edge) { vG_sources expand(vG_Source) }
-                node_n0: vG_object @filter(eq(vG_category, "NamedThing")) @cascade(vG_id) {
-                    expand(vG_Node)
+        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
+            expand(vF_Node)
+            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "has_phenotype")) @cascade(vF_predicate, vF_object) {
+                expand(vF_Edge) { vF_sources expand(vF_Source) }
+                node_n0: vF_object @filter(eq(vF_category, "NamedThing")) @cascade(vF_id) {
+                    expand(vF_Node)
                 }
             }
         }
@@ -1069,8 +1069,8 @@ async def test_simple_query_with_symmetric_predicate_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, ~vG_subject) {
-            expand(vG_Node)
+        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
+            expand(vF_Node)
 
             out_edges_e0: ~vG_subject
             @filter(eq(vG_predicate_ancestors, "related_to"))
@@ -1249,8 +1249,8 @@ async def test_normalization_with_special_edge_id_live_grpc() -> None:
     # Expected query should use normalized edge ID 'e0', not 'e0_bad$%^'
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, ~vG_subject) {
-            expand(vG_Node)
+        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
+            expand(vF_Node)
 
             out_edges_e0: ~vG_subject
             @filter(eq(vG_predicate_ancestors, "related_to"))

--- a/tests/data_tiers/tier_0/dgraph/test_driver.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver.py
@@ -765,18 +765,19 @@ async def test_simple_one_query_live_http() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vF_id, "NCBIGene:11276")) @cascade(vF_id, out_edges_e0) {
-            expand(vF_Node)
-            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "located_in")) @cascade(vF_predicate, vF_object) {
-                expand(vF_Edge) { vF_sources expand(vF_Source) }
-                node_n0: vF_object @filter(eq(vF_id, "GO:0031410")) @cascade(vF_id) {
-                    expand(vF_Node)
+        q0_node_n1(func: eq(vG_id, "NCBIGene:11276")) @cascade(vG_id, out_edges_e0) {
+            expand(vG_Node)
+            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "located_in")) @cascade(vG_predicate, vG_object) {
+                expand(vG_Edge) { vG_sources expand(vG_Source) }
+                node_n0: vG_object @filter(eq(vG_id, "GO:0031410")) @cascade(vG_id) {
+                    expand(vG_Node)
                 }
             }
         }
     }
     """).strip()
 
+    # driver = new_http_driver(version="vG")
     driver = new_http_driver()
     await driver.connect()
 
@@ -785,8 +786,8 @@ async def test_simple_one_query_live_http() -> None:
 
     # Initialize the transpiler with the detected version
     transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=False)
-    assert transpiler.version == "vF"
-    assert transpiler.prefix == "vF_"
+    assert transpiler.version == "vG"
+    assert transpiler.prefix == "vG_"
 
     dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)
     assert_query_equals(dgraph_query, dgraph_query_match)
@@ -904,12 +905,12 @@ async def test_simple_one_query_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vF_id, "NCBIGene:11276")) @cascade(vF_id, out_edges_e0) {
-            expand(vF_Node)
-            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "located_in")) @cascade(vF_predicate, vF_object) {
-                expand(vF_Edge) { vF_sources expand(vF_Source) }
-                node_n0: vF_object @filter(eq(vF_id, "GO:0031410")) @cascade(vF_id) {
-                    expand(vF_Node)
+        q0_node_n1(func: eq(vG_id, "NCBIGene:11276")) @cascade(vG_id, out_edges_e0) {
+            expand(vG_Node)
+            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "located_in")) @cascade(vG_predicate, vG_object) {
+                expand(vG_Edge) { vG_sources expand(vG_Source) }
+                node_n0: vG_object @filter(eq(vG_id, "GO:0031410")) @cascade(vG_id) {
+                    expand(vG_Node)
                 }
             }
         }
@@ -924,8 +925,8 @@ async def test_simple_one_query_live_grpc() -> None:
 
     # Initialize the transpiler with the detected version
     transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=False)
-    assert transpiler.version == "vF"
-    assert transpiler.prefix == "vF_"
+    assert transpiler.version == "vG"
+    assert transpiler.prefix == "vG_"
 
     # Use the transpiler to generate the Dgraph query
     dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)
@@ -986,12 +987,12 @@ async def test_simple_reverse_query_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
-            expand(vF_Node)
-            out_edges_e0: ~vF_subject @filter(eq(vF_predicate_ancestors, "has_phenotype")) @cascade(vF_predicate, vF_object) {
-                expand(vF_Edge) { vF_sources expand(vF_Source) }
-                node_n0: vF_object @filter(eq(vF_category, "NamedThing")) @cascade(vF_id) {
-                    expand(vF_Node)
+        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, out_edges_e0) {
+            expand(vG_Node)
+            out_edges_e0: ~vG_subject @filter(eq(vG_predicate_ancestors, "has_phenotype")) @cascade(vG_predicate, vG_object) {
+                expand(vG_Edge) { vG_sources expand(vG_Source) }
+                node_n0: vG_object @filter(eq(vG_category, "NamedThing")) @cascade(vG_id) {
+                    expand(vG_Node)
                 }
             }
         }
@@ -1006,8 +1007,8 @@ async def test_simple_reverse_query_live_grpc() -> None:
 
     # Initialize the transpiler with the detected version
     transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=False)
-    assert transpiler.version == "vF"
-    assert transpiler.prefix == "vF_"
+    assert transpiler.version == "vG"
+    assert transpiler.prefix == "vG_"
 
     # Use the transpiler to generate the Dgraph query
     dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)
@@ -1069,8 +1070,8 @@ async def test_simple_query_with_symmetric_predicate_live_grpc() -> None:
 
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
-            expand(vF_Node)
+        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, out_edges_e0) {
+            expand(vG_Node)
 
             out_edges_e0: ~vG_subject
             @filter(eq(vG_predicate_ancestors, "related_to"))
@@ -1107,8 +1108,8 @@ async def test_simple_query_with_symmetric_predicate_live_grpc() -> None:
 
     # Initialize the transpiler with the detected version
     transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=False)
-    assert transpiler.version == "vF"
-    assert transpiler.prefix == "vF_"
+    assert transpiler.version == "vG"
+    assert transpiler.prefix == "vG_"
 
     # Use the transpiler to generate the Dgraph query
     dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)
@@ -1249,8 +1250,8 @@ async def test_normalization_with_special_edge_id_live_grpc() -> None:
     # Expected query should use normalized edge ID 'e0', not 'e0_bad$%^'
     dgraph_query_match: str = dedent("""
     {
-        q0_node_n1(func: eq(vF_id, "NCBIGene:3778")) @cascade(vF_id, out_edges_e0) {
-            expand(vF_Node)
+        q0_node_n1(func: eq(vG_id, "NCBIGene:3778")) @cascade(vG_id, out_edges_e0) {
+            expand(vG_Node)
 
             out_edges_e0: ~vG_subject
             @filter(eq(vG_predicate_ancestors, "related_to"))
@@ -1287,8 +1288,8 @@ async def test_normalization_with_special_edge_id_live_grpc() -> None:
 
     # Initialize the transpiler with the detected version
     transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=False)
-    assert transpiler.version == "vF"
-    assert transpiler.prefix == "vF_"
+    assert transpiler.version == "vG"
+    assert transpiler.prefix == "vG_"
 
     # Use the transpiler to generate the Dgraph query
     dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)

--- a/tests/data_tiers/tier_0/dgraph/test_driver_subclassing.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver_subclassing.py
@@ -1,20 +1,13 @@
 import importlib
-import json
 import re
-import time
 from collections.abc import Iterator
-from typing import Any, cast, final, override
-from textwrap import dedent
-from unittest.mock import MagicMock, patch, AsyncMock
+from typing import Any, cast
 
-import asyncio
 import aiohttp
-import grpc
 import pytest
 
 import retriever.config.general as general_mod
 import retriever.data_tiers.tier_0.dgraph.driver as driver_mod
-from retriever.data_tiers.tier_0.dgraph import result_models as dg_models
 from retriever.data_tiers.tier_0.dgraph.transpiler import DgraphTranspiler
 from retriever.types.trapi import QueryGraphDict
 
@@ -257,7 +250,7 @@ async def test_subclassing_case1_form_d_live() -> None:
     )
     assert form_d_edge is not None, "Form D path not found in results"
     assert form_d_edge.node.edges, "First intermediate node for Form D should have an outgoing edge"
-    
+
     # Traverse to the second intermediate node
     second_intermediate_edge = form_d_edge.node.edges[0]
     assert second_intermediate_edge.node.binding == "intermediate_B"

--- a/tests/data_tiers/tier_0/dgraph/test_driver_subclassing.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver_subclassing.py
@@ -1,0 +1,322 @@
+import importlib
+import json
+import re
+import time
+from collections.abc import Iterator
+from typing import Any, cast, final, override
+from textwrap import dedent
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import asyncio
+import aiohttp
+import grpc
+import pytest
+
+import retriever.config.general as general_mod
+import retriever.data_tiers.tier_0.dgraph.driver as driver_mod
+from retriever.data_tiers.tier_0.dgraph import result_models as dg_models
+from retriever.data_tiers.tier_0.dgraph.transpiler import DgraphTranspiler
+from retriever.types.trapi import QueryGraphDict
+
+
+# Test-only subclass exposing the client property
+class _TestDgraphHttpDriver(driver_mod.DgraphHttpDriver):
+    def __init__(self, *, version: str | None = None) -> None:
+        """Initialize and pass version to the parent class."""
+        super().__init__(version=version)
+
+    @property
+    def http_session(self) -> aiohttp.ClientSession | None:
+        return self._http_session
+
+
+# Test-only subclass exposing the client property
+class _TestDgraphGrpcDriver(driver_mod.DgraphGrpcDriver):
+    def __init__(self, *, version: str | None = None) -> None:
+        """Initialize and pass version to the parent class."""
+        super().__init__(version=version)
+
+    _client: driver_mod.DgraphClientProtocol | None = None
+
+    @property
+    def client(self) -> driver_mod.DgraphClientProtocol | None:
+        return self._client
+
+    @client.setter
+    def client(self, value: driver_mod.DgraphClientProtocol | None) -> None:
+        """Allow setting the client for testing purposes."""
+        self._client = value
+
+
+def new_http_driver(version: str | None = None) -> _TestDgraphHttpDriver:
+    return _TestDgraphHttpDriver(version=version)
+
+
+def new_grpc_driver(version: str | None = None) -> _TestDgraphGrpcDriver:
+    return _TestDgraphGrpcDriver(version=version)
+
+
+# Test-only subclass exposing the client property
+class _TestDgraphTranspiler(DgraphTranspiler):
+    """Expose protected methods for testing without modifying production code."""
+    def convert_multihop_public(self, qgraph: QueryGraphDict) -> str:
+        return self.convert_multihop(qgraph)
+
+    def convert_batch_multihop_public(self, qgraphs: list[QueryGraphDict]) -> str:
+        return self.convert_batch_multihop(qgraphs)
+
+
+def qg(d: dict[str, Any]) -> QueryGraphDict:
+    """Cast a raw qgraph dict into a QueryGraphDict for type-checking in tests."""
+    return cast(QueryGraphDict, cast(object, d))
+
+
+def normalize(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip())
+
+
+def assert_query_equals(actual: str, expected: str) -> None:
+    assert normalize(actual) == normalize(expected)
+
+
+@pytest.fixture
+def mock_dgraph_config(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("TIER0__DGRAPH__HOST", "localhost")
+    monkeypatch.setenv("TIER0__DGRAPH__HTTP_PORT", "8080")
+    monkeypatch.setenv("TIER0__DGRAPH__GRPC_PORT", "9080")
+    monkeypatch.setenv("TIER0__DGRAPH__PREFERRED_VERSION", "vSubClass")
+    monkeypatch.setenv("TIER0__DGRAPH__USE_TLS", "false")
+    monkeypatch.setenv("TIER0__DGRAPH__QUERY_TIMEOUT", "10")
+    monkeypatch.setenv("TIER0__DGRAPH__CONNECT_RETRIES", "0")
+
+    # Rebuild CONFIG from env and reload driver so classes bind to the new CONFIG
+    importlib.reload(general_mod)
+    importlib.reload(driver_mod)
+    # Ensure the driver module uses the same CONFIG instance
+    monkeypatch.setattr(driver_mod, "CONFIG", general_mod.CONFIG, raising=False)
+    yield
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
+async def test_subclassing_case0_no_expansion_live() -> None:
+    """
+    Live test: Case 0 (predicate is 'subclass_of').
+    The transpiler should NOT generate any subclassing expansion forms.
+    """
+    driver = new_http_driver()
+    await driver.connect()
+    dgraph_schema_version = await driver.get_active_version()
+    transpiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=True)
+
+    qgraph_query: QueryGraphDict = qg({
+        "nodes": {"n0": {"ids": ["TEST:A_case0"]}, "n1": {"ids": ["TEST:B_case0"]}},
+        "edges": {"e0": {"subject": "n0", "object": "n1", "predicates": ["subclass_of"]}},
+    })
+
+    dgraph_query = transpiler.convert_multihop_public(qgraph_query)
+
+    # Assert that no subclassing forms were generated
+    assert "subclassB" not in dgraph_query
+    assert "subclassC" not in dgraph_query
+    assert "subclassD" not in dgraph_query
+
+    result = await driver.run_query(dgraph_query, transpiler=transpiler)
+    assert "q0" in result.data and result.data["q0"], "Query should find the direct path"
+    assert len(result.data["q0"]) == 1
+    root_node = result.data["q0"][0]
+    assert root_node.id == "TEST:A_case0"
+    assert len(root_node.edges) == 1
+    assert root_node.edges[0].node.id == "TEST:B_case0"
+
+    await driver.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
+async def test_subclassing_case1_form_b_live() -> None:
+    """Live test: Case 1, Form B (A' -> subclass_of -> A; A' -> R -> B)."""
+    driver = new_http_driver()
+    await driver.connect()
+    dgraph_schema_version = await driver.get_active_version()
+    transpiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=True)
+
+    qgraph_query: QueryGraphDict = qg({
+        "nodes": {"n0": {"ids": ["TEST:A_case1"]}, "n1": {"ids": ["TEST:B_case1"]}},
+        "edges": {"e0": {"subject": "n0", "object": "n1", "predicates": ["related_to"]}},
+    })
+
+    dgraph_query = transpiler.convert_multihop_public(qgraph_query)
+    result = await driver.run_query(dgraph_query, transpiler=transpiler)
+
+    assert "q0" in result.data and result.data["q0"], "Query should find the Form B path"
+    assert len(result.data["q0"]) == 1
+    print("### result.data =", result.data)
+    root_node = result.data["q0"][0]
+    assert root_node.id == "TEST:A_case1"
+
+    # Find the specific edge from the Form B expansion by looking for the
+    # intermediate node's unique binding, set in the transpiler.
+    form_b_edge = next(
+        (
+            edge
+            for edge in root_node.edges
+            if edge.node.binding == "intermediate"
+        ),
+        None,
+    )
+    assert form_b_edge is not None, "Form B path not found in results"
+    assert form_b_edge.node.edges, "Intermediate node for Form B should have an outgoing edge"
+    assert len(form_b_edge.node.edges) == 1, "Form B path should have one final edge"
+
+    # Now, assert the final node ID by traversing the nested structure
+    final_node = form_b_edge.node.edges[0].node
+    assert final_node.id == "TEST:B_case1"
+
+    await driver.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
+async def test_subclassing_case1_form_c_live() -> None:
+    """Live test: Case 1, Form C (A -> R -> B'; B' -> subclass_of -> B)."""
+    driver = new_http_driver()
+    await driver.connect()
+    dgraph_schema_version = await driver.get_active_version()
+    transpiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=True)
+
+    qgraph_query: QueryGraphDict = qg({
+        "nodes": {"n0": {"ids": ["TEST:A_case1c"]}, "n1": {"ids": ["TEST:B_case1c"]}},
+        "edges": {"e0": {"subject": "n0", "object": "n1", "predicates": ["related_to"]}},
+    })
+
+    dgraph_query = transpiler.convert_multihop_public(qgraph_query)
+    result = await driver.run_query(dgraph_query, transpiler=transpiler)
+
+    assert "q0" in result.data and result.data["q0"], "Query should find a result"
+    assert len(result.data["q0"]) == 1
+    root_node = result.data["q0"][0]
+    assert root_node.id == "TEST:A_case1c"
+
+    # Find the specific edge from the Form C expansion by looking for the
+    # intermediate node's unique binding.
+    form_c_edge = next(
+        (
+            edge
+            for edge in root_node.edges
+            if edge.node.binding == "intermediate"
+        ),
+        None,
+    )
+    assert form_c_edge is not None, "Form C path not found in results"
+    assert form_c_edge.node.edges, "Intermediate node for Form C should have an outgoing edge"
+    assert len(form_c_edge.node.edges) == 1, "Form C path should have one final edge"
+
+    # Traverse the nested structure to get the final node
+    final_node = form_c_edge.node.edges[0].node
+    assert final_node.id == "TEST:B_case1c"
+
+    await driver.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
+async def test_subclassing_case1_form_d_live() -> None:
+    """Live test: Case 1, Form D (A' -> sub -> A; A' -> R -> B'; B' -> sub -> B)."""
+    driver = new_http_driver()
+    await driver.connect()
+    dgraph_schema_version = await driver.get_active_version()
+    transpiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=True)
+
+    qgraph_query: QueryGraphDict = qg({
+        "nodes": {"n0": {"ids": ["TEST:A_case1d"]}, "n1": {"ids": ["TEST:B_case1d"]}},
+        "edges": {"e0": {"subject": "n0", "object": "n1", "predicates": ["related_to"]}},
+    })
+
+    dgraph_query = transpiler.convert_multihop_public(qgraph_query)
+    result = await driver.run_query(dgraph_query, transpiler=transpiler)
+
+    assert "q0" in result.data and result.data["q0"], "Query should find a result"
+    assert len(result.data["q0"]) == 1
+    root_node = result.data["q0"][0]
+    assert root_node.id == "TEST:A_case1d"
+
+    # Find the specific edge from the Form D expansion by looking for the
+    # first intermediate node's unique binding.
+    form_d_edge = next(
+        (
+            edge
+            for edge in root_node.edges
+            if edge.node.binding == "intermediate_A"
+        ),
+        None,
+    )
+    assert form_d_edge is not None, "Form D path not found in results"
+    assert form_d_edge.node.edges, "First intermediate node for Form D should have an outgoing edge"
+    
+    # Traverse to the second intermediate node
+    second_intermediate_edge = form_d_edge.node.edges[0]
+    assert second_intermediate_edge.node.binding == "intermediate_B"
+    assert second_intermediate_edge.node.edges, "Second intermediate node for Form D should have an outgoing edge"
+
+    # Traverse to the final node
+    final_node = second_intermediate_edge.node.edges[0].node
+    assert final_node.id == "TEST:B_case1d"
+
+    await driver.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
+async def test_subclassing_case2_id_to_cat_live() -> None:
+    """Live test: Case 2 (ID -> R -> CAT-only) should find a path via Form B."""
+    driver = new_http_driver()
+    await driver.connect()
+    dgraph_schema_version = await driver.get_active_version()
+    transpiler = _TestDgraphTranspiler(version=dgraph_schema_version, subclassing_enabled=True)
+
+    qgraph_query: QueryGraphDict = qg({
+        "nodes": {
+            "n0": {"ids": ["TEST:A_case2"]},
+            "n1": {"categories": ["TestCategory"]},
+        },
+        "edges": {"e0": {"subject": "n0", "object": "n1", "predicates": ["related_to"]}},
+    })
+
+    dgraph_query = transpiler.convert_multihop_public(qgraph_query)
+
+    # Verify only Form B is generated for this case
+    assert "subclassB" in dgraph_query
+    assert "subclassC" not in dgraph_query
+    assert "subclassD" not in dgraph_query
+
+    result = await driver.run_query(dgraph_query, transpiler=transpiler)
+
+    assert "q0" in result.data and result.data["q0"], "Query should find the Case 2 path"
+    assert len(result.data["q0"]) == 1
+    root_node = result.data["q0"][0]
+    assert root_node.id == "TEST:A_case2"
+
+    # Find the specific edge from the Form B expansion
+    form_b_edge = next(
+        (
+            edge
+            for edge in root_node.edges
+            if edge.node.binding == "intermediate"
+        ),
+        None,
+    )
+    assert form_b_edge is not None, "Form B path for Case 2 not found"
+    assert form_b_edge.node.edges, "Intermediate node for Case 2 should have an outgoing edge"
+
+    # The result should be the specific node found, not just the category
+    final_node = form_b_edge.node.edges[0].node
+    assert final_node.id == "TEST:B_case2"
+    assert "TestCategory" in final_node.category
+
+    await driver.close()

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -674,11 +674,11 @@ QUALIFIER_SETS_AND_QGRAPH: QueryGraphDict = qg({
 
 EXP_SIMPLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514"))  @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -719,11 +719,11 @@ EXP_SIMPLE_REVERSE = dedent("""
 
 EXP_SIMPLE_WITH_VERSION = dedent("""
 {
-    q0_node_n1(func: eq(v1_id, "UMLS:C1564592")) @cascade(v1_id, out_edges_e0) {
+    q0_node_n0(func: eq(v1_id, "CHEBI:4514")) @cascade(v1_id, in_edges_e0) {
         expand(v1_Node)
-        out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "subclass_of")) @cascade(v1_predicate, v1_object) {
+        in_edges_e0: ~v1_object @filter(eq(v1_predicate_ancestors, "subclass_of")) @cascade(v1_predicate, v1_subject) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n0: v1_object @filter(eq(v1_id, "CHEBI:4514")) @cascade(v1_id) {
+            node_n1: v1_subject @filter(eq(v1_id, "UMLS:C1564592")) @cascade(v1_id) {
                 expand(v1_Node)
             }
         }
@@ -734,11 +734,11 @@ EXP_SIMPLE_WITH_VERSION = dedent("""
 
 EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
@@ -748,55 +748,15 @@ EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 
 EXP_TWO_HOP = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0, in_edges_e1) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, in_edges_e1) {
                 expand(Node)
-            }
-        }
-        in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
-            expand(Edge) { sources expand(Source) }
-            node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
-                expand(Node)
-            }
-        }
-    }
-}
-""").strip()
-
-EXP_TWO_HOP_WITH_VERSION = dedent("""
-{
-    q0_node_n1(func: eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, out_edges_e0, in_edges_e1) {
-        expand(v1_Node)
-        out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
-            expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n0: v1_object @filter(eq(v1_id, "CHEBI:3125")) @cascade(v1_id) {
-                expand(v1_Node)
-            }
-        }
-        in_edges_e1: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
-            expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n2: v1_subject @filter(eq(v1_id, "UMLS:C0496995")) @cascade(v1_id) {
-                expand(v1_Node)
-            }
-        }
-    }
-}
-""").strip()
-
-EXP_THREE_HOP = dedent("""
-{
-    q0_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1, in_edges_e2) {
-        expand(Node)
-        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
-            expand(Edge) { sources expand(Source) }
-            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
-                expand(Node)
-                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
                         expand(Node)
                     }
                 }
@@ -808,15 +768,15 @@ EXP_THREE_HOP = dedent("""
 
 EXP_TWO_HOP_WITH_VERSION = dedent("""
 {
-    q0_node_n2(func: eq(v1_id, "UMLS:C0496995")) @cascade(v1_id, ~v1_subject) {
+    q0_node_n0(func: eq(v1_id, "CHEBI:3125")) @cascade(v1_id, in_edges_e0) {
         expand(v1_Node)
-        out_edges_e1: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
+        in_edges_e0: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n1: v1_object @filter(eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, ~v1_subject) {
+            node_n1: v1_subject @filter(eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, in_edges_e1) {
                 expand(v1_Node)
-                out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
+                in_edges_e1: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
                     expand(v1_Edge) { v1_sources expand(v1_Source) }
-                    node_n0: v1_object @filter(eq(v1_id, "CHEBI:3125")) @cascade(v1_id) {
+                    node_n2: v1_subject @filter(eq(v1_id, "UMLS:C0496995")) @cascade(v1_id) {
                         expand(v1_Node)
                     }
                 }
@@ -828,19 +788,19 @@ EXP_TWO_HOP_WITH_VERSION = dedent("""
 
 EXP_THREE_HOP = dedent("""
 {
-    q0_node_n3(func: eq(id, "UMLS:C0149720")) @cascade(id, out_edges_e2, in_edges_e3) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, in_edges_e1) {
                 expand(Node)
-                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, in_edges_e2) {
                         expand(Node)
-                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id) {
                                 expand(Node)
                             }
                         }
@@ -854,23 +814,23 @@ EXP_THREE_HOP = dedent("""
 
 EXP_FOUR_HOP = dedent("""
 {
-    q0_node_n4(func: eq(id, "UMLS:C0496994")) @cascade(id, out_edges_e3, in_edges_e4) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e3: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, out_edges_e2) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, in_edges_e1) {
                 expand(Node)
-                out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, in_edges_e2) {
                         expand(Node)
-                        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id, in_edges_e3) {
                                 expand(Node)
-                                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                                    node_n4: subject @filter(eq(id, "UMLS:C0496994")) @cascade(id) {
                                         expand(Node)
                                     }
                                 }
@@ -886,27 +846,27 @@ EXP_FOUR_HOP = dedent("""
 
 EXP_FIVE_HOP = dedent("""
 {
-    q0_node_n5(func: eq(id, "UMLS:C2879715")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, "UMLS:C0496994")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, in_edges_e1) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, in_edges_e2) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id, in_edges_e3) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, "UMLS:C0496994")) @cascade(id, in_edges_e4) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, "UMLS:C2879715")) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -924,27 +884,27 @@ EXP_FIVE_HOP = dedent("""
 
 EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n3(func: eq(id, ["Q6", "Q7"])) @cascade(id, out_edges_e2, in_edges_e3) {
+    q0_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, out_edges_e1) {
+            node_n1: subject @filter(eq(id, ["Q2", "Q3"])) @cascade(id, in_edges_e1) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, out_edges_e0) {
+                    node_n2: subject @filter(eq(id, ["Q4", "Q5"])) @cascade(id, in_edges_e2) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, ["Q6", "Q7"])) @cascade(id, in_edges_e3) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -956,29 +916,17 @@ EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
                 }
             }
         }
-        in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
-            expand(Edge) { sources expand(Source) }
-            node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
-                expand(Node)
-                in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
-                    expand(Edge) { sources expand(Source) }
-                    node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
-                        expand(Node)
-                    }
-                }
-            }
-        }
     }
 }
 """).strip()
 
 EXP_CATEGORY_FILTER = dedent("""
 {
-    q0_node_n1(func: eq(category, "Disease")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(category, "Gene")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(category, "Gene")) @cascade(id) {
+            node_n1: subject @filter(eq(category, "Disease")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1044,11 +992,12 @@ EXP_NUMERIC_FILTER = dedent("""
 
 EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Q2")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P")) @cascade(predicate, object) {
+
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, "Q2")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1058,63 +1007,65 @@ EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 
 EXP_PREDICATES_SINGLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "A")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "Ponly")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "Ponly")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "A")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "B")) @cascade(id) {
                 expand(Node)
             }
         }
     }
 }
+
 """).strip()
 
 EXP_ATTRIBUTES_ONLY = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "A")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(knowledge_level, "primary")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(knowledge_level, "primary")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "A")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "B")) @cascade(id) {
                 expand(Node)
             }
         }
     }
 }
+
 """).strip()
 
 EXP_START_OBJECT_WITH_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Y")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "X")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "rel")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "rel")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "X")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "Y")) @cascade(id) {
                 expand(Node)
             }
         }
     }
 }
+
 """).strip()
 
 EXP_BATCH_QGRAPHS = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
     }
-
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
+    q1_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1124,79 +1075,60 @@ EXP_BATCH_QGRAPHS = dedent("""
 
 EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
     }
-
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
+    q1_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
     }
-
-    q2_node_n1(func: eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0, in_edges_e1) {
+    q2_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, in_edges_e1) {
                 expand(Node)
-            }
-        }
-        in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
-            expand(Edge) { sources expand(Source) }
-            node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
-                expand(Node)
-            }
-        }
-    }
-
-    q3_node_n3(func: eq(id, ["Q6", "Q7"])) @cascade(id, out_edges_e2, in_edges_e3) {
-        expand(Node)
-        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
-            expand(Edge) { sources expand(Source) }
-            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, out_edges_e1) {
-                expand(Node)
-                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, out_edges_e0) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
                         expand(Node)
                     }
                 }
             }
         }
     }
-
-    q3_node_n5(func: eq(id, ["Q10", "Q11"])) @cascade(id, ~subject) {
+    q3_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, in_edges_e0) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
+            node_n1: subject @filter(eq(id, ["Q2", "Q3"])) @cascade(id, in_edges_e1) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, ["Q4", "Q5"])) @cascade(id, in_edges_e2) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, ["Q6", "Q7"])) @cascade(id, in_edges_e3) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -1758,11 +1690,11 @@ def test_normalization_with_underscores_in_ids(transpiler_no_subclassing: _TestD
     # 3. Expected - Should use normalized IDs (n0, n1, e0) not original ones
     expected = dedent("""
     {
-        q0_node_n1(func: eq(id, "NCBIGene:11276")) @cascade(id, out_edges_e0) {
+        q0_node_n0(func: eq(id, "GO:0031410")) @cascade(id, in_edges_e0) {
             expand(Node)
-            out_edges_e0: ~subject @filter(eq(predicate_ancestors, "located_in")) @cascade(predicate, object) {
+            in_edges_e0: ~object @filter(eq(predicate_ancestors, "located_in")) @cascade(predicate, subject) {
                 expand(Edge) { sources expand(Source) }
-                node_n0: object @filter(eq(id, "GO:0031410")) @cascade(id) {
+                node_n1: subject @filter(eq(id, "NCBIGene:11276")) @cascade(id) {
                     expand(Node)
                 }
             }
@@ -1776,12 +1708,12 @@ def test_normalization_with_underscores_in_ids(transpiler_no_subclassing: _TestD
     # Verify normalized IDs are used in the query
     assert "node_n0" in actual, "Should use normalized node ID n0, not n0_test"
     assert "node_n1" in actual, "Should use normalized node ID n1, not n1_patient"
-    assert "out_edges_e0:" in actual, "Should use normalized edge ID e0, not e0_test"
+    assert "in_edges_e0:" in actual, "Should use normalized edge ID e0, not e0_test"
 
     # Verify original IDs are NOT in the query structure
     assert "node_n0_test" not in actual, "Original node ID should not appear in query"
     assert "node_n1_patient" not in actual, "Original node ID should not appear in query"
-    assert "out_edges_e0_test:" not in actual, "Original edge ID should not appear in query"
+    assert "in_edges_e0_test:" not in actual, "Original edge ID should not appear in query"
 
 
 def test_normalization_with_special_characters(transpiler_no_subclassing: _TestDgraphTranspiler) -> None:
@@ -2404,7 +2336,7 @@ def test_pinnedness_tie_breaker_uses_node_id(transpiler: _TestDgraphTranspiler) 
     actual = transpiler.convert_multihop_public(qgraph)
 
     # With equal category-only nodes, tie-breaker picks lexicographically larger id ("z_last"), normalized to n1.
-    assert "q0_node_n1" in actual
+    assert "q0_node_n0" in actual
     # Root should NOT use ID filter since neither node has IDs; it should use category
     assert "func: eq(id," not in actual
     assert 'func: eq(category, "Gene")' in actual
@@ -2480,10 +2412,13 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
             }
             in_edges-subclassB_e2: ~object @filter(eq(predicate_ancestors, "subclass_of")) {
                 expand(Edge) { sources expand(Source) }
-                out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
-                    expand(Edge) { sources expand(Source) }
-                    node_n2: object @filter(eq(category, "Disease")) @cascade(id, in_edges_e0) {
-                        expand(Node)
+                node_intermediate: subject @filter(has(id)) @cascade(id) {
+                    expand(Node)
+                    out_edges-subclassB-mid_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        expand(Edge) { sources expand(Source) }
+                        node_n2: object @filter(eq(category, "Disease")) @cascade(id, in_edges_e0) {
+                            expand(Node)
+                        }
                     }
                 }
             }
@@ -2500,7 +2435,8 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
                 }
             }
         }
-    }""").strip()
+    }
+    """).strip()
 
     # 3. Assert
     assert normalize(actual) == normalize(expected)

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -674,7 +674,7 @@ QUALIFIER_SETS_AND_QGRAPH: QueryGraphDict = qg({
 
 EXP_SIMPLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -688,7 +688,7 @@ EXP_SIMPLE = dedent("""
 
 EXP_SIMPLE_GT_NOT = dedent("""
 {
-  q0_node_n0(func: eq(id, ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"])) @cascade(id, ~subject) {
+  q0_node_n0(func: eq(id, ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"])) @cascade(id, out_edges_e0) {
     expand(Node)
     out_edges_e0: ~subject
       @filter(eq(predicate_ancestors, "has_phenotype") AND
@@ -705,7 +705,7 @@ EXP_SIMPLE_GT_NOT = dedent("""
 
 EXP_SIMPLE_REVERSE = dedent("""
 {
-    q0_node_n1(func: eq(id, "NCBIGene:3778")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "NCBIGene:3778")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -719,7 +719,7 @@ EXP_SIMPLE_REVERSE = dedent("""
 
 EXP_SIMPLE_WITH_VERSION = dedent("""
 {
-    q0_node_n1(func: eq(v1_id, "UMLS:C1564592")) @cascade(v1_id, ~v1_subject) {
+    q0_node_n1(func: eq(v1_id, "UMLS:C1564592")) @cascade(v1_id, out_edges_e0) {
         expand(v1_Node)
         out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "subclass_of")) @cascade(v1_predicate, v1_object) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
@@ -734,7 +734,7 @@ EXP_SIMPLE_WITH_VERSION = dedent("""
 
 EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -748,11 +748,51 @@ EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 
 EXP_TWO_HOP = dedent("""
 {
-    q0_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0, in_edges_e1) {
+        expand(Node)
+        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+            expand(Edge) { sources expand(Source) }
+            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                expand(Node)
+            }
+        }
+        in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
+            expand(Edge) { sources expand(Source) }
+            node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
+                expand(Node)
+            }
+        }
+    }
+}
+""").strip()
+
+EXP_TWO_HOP_WITH_VERSION = dedent("""
+{
+    q0_node_n1(func: eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, out_edges_e0, in_edges_e1) {
+        expand(v1_Node)
+        out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
+            expand(v1_Edge) { v1_sources expand(v1_Source) }
+            node_n0: v1_object @filter(eq(v1_id, "CHEBI:3125")) @cascade(v1_id) {
+                expand(v1_Node)
+            }
+        }
+        in_edges_e1: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
+            expand(v1_Edge) { v1_sources expand(v1_Source) }
+            node_n2: v1_subject @filter(eq(v1_id, "UMLS:C0496995")) @cascade(v1_id) {
+                expand(v1_Node)
+            }
+        }
+    }
+}
+""").strip()
+
+EXP_THREE_HOP = dedent("""
+{
+    q0_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1, in_edges_e2) {
         expand(Node)
         out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
-            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
                 expand(Node)
                 out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
@@ -788,15 +828,15 @@ EXP_TWO_HOP_WITH_VERSION = dedent("""
 
 EXP_THREE_HOP = dedent("""
 {
-    q0_node_n3(func: eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+    q0_node_n3(func: eq(id, "UMLS:C0149720")) @cascade(id, out_edges_e2, in_edges_e3) {
         expand(Node)
         out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
-            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1) {
                 expand(Node)
                 out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
-                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
                         expand(Node)
                         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                             expand(Edge) { sources expand(Source) }
@@ -814,19 +854,19 @@ EXP_THREE_HOP = dedent("""
 
 EXP_FOUR_HOP = dedent("""
 {
-    q0_node_n4(func: eq(id, "UMLS:C0496994")) @cascade(id, ~subject) {
+    q0_node_n4(func: eq(id, "UMLS:C0496994")) @cascade(id, out_edges_e3, in_edges_e4) {
         expand(Node)
         out_edges_e3: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
-            node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+            node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, out_edges_e2) {
                 expand(Node)
                 out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
-                    node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+                    node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, out_edges_e1) {
                         expand(Node)
                         out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                             expand(Edge) { sources expand(Source) }
-                            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0) {
                                 expand(Node)
                                 out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                                     expand(Edge) { sources expand(Source) }
@@ -884,15 +924,15 @@ EXP_FIVE_HOP = dedent("""
 
 EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n5(func: eq(id, ["Q10", "Q11"])) @cascade(id, ~subject) {
+    q0_node_n3(func: eq(id, ["Q6", "Q7"])) @cascade(id, out_edges_e2, in_edges_e3) {
         expand(Node)
         out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~subject) {
+            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, out_edges_e1) {
                 expand(Node)
                 out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~subject) {
+                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, out_edges_e0) {
                         expand(Node)
                         out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
                             expand(Edge) { sources expand(Source) }
@@ -916,13 +956,25 @@ EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
                 }
             }
         }
+        in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
+            expand(Edge) { sources expand(Source) }
+            node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
+                expand(Node)
+                in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
+                    expand(Edge) { sources expand(Source) }
+                    node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
+                        expand(Node)
+                    }
+                }
+            }
+        }
     }
 }
 """).strip()
 
 EXP_CATEGORY_FILTER = dedent("""
 {
-    q0_node_n1(func: eq(category, "Disease")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(category, "Disease")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -936,7 +988,7 @@ EXP_CATEGORY_FILTER = dedent("""
 
 EXP_MULTIPLE_FILTERS = dedent("""
 {
-    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
         in_edges_e0: ~object @filter(eq(predicate_ancestors, ["has_phenotype", "contributes_to"]) AND eq(knowledge_level, "prediction")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
@@ -950,7 +1002,7 @@ EXP_MULTIPLE_FILTERS = dedent("""
 
 EXP_NEGATED_CONSTRAINT = dedent("""
 {
-    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, in_edges_e0) {
         expand(Node)
         in_edges_e0: ~object @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
@@ -964,7 +1016,7 @@ EXP_NEGATED_CONSTRAINT = dedent("""
 
 EXP_PUBLICATION_FILTER = dedent("""
 {
-    q0_node_n0(func: eq(id, "DOID:14330")) @cascade(id, ~object) {
+    q0_node_n0(func: eq(id, "DOID:14330")) @cascade(id, in_edges_e0) {
         expand(Node)
         in_edges_e0: ~object @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
@@ -978,7 +1030,7 @@ EXP_PUBLICATION_FILTER = dedent("""
 
 EXP_NUMERIC_FILTER = dedent("""
 {
-    q0_node_n0(func: eq(id, "DOID:14330")) @cascade(id, ~object) {
+    q0_node_n0(func: eq(id, "DOID:14330")) @cascade(id, in_edges_e0) {
         expand(Node)
         in_edges_e0: ~object @filter(gt(edge_id, "100")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
@@ -992,7 +1044,7 @@ EXP_NUMERIC_FILTER = dedent("""
 
 EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Q2")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "Q2")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1006,7 +1058,7 @@ EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 
 EXP_PREDICATES_SINGLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "B")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "Ponly")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1020,7 +1072,7 @@ EXP_PREDICATES_SINGLE = dedent("""
 
 EXP_ATTRIBUTES_ONLY = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "B")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(knowledge_level, "primary")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1034,7 +1086,7 @@ EXP_ATTRIBUTES_ONLY = dedent("""
 
 EXP_START_OBJECT_WITH_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Y")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "Y")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "rel")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1048,7 +1100,7 @@ EXP_START_OBJECT_WITH_IDS = dedent("""
 
 EXP_BATCH_QGRAPHS = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1058,7 +1110,7 @@ EXP_BATCH_QGRAPHS = dedent("""
         }
     }
 
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1072,7 +1124,7 @@ EXP_BATCH_QGRAPHS = dedent("""
 
 EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1082,7 +1134,7 @@ EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
         }
     }
 
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1092,15 +1144,31 @@ EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
         }
     }
 
-    q2_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+    q2_node_n1(func: eq(id, "UMLS:C0282090")) @cascade(id, out_edges_e0, in_edges_e1) {
         expand(Node)
         out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
             node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
                 expand(Node)
-                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+            }
+        }
+        in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
+            expand(Edge) { sources expand(Source) }
+            node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
+                expand(Node)
+            }
+        }
+    }
+
+    q3_node_n3(func: eq(id, ["Q6", "Q7"])) @cascade(id, out_edges_e2, in_edges_e3) {
+        expand(Node)
+        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
+            expand(Edge) { sources expand(Source) }
+            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, out_edges_e1) {
+                expand(Node)
+                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
-                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, out_edges_e0) {
                         expand(Node)
                     }
                 }
@@ -1112,7 +1180,7 @@ EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
         expand(Node)
         out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~subject) {
+            node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, in_edges_e4) {
                 expand(Node)
                 out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
                     expand(Edge) { sources expand(Source) }
@@ -1146,7 +1214,7 @@ EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
 
 EXP_BATCH_MULTI_IDS_SINGLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "C")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "C")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1160,7 +1228,7 @@ EXP_BATCH_MULTI_IDS_SINGLE = dedent("""
 
 EXP_BATCH_NO_IDS_SINGLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "D")) @cascade(id, ~subject) {
+    q0_node_n1(func: eq(id, "D")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "R")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1174,7 +1242,7 @@ EXP_BATCH_NO_IDS_SINGLE = dedent("""
 
 DGRAPH_FLOATING_OBJECT_QUERY = dedent("""
 {
-    q0_node_n0(func: eq(id, "NCBIGene:3778")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "NCBIGene:3778")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "causes")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1188,7 +1256,7 @@ DGRAPH_FLOATING_OBJECT_QUERY = dedent("""
 
 DGRAPH_FLOATING_OBJECT_QUERY_WITH_VERSION = dedent("""
 {
-    q0_node_n0(func: eq(v1_id, "NCBIGene:3778")) @cascade(v1_id, ~v1_subject) {
+    q0_node_n0(func: eq(v1_id, "NCBIGene:3778")) @cascade(v1_id, out_edges_e0) {
         expand(v1_Node)
         out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "causes")) @cascade(v1_predicate, v1_object) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
@@ -1202,7 +1270,7 @@ DGRAPH_FLOATING_OBJECT_QUERY_WITH_VERSION = dedent("""
 
 DGRAPH_FLOATING_OBJECT_QUERY_TWO_CATEGORIES = dedent("""
 {
-    q0_node_n0(func: eq(id, "NCBIGene:3778")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "NCBIGene:3778")) @cascade(id, out_edges_e0) {
         expand(Node)
         out_edges_e0: ~subject @filter(eq(predicate_ancestors, "causes")) @cascade(predicate, object) {
             expand(Edge) { sources expand(Source) }
@@ -1216,7 +1284,7 @@ DGRAPH_FLOATING_OBJECT_QUERY_TWO_CATEGORIES = dedent("""
 
 EXP_QUALIFIER_SET = dedent("""
 {
-  q0_node_n0(func: eq(id, ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"])) @cascade(id, ~subject) {
+  q0_node_n0(func: eq(id, ["MONDO:0030010", "MONDO:0011766", "MONDO:0009890"])) @cascade(id, out_edges_e0) {
     expand(Node)
     out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype") AND
       (eq(frequency_qualifier, "HP:0040280") AND eq(onset_qualifier, "ANY_VALUE") AND eq(sex_qualifier, "ANY_OTHER_VALUE"))) @cascade(predicate, object) {
@@ -1231,7 +1299,7 @@ EXP_QUALIFIER_SET = dedent("""
 
 EXP_QUALIFIER_SETS_AND = dedent("""
 {
-  q0_node_n0(func: eq(id, "X")) @cascade(id, ~subject) {
+  q0_node_n0(func: eq(id, "X")) @cascade(id, out_edges_e0) {
     expand(Node)
     out_edges_e0: ~subject @filter(eq(predicate_ancestors, "R") AND
       ((eq(frequency_qualifier, "F1") AND eq(onset_qualifier, "O1")) OR eq(sex_qualifier, "S1"))) @cascade(predicate, object) {
@@ -1414,7 +1482,7 @@ def test_symmetric_predicate_generates_bidirectional_queries(transpiler: _TestDg
     actual = transpiler.convert_multihop_public(qgraph)
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, "related_to")) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
@@ -1457,7 +1525,7 @@ def test_symmetric_predicate_incoming_edge(transpiler: _TestDgraphTranspiler) ->
     actual = transpiler.convert_multihop_public(qgraph)
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~object) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, in_edges_e0) {
             expand(Node)
             in_edges_e0: ~object @filter(eq(predicate_ancestors, "correlated_with")) @cascade(predicate, subject) {
                 expand(Edge) { sources expand(Source) }
@@ -1509,11 +1577,11 @@ def test_symmetric_predicate_multi_hop(transpiler: _TestDgraphTranspiler) -> Non
     actual = transpiler.convert_multihop_public(qgraph)
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, "related_to")) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
-                node_n1: object @filter(eq(category, "Gene")) @cascade(id, ~subject) {
+                node_n1: object @filter(eq(category, "Gene")) @cascade(id, out_edges_e1) {
                     expand(Node)
                     out_edges_e1: ~subject @filter(eq(predicate_ancestors, "participates_in")) @cascade(predicate, object) {
                         expand(Edge) { sources expand(Source) }
@@ -1525,7 +1593,7 @@ def test_symmetric_predicate_multi_hop(transpiler: _TestDgraphTranspiler) -> Non
             }
             in_edges-symmetric_e0: ~object @filter(eq(predicate_ancestors, "related_to")) @cascade(predicate, subject) {
                 expand(Edge) { sources expand(Source) }
-                node_n1: subject @filter(eq(category, "Gene")) @cascade(id, ~subject) {
+                node_n1: subject @filter(eq(category, "Gene")) @cascade(id, out_edges_e1) {
                     expand(Node)
                     out_edges_e1: ~subject @filter(eq(predicate_ancestors, "participates_in")) @cascade(predicate, object) {
                         expand(Edge) { sources expand(Source) }
@@ -1573,7 +1641,7 @@ def test_multiple_symmetric_predicates_on_edge(transpiler: _TestDgraphTranspiler
     actual = transpiler.convert_multihop_public(qgraph)
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, ["related_to", "associated_with"])) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
@@ -1622,7 +1690,7 @@ def test_mixed_predicates_treats_as_symmetric(transpiler: _TestDgraphTranspiler)
     actual = transpiler.convert_multihop_public(qgraph)
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, ["related_to", "treated_by"])) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
@@ -1674,7 +1742,7 @@ def test_normalization_with_underscores_in_ids(transpiler: _TestDgraphTranspiler
     # 3. Expected - Should use normalized IDs (n0, n1, e0) not original ones
     expected = dedent("""
     {
-        q0_node_n1(func: eq(id, "NCBIGene:11276")) @cascade(id, ~subject) {
+        q0_node_n1(func: eq(id, "NCBIGene:11276")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, "located_in")) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
@@ -1723,7 +1791,7 @@ def test_normalization_with_special_characters(transpiler: _TestDgraphTranspiler
     # 3. Expected - Should use normalized IDs
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }
@@ -1865,7 +1933,7 @@ def test_normalization_symmetric_predicate(transpiler: _TestDgraphTranspiler) ->
     # 3. Expected - Should use normalized IDs with symmetric edges
     expected = dedent("""
     {
-        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, out_edges_e0) {
             expand(Node)
             out_edges_e0: ~subject @filter(eq(predicate_ancestors, "correlated_with")) @cascade(predicate, object) {
                 expand(Edge) { sources expand(Source) }

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -1483,6 +1483,18 @@ def test_symmetric_predicate_incoming_edge(transpiler: _TestDgraphTranspiler) ->
                     expand(Node)
                 }
             }
+            in_edges-subclassObjB_e0: ~object @filter(eq(predicate_ancestors, "correlated_with")) @cascade(predicate, subject) {
+                expand(Edge) { sources expand(Source) }
+                node_intermediate: subject @filter(has(id)) @cascade(id, ~subject) {
+                    expand(Node)
+                    out_edges-subclassObjB-tail_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+                        expand(Edge) { sources expand(Source) }
+                        node_n1: object @filter(eq(category, "Gene")) @cascade(id) {
+                            expand(Node)
+                        }
+                    }
+                }
+            }
         }
     }
     """).strip()
@@ -2394,6 +2406,7 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
 
     # 2. Act
     actual = transpiler.convert_multihop_public(qgraph)
+
     expected = dedent("""
     {
         q0_node_n0(func: eq(id, "MONDO:0011705")) @cascade(id, out_edges_e2, in_edges_e1) {
@@ -2429,6 +2442,18 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
                     in_edges_e0: ~object @filter(eq(predicate_ancestors, "treats_or_applied_or_studied_to_treat")) @cascade(predicate, subject) {
                         expand(Edge) { sources expand(Source) }
                         node_n1: subject @filter(eq(category, "ChemicalEntity")) @cascade(id) {
+                            expand(Node)
+                        }
+                    }
+                }
+            }
+            in_edges-subclassObjB_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
+                expand(Edge) { sources expand(Source) }
+                node_intermediate: subject @filter(has(id)) @cascade(id, ~subject) {
+                    expand(Node)
+                    out_edges-subclassObjB-tail_e1: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+                        expand(Edge) { sources expand(Source) }
+                        node_n2: object @filter(eq(category, "Disease")) @cascade(id, in_edges_e0) {
                             expand(Node)
                         }
                     }

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -1448,7 +1448,7 @@ def test_symmetric_predicate_generates_bidirectional_queries(transpiler_no_subcl
     assert "in_edges-symmetric_e0:" in actual
 
 
-def test_symmetric_predicate_incoming_edge(transpiler: _TestDgraphTranspiler) -> None:
+def test_symmetric_predicate_incoming_edge(transpiler_with_subclassing: _TestDgraphTranspiler) -> None:
     """Test that symmetric predicates work for incoming edges."""
     # 1. Arrange
     qgraph = qg({
@@ -1466,7 +1466,7 @@ def test_symmetric_predicate_incoming_edge(transpiler: _TestDgraphTranspiler) ->
     })
 
     # 2. Act
-    actual = transpiler.convert_multihop_public(qgraph)
+    actual = transpiler_with_subclassing.convert_multihop_public(qgraph)
     expected = dedent("""
     {
         q0_node_n0(func: eq(id, "MONDO:0005148")) @cascade(id, in_edges_e0) {
@@ -2354,7 +2354,7 @@ def test_pinnedness_tie_breaker_uses_node_id(transpiler: _TestDgraphTranspiler) 
     assert 'func: eq(category, "Gene")' in actual
 
 
-def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
+def test_pinnedness_issue(transpiler_with_subclassing: _TestDgraphTranspiler) -> None:
     """Test Pinnedness algorithm issue."""
     # 1. Arrange
     qgraph = qg({
@@ -2405,7 +2405,7 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
     })
 
     # 2. Act
-    actual = transpiler.convert_multihop_public(qgraph)
+    actual = transpiler_with_subclassing.convert_multihop_public(qgraph)
 
     expected = dedent("""
     {

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -1991,15 +1991,15 @@ def test_subclassing_case1_id_to_id_generates_b_c_d_forms(transpiler_with_subcla
     # Expect primary edge plus three subclass forms
     assert "out_edges_e0:" in actual, "Primary traversal missing"
     assert "in_edges-subclassB_e0:" in actual, "Subclass Form B missing"
-    assert "in_edges-subclassC_e0:" in actual, "Subclass Form C missing"
+    assert "out_edges-subclassC_e0:" in actual, "Subclass Form C missing"
     assert "in_edges-subclassD_e0:" in actual, "Subclass Form D missing"
 
     # Subclass edges should filter only on subclass_of predicate (no attribute/qualifier constraints)
     # Check that subclass blocks include subclass_of filter
     assert "in_edges-subclassB_e0: ~object @filter(eq(predicate_ancestors, \"subclass_of\"))" in actual
-    assert "in_edges-subclassC-tail_e0: ~object @filter(eq(predicate_ancestors, \"subclass_of\"))" in actual
+    assert "out_edges-subclassC-tail_e0: ~subject @filter(eq(predicate_ancestors, \"subclass_of\"))" in actual
     assert "in_edges-subclassD_tail_e0" not in actual  # use exact names defined in transpiler
-    assert "in_edges-subclassD-tail_e0: ~object @filter(eq(predicate_ancestors, \"subclass_of\"))" in actual
+    assert "out_edges-subclassD-tail_e0: ~subject @filter(eq(predicate_ancestors, \"subclass_of\"))" in actual
 
 
 def test_subclassing_case2_id_to_category_generates_b_only(transpiler_with_subclassing: _TestDgraphTranspiler) -> None:
@@ -2052,7 +2052,7 @@ def test_subclassing_skips_when_predicate_is_subclass_of_case0a_0b(transpiler_wi
         },
     })
     actual_id_id = transpiler_with_subclassing.convert_multihop_public(qgraph_id_id)
-    assert "in_edges_e0:" in actual_id_id
+    assert "out_edges_e0:" in actual_id_id
     assert "in_edges-subclassB_e0:" not in actual_id_id
     assert "in_edges-subclassC_e0:" not in actual_id_id
     assert "in_edges-subclassD_e0:" not in actual_id_id
@@ -2127,7 +2127,7 @@ def test_subclassing_disabled_emits_no_subclass_blocks(transpiler_no_subclassing
 
     actual = transpiler_no_subclassing.convert_multihop_public(qgraph)
 
-    assert "in_edges_e0:" in actual
+    assert "out_edges_e0:" in actual
     assert "in_edges-subclassB_e0:" not in actual
     assert "in_edges-subclassC_e0:" not in actual
     assert "in_edges-subclassD_e0:" not in actual
@@ -2151,7 +2151,7 @@ def test_subclassing_case2_does_not_trigger_when_target_has_ids(transpiler_with_
 
     # Because this is Case 1 (IDs on both ends), we should see B/C/D forms:
     assert "in_edges-subclassB_e0:" in actual
-    assert "in_edges-subclassC_e0:" in actual
+    assert "out_edges-subclassC_e0:" in actual
     assert "in_edges-subclassD_e0:" in actual
 
 
@@ -2185,18 +2185,18 @@ def test_subclassing_two_hop_id_to_id_on_both_hops(transpiler_with_subclassing: 
     actual = transpiler_with_subclassing.convert_multihop_public(qgraph)
 
     # Primary traversals (same as two-hop baseline)
-    assert "out_edges_e0:" in actual
+    assert "in_edges_e0:" in actual
     assert "in_edges_e1:" in actual
 
     # Subclassing on first hop (e0): expect B/C/D
     assert "in_edges-subclassB_e0:" in actual
-    assert "in_edges-subclassC_e0:" in actual
+    assert "out_edges-subclassC_e0:" in actual
     assert "in_edges-subclassD_e0:" in actual
 
     # Subclassing on second hop (e1): expect B/C/D
-    assert "out_edges-subclassB_e1:" in actual or "in_edges-subclassB_e1:" in actual
-    assert "out_edges-subclassC_e1:" in actual or "in_edges-subclassC_e1:" in actual
-    assert "out_edges-subclassD_e1:" in actual or "in_edges-subclassD_e1:" in actual
+    assert "in_edges-subclassB_e1:" in actual
+    assert "out_edges-subclassC_e1:" in actual
+    assert "in_edges-subclassD_e1:" in actual
 
     # Subclass edges should use only subclass_of filter (no attribute/qualifier constraints)
     assert ' @filter(eq(predicate_ancestors, "subclass_of"))' in actual
@@ -2233,12 +2233,12 @@ def test_subclassing_two_hop_id_to_category_on_second_hop_generates_b_only(trans
     actual = transpiler_with_subclassing.convert_multihop_public(qgraph)
 
     # Primary traversals present
-    assert "out_edges_e0:" in actual
+    assert "in_edges_e0:" in actual
     assert "out_edges_e1:" in actual  # direction matches subject=n1 → object=n2
 
     # First hop (ID→R→ID) should have B/C/D
     assert "in_edges-subclassB_e0:" in actual
-    assert "in_edges-subclassC_e0:" in actual
+    assert "out_edges-subclassC_e0:" in actual
     assert "in_edges-subclassD_e0:" in actual
 
     # Second hop (ID→R→CAT) should have only Form B
@@ -2410,9 +2410,9 @@ def test_pinnedness_issue(transpiler: _TestDgraphTranspiler) -> None:
                     }
                 }
             }
-            in_edges-subclassB_e2: ~object @filter(eq(predicate_ancestors, "subclass_of")) {
+            in_edges-subclassB_e2: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
                 expand(Edge) { sources expand(Source) }
-                node_intermediate: subject @filter(has(id)) @cascade(id) {
+                node_intermediate: subject @filter(has(id)) @cascade(id, ~subject) {
                     expand(Node)
                     out_edges-subclassB-mid_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
                         expand(Edge) { sources expand(Source) }
@@ -2459,8 +2459,7 @@ def test_subclassing_preserves_constraints_on_predicate_edge(transpiler_with_sub
                 "object": "n1",
                 "predicates": ["biolink:related_to"],
                 "attribute_constraints": [{
-                    "id": "ac1",
-                    "name": "knowledge_level",
+                    "id": "knowledge_level",
                     "operator": "==",
                     "value": "prediction",
                 }],


### PR DESCRIPTION
### Description

This PR implements subclassing expansion in the Dgraph transpiler to enhance query capabilities.

- Adds a `subclassing_enabled` flag to `DgraphTranspiler` (default True) to emit subclass-based subqueries per hop.
- Implements expansions:
  - Case 0a/0b: No expansion when original predicate is `subclass_of` (`ID→subclass_of→ID` or `ID→subclass_of→CAT`).
  - Case 1 (`ID→P→ID`): generate three forms
    - Form B: `A’ ← subclass_of ← A; A’ → R → B`
    - Form C: `A → P → B’; B’ ← subclass_of ← B`
    - Form D: `A’ ← subclass_of ← A; A’ → P → B’; B’ ← subclass_of ← B`
  - Case 2 (`ID→P→CAT-only`): generate Form B only (`A’ ← subclass_of ← A; A’ → P → CAT`), and only when target has categories but no IDs.
- Preserves constraints:
  - Applies attribute/qualifier constraints only to the original `predicate R` segments in subclass forms.
  - Does not apply constraints to `subclass_of` edges.
- Updates node-level `@cascade` to include edge `aliases` (out_edges_eX/in_edges_eX) instead of reverse fields.
- Adds tests.


### Dgraph Subclassing Traversal Logic

The following describes the Dgraph traversal logic for each expansion form, showing how nodes are connected via their `subject` and `object` edge fields.

- Case 1: `ID:A → predicate1 → ID:B`
  - Form A: `ID:A → ~subject → predicate1 → object → ID:B`
  - Form B: `ID:A → ~object → subclass_of → subject → A' → ~subject → predicate1 → object → ID:B`
  - Form C: `ID:A → ~subject → predicate1 → object → B' → ~subject → subclass_of → object → ID:B`
  - Form D: `ID:A → ~object → subclass_of → subject → A' → ~subject → predicate1 → object → B' → ~subject → subclass_of → object → ID:B`
- Case 2: ID:A → predicate1 → CAT:B
  - Form A: `ID:A → ~subject → predicate1 → object → CAT:B`
  - Form B: `ID:A → ~object → subclass_of → subject → A' → ~subject → predicate1 → object → CAT:B`

### Data Representation in Dgraph

1. Query starting from Subject Node to Edge
Question: Given a subject node, how do I find all edges that start from it?
`SubjectNode → ~subject → Edge`

2. Query starting from Object Node to Edge
Question: Given an object node, how do I find all edges that point to it?
`ObjectNode → ~object → Edge`

3. Query starting from Edge to Subject Node
Question: Given an edge, how do I find its subject (source) node?
`Edge → subject → SubjectNode`

4. Query starting from Edge to Object Node
Question: Given an edge, how do I find its object (target) node?
`Edge → object → ObjectNode`

5. Query starting from Edge to Both Subject and Object Nodes
Question: Given an edge, how do I find both its subject and object nodes in a single query?
`SubjectNode ← subject ← Edge → object → ObjectNode`


