### PR TITLE
Remove nodes from Ubergraph-Info payload

### DIFF
--- a/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
@@ -267,15 +267,12 @@ async def retrieve_ubergraph_info_from_es(
 
 def to_ubergraph_info(data: T1MetaData) -> UbergraphNodeInfo:
     """Casting method to satisfy our linter overlord."""
-    return UbergraphNodeInfo(
-        nodes=data.get("nodes", {}), mapping=data.get("mapping", {})
-    )
+    return UbergraphNodeInfo(mapping=data.get("mapping", {}))
 
 
 def from_ubergraph_info(info: UbergraphNodeInfo) -> T1MetaData:
     """Reverse of `to_ubergraph_info`."""
     return {
-        "nodes": info["nodes"],
         "mapping": info["mapping"],
     }
 

--- a/src/retriever/data_tiers/tier_1/elasticsearch/types.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/types.py
@@ -23,7 +23,6 @@ from retriever.utils import biolink
 class UbergraphNodeInfo(TypedDict):
     """Ubergraph node info."""
 
-    nodes: dict[str, dict[str, Any]]
     mapping: dict[str, dict[str, Any]]
 
 

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -238,7 +238,5 @@ async def test_ubergraph_info_retrieval():
     # for k, v in islice(info['mapping'].items(), 5):
     #     print(k, v)
 
-    assert "nodes" in info
     assert "mapping" in info
-    assert len(info["nodes"]) == 581234
     assert len(info["mapping"]) == 581143


### PR DESCRIPTION
The `nodes` field has been removed from the `ubergraph information` payload to reduce storage usage and improve fetching time, as node details can be queried directly from the Ubergraph index in Elasticsearch.