### PR TITLE
Add metadata endpoint

### DIFF
--- a/config/openapi.default.yaml
+++ b/config/openapi.default.yaml
@@ -63,6 +63,8 @@ response_descriptions:
   meta_knowledge_graph:
     '200': Returns meta knowledge graph representation of this TRAPI web
       service.
+  metadata:
+    '200': Returns metadata for currently-served data in the backends.
   query:
     '200': OK. There may or may not be results. Note that some of the provided
       identifiers may not have been recognized.

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -10,7 +10,7 @@ from uvicorn.supervisors.multiprocess import SIGNALS
 
 from retriever.config.logger import configure_logging
 from retriever.data_tiers import tier_manager
-from retriever.metakg.metakg import MetaKGManager
+from retriever.metadata.optable import OPTableManager
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MONGO_CLIENT, MONGO_QUEUE
 from retriever.utils.redis import REDIS_CLIENT
@@ -29,7 +29,7 @@ async def _background_async() -> None:
     add_mongo_sink()
     await REDIS_CLIENT.initialize()
     await tier_manager.connect_drivers()
-    metakg_manager = MetaKGManager(leader=True)
+    metakg_manager = OPTableManager(leader=True)
     await metakg_manager.initialize()
     logger.success("Background process setup complete!")
 

--- a/src/retriever/config/openapi.py
+++ b/src/retriever/config/openapi.py
@@ -110,6 +110,9 @@ class ResponseDescriptions(BaseModel):
     meta_knowledge_graph: dict[str, str] = {
         "200": "Returns meta knowledge graph representation of this TRAPI web service.",
     }
