### PR TITLE
Add ES info to error message when metadata fetching failed

### DIFF
--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -266,7 +266,8 @@ class ElasticSearchDriver(DatabaseDriver):
 
         if metadata_blob is None:
             raise ValueError(
-                "Unable to obtain metadata from backend, cannot parse operations."
+                "Unable to obtain metadata from backend, cannot parse operations.",
+                f"Elasticsearch config: {CONFIG.tier1.elasticsearch}",
             )
 
         if self.es_connection is None:


### PR DESCRIPTION
Provide more debugging information for issues like #91, when a valid ES connection does not return metadata as expected.