### PR TITLE
feat(tier0): Deterministically break pinnedness ties by QNode ID suffix (prefer earlier IDs)

### DIFF
--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -278,7 +278,9 @@ class DgraphTranspiler(Tier0Transpiler):
 
         # Return the node_id with the maximum pinnedness score
         # Use node_id as tiebreaker for deterministic ordering
-        return max(pinnedness_scores, key=lambda nid: (pinnedness_scores[nid], nid))
+        return max(
+            pinnedness_scores, key=lambda nid: (pinnedness_scores[nid], -ord(nid[-1]))
+        )
 
     # --- Pinnedness Algorithm Methods ---
 

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -674,11 +674,11 @@ QUALIFIER_SETS_AND_QGRAPH: QueryGraphDict = qg({
 
 EXP_SIMPLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514"))  @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -719,26 +719,25 @@ EXP_SIMPLE_REVERSE = dedent("""
 
 EXP_SIMPLE_WITH_VERSION = dedent("""
 {
-    q0_node_n1(func: eq(v1_id, "UMLS:C1564592")) @cascade(v1_id, ~v1_subject) {
+    q0_node_n0(func: eq(v1_id, "CHEBI:4514")) @cascade(v1_id, ~v1_object) {
         expand(v1_Node)
-        out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "subclass_of")) @cascade(v1_predicate, v1_object) {
+        in_edges_e0: ~v1_object @filter(eq(v1_predicate_ancestors, "subclass_of")) @cascade(v1_predicate, v1_subject) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n0: v1_object @filter(eq(v1_id, "CHEBI:4514")) @cascade(v1_id) {
+            node_n1: v1_subject @filter(eq(v1_id, "UMLS:C1564592")) @cascade(v1_id) {
                 expand(v1_Node)
             }
         }
     }
 }
-"""
-).strip()
+""").strip()
 
 EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
@@ -748,15 +747,15 @@ EXP_SIMPLE_MULTIPLE_IDS = dedent("""
 
 EXP_TWO_HOP = dedent("""
 {
-    q0_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
                         expand(Node)
                     }
                 }
@@ -768,15 +767,15 @@ EXP_TWO_HOP = dedent("""
 
 EXP_TWO_HOP_WITH_VERSION = dedent("""
 {
-    q0_node_n2(func: eq(v1_id, "UMLS:C0496995")) @cascade(v1_id, ~v1_subject) {
+    q0_node_n0(func: eq(v1_id, "CHEBI:3125")) @cascade(v1_id, ~v1_object) {
         expand(v1_Node)
-        out_edges_e1: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
+        in_edges_e0: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
             expand(v1_Edge) { v1_sources expand(v1_Source) }
-            node_n1: v1_object @filter(eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, ~v1_subject) {
+            node_n1: v1_subject @filter(eq(v1_id, "UMLS:C0282090")) @cascade(v1_id, ~v1_object) {
                 expand(v1_Node)
-                out_edges_e0: ~v1_subject @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_object) {
+                in_edges_e1: ~v1_object @filter(eq(v1_predicate_ancestors, "has_phenotype")) @cascade(v1_predicate, v1_subject) {
                     expand(v1_Edge) { v1_sources expand(v1_Source) }
-                    node_n0: v1_object @filter(eq(v1_id, "CHEBI:3125")) @cascade(v1_id) {
+                    node_n2: v1_subject @filter(eq(v1_id, "UMLS:C0496995")) @cascade(v1_id) {
                         expand(v1_Node)
                     }
                 }
@@ -788,19 +787,19 @@ EXP_TWO_HOP_WITH_VERSION = dedent("""
 
 EXP_THREE_HOP = dedent("""
 {
-    q0_node_n3(func: eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~object) {
                         expand(Node)
-                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id) {
                                 expand(Node)
                             }
                         }
@@ -814,23 +813,23 @@ EXP_THREE_HOP = dedent("""
 
 EXP_FOUR_HOP = dedent("""
 {
-    q0_node_n4(func: eq(id, "UMLS:C0496994")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e3: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~object) {
                         expand(Node)
-                        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~object) {
                                 expand(Node)
-                                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                                    node_n4: subject @filter(eq(id, "UMLS:C0496994")) @cascade(id) {
                                         expand(Node)
                                     }
                                 }
@@ -846,27 +845,27 @@ EXP_FOUR_HOP = dedent("""
 
 EXP_FIVE_HOP = dedent("""
 {
-    q0_node_n5(func: eq(id, "UMLS:C2879715")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, "UMLS:C0496994")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~object) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, "UMLS:C0149720")) @cascade(id, ~object) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, "UMLS:C0496994")) @cascade(id, ~object) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, "UMLS:C2879715")) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -884,27 +883,27 @@ EXP_FIVE_HOP = dedent("""
 
 EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
 {
-    q0_node_n5(func: eq(id, ["Q10", "Q11"])) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~object) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~object) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~object) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -922,11 +921,11 @@ EXP_FIVE_HOP_MULTIPLE_IDS = dedent("""
 
 EXP_CATEGORY_FILTER = dedent("""
 {
-    q0_node_n1(func: eq(category, "Disease")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(category, "Gene")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "gene_associated_with_condition")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(category, "Gene")) @cascade(id) {
+            node_n1: subject @filter(eq(category, "Disease")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -992,11 +991,11 @@ EXP_NUMERIC_FILTER = dedent("""
 
 EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Q2")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, "Q2")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1006,11 +1005,11 @@ EXP_SINGLE_STRING_WITH_COMMAS = dedent("""
 
 EXP_PREDICATES_SINGLE = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "A")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "Ponly")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "Ponly")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "A")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "B")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1020,11 +1019,11 @@ EXP_PREDICATES_SINGLE = dedent("""
 
 EXP_ATTRIBUTES_ONLY = dedent("""
 {
-    q0_node_n1(func: eq(id, "B")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "A")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(knowledge_level, "primary")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(knowledge_level, "primary")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "A")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "B")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1034,11 +1033,11 @@ EXP_ATTRIBUTES_ONLY = dedent("""
 
 EXP_START_OBJECT_WITH_IDS = dedent("""
 {
-    q0_node_n1(func: eq(id, "Y")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "X")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "rel")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "rel")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "X")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "Y")) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1048,21 +1047,21 @@ EXP_START_OBJECT_WITH_IDS = dedent("""
 
 EXP_BATCH_QGRAPHS = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
     }
 
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q1_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
@@ -1072,35 +1071,35 @@ EXP_BATCH_QGRAPHS = dedent("""
 
 EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
 {
-    q0_node_n1(func: eq(id, "UMLS:C1564592")) @cascade(id, ~subject) {
+    q0_node_n0(func: eq(id, "CHEBI:4514")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "subclass_of")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, "CHEBI:4514")) @cascade(id) {
+            node_n1: subject @filter(eq(id, "UMLS:C1564592")) @cascade(id) {
                 expand(Node)
             }
         }
     }
 
-    q1_node_n1(func: eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id, ~subject) {
+    q1_node_n0(func: eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n0: object @filter(eq(id, ["CHEBI:3125", "CHEBI:53448"])) @cascade(id) {
+            node_n1: subject @filter(eq(id, ["UMLS:C0282090", "CHEBI:10119"])) @cascade(id) {
                 expand(Node)
             }
         }
     }
 
-    q2_node_n2(func: eq(id, "UMLS:C0496995")) @cascade(id, ~subject) {
+    q2_node_n0(func: eq(id, "CHEBI:3125")) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e1: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n1: object @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, "UMLS:C0282090")) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e0: ~subject @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "has_phenotype")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n0: object @filter(eq(id, "CHEBI:3125")) @cascade(id) {
+                    node_n2: subject @filter(eq(id, "UMLS:C0496995")) @cascade(id) {
                         expand(Node)
                     }
                 }