+    metadata: dict[str, str] = {
+        "200": "Returns metadata for currently-served data in the backends."
+    }
     query: dict[str, str] = {
         "200": "OK. There may or may not be results. Note that some of the provided identifiers may not have been recognized.",
         "400": "Bad request. The request is invalid according to this OpenAPI schema OR a specific identifier is believed to be invalid somehow (not just unrecognized).",

--- a/src/retriever/lookup/branch.py
+++ b/src/retriever/lookup/branch.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from functools import cached_property
 from typing import override
 
-from retriever.metakg.metakg import OperationPlan
+from retriever.metadata.optable import OperationPlan
 from retriever.types.general import AdjacencyGraph, QEdgeIDMap
 from retriever.types.metakg import Operation
 from retriever.types.trapi import CURIE, QEdgeDict, QEdgeID, QNodeID, QueryGraphDict

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -15,7 +15,7 @@ from retriever.data_tiers import tier_manager
 from retriever.lookup.qgx import QueryGraphExecutor
 from retriever.lookup.utils import expand_qgraph
 from retriever.lookup.validate import validate
-from retriever.metakg.metakg import METAKG_MANAGER
+from retriever.metadata.optable import OP_TABLE_MANAGER
 from retriever.types.general import LookupArtifacts, QueryInfo
 from retriever.types.trapi import (
     AuxGraphID,
@@ -235,7 +235,7 @@ async def qgraph_supported(
 
     Prepares response with appropriate messages if not.
     """
-    operation_plan = await METAKG_MANAGER.create_operation_plan(qgraph, tiers)
+    operation_plan = await OP_TABLE_MANAGER.create_operation_plan(qgraph, tiers)
     if isinstance(operation_plan, list):
         job_log.warning(
             f"MetaEdges could not be found for the following QEdge(s): {operation_plan}"

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -16,7 +16,7 @@ from retriever.lookup.branch import (
 from retriever.lookup.partial import Partial
 from retriever.lookup.subquery import subquery
 from retriever.lookup.utils import get_subgraph, make_mappings
-from retriever.metakg.metakg import METAKG_MANAGER
+from retriever.metadata.optable import OP_TABLE_MANAGER
 from retriever.types.general import (
     AdjacencyGraph,
     KAdjacencyGraph,
@@ -115,7 +115,7 @@ class QueryGraphExecutor:
             self.job_log.info(
                 f"Starting lookup against Tier {', '.join(str(t) for t in self.ctx.tiers if t > 0)}..."
             )
-            operation_plan = await METAKG_MANAGER.create_operation_plan(
+            operation_plan = await OP_TABLE_MANAGER.create_operation_plan(
                 self.qgraph, {t for t in self.ctx.tiers if t > 0}
             )
             if isinstance(operation_plan, list):

--- a/src/retriever/metadata/metadata.py
+++ b/src/retriever/metadata/metadata.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from retriever.data_tiers.tier_manager import get_driver
+from retriever.types.dingo import DINGOMetadata
+from retriever.types.general import ErrorDetail, QueryInfo
+
+
+async def get_metadata(
+    query: QueryInfo,
+) -> tuple[int, DINGOMetadata | ErrorDetail]:
+    """Obtain tier-specific metadata.
+
+    Returns:
+        A tuple of HTTP status code, response body.
+    """
+    try:
+        async with asyncio.timeout(
+            query.timeout[-1] if query.timeout[-1] is not -1 else None
+        ):
+            driver = get_driver(next(iter(query.tiers), 0))
+            metadata = await driver.get_metadata()
+            if metadata is None:
+                return 500, ErrorDetail(detail="Metadata could not be retrieved.")
+            return 200, DINGOMetadata(**metadata)
+    except TimeoutError:
+        return 500, ErrorDetail(detail="Retrieving backend metadata timed out.")

--- a/src/retriever/metadata/optable.py
+++ b/src/retriever/metadata/optable.py
@@ -60,7 +60,7 @@ class TRAPIMetaKGInfo(NamedTuple):
     infores: str
 
 
-class MetaKGManager:
+class OPTableManager:
     """Utility class that keeps an up-to-date metakg."""
 
     def __init__(self, leader: bool = False) -> None:
@@ -274,7 +274,7 @@ class MetaKGManager:
         return plan
 
 
-METAKG_MANAGER = MetaKGManager()
+OP_TABLE_MANAGER = OPTableManager()
 
 
 async def build_edges(
@@ -337,7 +337,7 @@ async def get_trapi_metakg(tiers: tuple[TierNumber, ...]) -> MetaKnowledgeGraphD
     Because it depends on METAKG_MANAGER, it can't be used with the lead manager.
     This shouldn't be a problem because the lead manager isn't used to answer API calls.
     """
-    op_table = await METAKG_MANAGER.get_op_table()
+    op_table = await OP_TABLE_MANAGER.get_op_table()
     edges, edge_qualifiers, edge_attributes, mentioned_nodes = await build_edges(
         op_table, tiers
     )

--- a/src/retriever/metadata/trapi_metakg.py
+++ b/src/retriever/metadata/trapi_metakg.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from retriever.metakg.metakg import get_trapi_metakg
+from retriever.metadata.optable import get_trapi_metakg
 from retriever.types.general import ErrorDetail, QueryInfo
 from retriever.types.trapi import (
     MetaKnowledgeGraphDict,
@@ -16,9 +16,10 @@ async def trapi_metakg(
         A tuple of HTTP status code, response body.
     """
     try:
-        async with asyncio.timeout(query.timeout[-1]):
+        async with asyncio.timeout(
+            query.timeout[-1] if query.timeout[-1] is not -1 else None
+        ):
             metakg = await get_trapi_metakg(tuple(query.tiers))
+            return 200, metakg
     except TimeoutError:
         return 500, ErrorDetail(detail="Building TRAPI MetaKG timed out.")
-
-    return 200, metakg

--- a/src/retriever/types/general.py
+++ b/src/retriever/types/general.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated, Literal, NamedTuple, TypedDict
 
 from fastapi import BackgroundTasks, Request, Response
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BeforeValidator
 
 from retriever.types.trapi import (
     CURIE,
@@ -22,7 +22,7 @@ from retriever.types.trapi import (
 from retriever.types.trapi_pydantic import TierNumber
 
 
-class ErrorDetail(BaseModel):
+class ErrorDetail(TypedDict):
     """Basic FastAPI error response body."""
 
     detail: str


### PR DESCRIPTION
- Adds a `/metadata/tier_{tier}` endpoint that strictly passes through the metadata provided by data tier backends
- Refactors for some additional clarity between metadata -> op_table -> metakg