@@ -1108,27 +1107,27 @@ EXP_BATCH_QGRAPHS_MULTI_HOP = dedent("""
         }
     }
 
-    q3_node_n5(func: eq(id, ["Q10", "Q11"])) @cascade(id, ~subject) {
+    q3_node_n0(func: eq(id, ["Q0", "Q1"])) @cascade(id, ~object) {
         expand(Node)
-        out_edges_e4: ~subject @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, object) {
+        in_edges_e0: ~object @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, subject) {
             expand(Edge) { sources expand(Source) }
-            node_n4: object @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~subject) {
+            node_n1: subject @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~object) {
                 expand(Node)
-                out_edges_e3: ~subject @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, object) {
+                in_edges_e1: ~object @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, subject) {
                     expand(Edge) { sources expand(Source) }
-                    node_n3: object @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~subject) {
+                    node_n2: subject @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~object) {
                         expand(Node)
-                        out_edges_e2: ~subject @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, object) {
+                        in_edges_e2: ~object @filter(eq(predicate_ancestors, "P2")) @cascade(predicate, subject) {
                             expand(Edge) { sources expand(Source) }
-                            node_n2: object @filter(eq(id, ["Q4", "Q5"])) @cascade(id, ~subject) {
+                            node_n3: subject @filter(eq(id, ["Q6", "Q7"])) @cascade(id, ~object) {
                                 expand(Node)
-                                out_edges_e1: ~subject @filter(eq(predicate_ancestors, "P1")) @cascade(predicate, object) {
+                                in_edges_e3: ~object @filter(eq(predicate_ancestors, "P3")) @cascade(predicate, subject) {
                                     expand(Edge) { sources expand(Source) }
-                                    node_n1: object @filter(eq(id, ["Q2", "Q3"])) @cascade(id, ~subject) {
+                                    node_n4: subject @filter(eq(id, ["Q8", "Q9"])) @cascade(id, ~object) {
                                         expand(Node)
-                                        out_edges_e0: ~subject @filter(eq(predicate_ancestors, "P0")) @cascade(predicate, object) {
+                                        in_edges_e4: ~object @filter(eq(predicate_ancestors, "P4")) @cascade(predicate, subject) {
                                             expand(Edge) { sources expand(Source) }
-                                            node_n0: object @filter(eq(id, ["Q0", "Q1"])) @cascade(id) {
+                                            node_n5: subject @filter(eq(id, ["Q10", "Q11"])) @cascade(id) {
                                                 expand(Node)
                                             }
                                         }
@@ -1674,11 +1673,11 @@ def test_normalization_with_underscores_in_ids(transpiler: _TestDgraphTranspiler
     # 3. Expected - Should use normalized IDs (n0, n1, e0) not original ones
     expected = dedent("""
     {
-        q0_node_n1(func: eq(id, "NCBIGene:11276")) @cascade(id, ~subject) {
+        q0_node_n0(func: eq(id, "GO:0031410")) @cascade(id, ~object) {
             expand(Node)
-            out_edges_e0: ~subject @filter(eq(predicate_ancestors, "located_in")) @cascade(predicate, object) {
+            in_edges_e0: ~object @filter(eq(predicate_ancestors, "located_in")) @cascade(predicate, subject) {
                 expand(Edge) { sources expand(Source) }
-                node_n0: object @filter(eq(id, "GO:0031410")) @cascade(id) {
+                node_n1: subject @filter(eq(id, "NCBIGene:11276")) @cascade(id) {
                     expand(Node)
                 }
             }
@@ -1692,12 +1691,12 @@ def test_normalization_with_underscores_in_ids(transpiler: _TestDgraphTranspiler
     # Verify normalized IDs are used in the query
     assert "node_n0" in actual, "Should use normalized node ID n0, not n0_test"
     assert "node_n1" in actual, "Should use normalized node ID n1, not n1_patient"
-    assert "out_edges_e0:" in actual, "Should use normalized edge ID e0, not e0_test"
+    assert "in_edges_e0:" in actual, "Should use normalized edge ID e0, not e0_test"
 
     # Verify original IDs are NOT in the query structure
     assert "node_n0_test" not in actual, "Original node ID should not appear in query"
     assert "node_n1_patient" not in actual, "Original node ID should not appear in query"
-    assert "out_edges_e0_test:" not in actual, "Original edge ID should not appear in query"
+    assert "in_edges_e0_test:" not in actual, "Original edge ID should not appear in query"
 
 
 def test_normalization_with_special_characters(transpiler: _TestDgraphTranspiler) -> None:
@@ -2022,7 +2021,7 @@ def test_pinnedness_tie_breaker_uses_node_id(transpiler: _TestDgraphTranspiler) 
     actual = transpiler.convert_multihop_public(qgraph)
 
     # With equal category-only nodes, tie-breaker picks lexicographically larger id ("z_last"), normalized to n1.
-    assert "q0_node_n1" in actual
+    assert "q0_node_n0" in actual
     # Root should NOT use ID filter since neither node has IDs; it should use category
     assert "func: eq(id," not in actual
     assert 'func: eq(category, "Gene")' in actual


### PR DESCRIPTION
# Objective
Adjust tie-breaking when multiple nodes share the same pinnedness score.

Ensures more predictable start-node selection when pinnedness scores are equal, aligning tie-breaking with normalized-style node IDs that end in an index-like suffix.

# Notes
This only affects cases where pinnedness scores are tied; primary selection by pinnedness is unchanged.