### PR TITLE
Secondary TRAPI compliance

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -74,6 +74,7 @@ tier0:
     connect_retries: 5  # Number of retries before declaring a connection failure.
     grpc_max_send_message_length: -1  # gRPC max send message length in bytes (-1 for unlimited).
     grpc_max_receive_message_length: -1  # gRPC max receive message length in bytes (-1 for unlimited).
+  dump_queries: false  # Write out TRAPI and translated queries to a file in jsonl format.
 tier1:
   backend: elasticsearch
   metadata_url: https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json

--- a/config/openapi.default.yaml
+++ b/config/openapi.default.yaml
@@ -47,7 +47,7 @@ x_trapi:
   asyncquery: true  # Supports async query type.
   operations: [lookup]
   batch_size_limit: 300  # Maximum IDs on any one node.
-  rate_limit: 300  # Maximum number of requests per minute.
+  rate_limit: 1000  # Maximum number of requests per minute.
   test_data_location:
     default:
       url: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-bte-ara.json

--- a/src/retriever/config/openapi.py
+++ b/src/retriever/config/openapi.py
@@ -96,7 +96,7 @@ class XTrapi(BaseModel):
     ] = 300
     rate_limit: Annotated[
         int, Field(description="Maximum number of requests per minute.")
-    ] = 300
+    ] = 1000
     test_data_location: TestDataLocationObject = TestDataLocationObject()
     externalDocs: ExternalDocs = ExternalDocs(
         description="The values for version are restricted according to the regex in this external JSON schema. See schema and examples at url",

--- a/src/retriever/metadata/optable.py
+++ b/src/retriever/metadata/optable.py
@@ -1,5 +1,7 @@
 import asyncio
 import itertools
+from collections import defaultdict
+from collections.abc import Iterable
 from typing import NamedTuple
 
 import ormsgpack
@@ -26,10 +28,12 @@ from retriever.types.trapi import (
     MetaQualifierDict,
     QEdgeDict,
     QEdgeID,
+    QNodeID,
     QualifierTypeID,
     QueryGraphDict,
 )
 from retriever.types.trapi_pydantic import TierNumber
+from retriever.utils import biolink
 from retriever.utils.biolink import expand
 from retriever.utils.redis import OP_TABLE_KEY, OP_TABLE_UPDATE_CHANNEL, REDIS_CLIENT
 from retriever.utils.trapi import (
@@ -42,6 +46,8 @@ tracer = trace.get_tracer("lookup.execution.tracer")
 METAKG_GET_ATTEMPTS = 3
 
 OperationPlan = dict[QEdgeID, list[Operation]]
+
+SPO = tuple[BiolinkEntity, BiolinkPredicate, BiolinkEntity]
 
 
 class DINGOMetaKGInfo(NamedTuple):
@@ -60,41 +66,61 @@ class TRAPIMetaKGInfo(NamedTuple):
     infores: str
 
 
+class QueryNotTraversable(Exception):
+    """An exception that implies the edge is not supported by a MetaEdge."""
+
+
+class UnsupportedConstraint(Exception):
+    """An exception that implies the edge's constraints are not totally supported."""
+
+    unmet: list[str]
+
+    def __init__(self, unmet: Iterable[str], *args: object) -> None:
+        """Initialize an instance."""
+        super().__init__(*args)
+        self.unmet = list(unmet)
+
+
 class OPTableManager:
-    """Utility class that keeps an up-to-date metakg."""
+    """Utility class that keeps an up-to-date OperationTable."""
 
     def __init__(self, leader: bool = False) -> None:
-        """Initialize a MetaKGManager instance."""
+        """Initialize a OpTableManager instance."""
         self.task: asyncio.Task[None] | None = None
         self._operation_table: OperationTable | None = None
         self.update_lock: asyncio.Lock = asyncio.Lock()
         self.is_leader: bool = leader
 
-    async def store_operation_table(self, metakg: OperationTable) -> None:
-        """Update the stored MetaKG."""
-        metakg_json = ormsgpack.packb(
+    async def store_operation_table(self, op_table: OperationTable) -> None:
+        """Update the stored OpTable."""
+        op_table_json = ormsgpack.packb(
             {
                 "operations_flat": [
-                    op._asdict() for op in metakg.operations_flat.values()
+                    op._asdict() for op in op_table.operations_flat.values()
                 ],
-                "nodes": {cat: node._asdict() for cat, node in metakg.nodes.items()},
+                "nodes": {
+                    cat: {
+                        str(tier): node._asdict() for tier, node in tier_nodes.items()
+                    }
+                    for cat, tier_nodes in op_table.nodes.items()
+                },
             }
         )
 
-        await REDIS_CLIENT.set(OP_TABLE_KEY, metakg_json, compress=True)
+        await REDIS_CLIENT.set(OP_TABLE_KEY, op_table_json, compress=True)
         await REDIS_CLIENT.publish(OP_TABLE_UPDATE_CHANNEL, 1)
 
     async def retrieve_stored_operation_table(self) -> OperationTable | None:
-        """Retrieve the stored MetaKG."""
+        """Retrieve the stored OpTable."""
         stored = await REDIS_CLIENT.get(OP_TABLE_KEY, compressed=True)
         if stored is None:
             return None
-        metakg_json = ormsgpack.unpackb(stored)
+        op_table_json = ormsgpack.unpackb(stored)
 
         operations_sorted = SortedOperations()
         operations_flat = FlatOperations()
 
-        for op_dict in metakg_json["operations_flat"]:
+        for op_dict in op_table_json["operations_flat"]:
             op = Operation(**op_dict)
             operations_flat[op.hash] = op
             if op.subject not in operations_sorted:
@@ -109,12 +135,64 @@ class OPTableManager:
             operations_sorted=operations_sorted,
             operations_flat=operations_flat,
             nodes={
-                spo: OperationNode(**node) for spo, node in metakg_json["nodes"].items()
+                category: {
+                    int(tier): OperationNode(**node)
+                    for tier, node in tier_nodes.items()
+                }
+                for category, tier_nodes in op_table_json["nodes"].items()
             },
         )
 
+    def merge_operations(
+        self,
+        operations_flat: FlatOperations,
+        operations_sorted: SortedOperations,
+        new_operations: list[Operation],
+    ) -> None:
+        """Merge new operations into the existing operations."""
+        for op in new_operations:
+            if attributes := op.attributes:
+                for attr in attributes:
+                    attr["constraint_use"] = True
+                    attr["constraint_name"] = biolink.rmprefix(
+                        attr["attribute_type_id"]
+                    )
+            operations_flat[op.hash] = op
+            if op.subject not in operations_sorted:
+                operations_sorted[op.subject] = {}
+            if op.predicate not in operations_sorted[op.subject]:
+                operations_sorted[op.subject][op.predicate] = {}
+            if op.object not in operations_sorted[op.subject][op.predicate]:
+                operations_sorted[op.subject][op.predicate][op.object] = []
+            operations_sorted[op.subject][op.predicate][op.object].append(op)
+
+    def merge_nodes(
+        self,
+        nodes: dict[BiolinkEntity, dict[TierNumber, OperationNode]],
+        new_nodes: dict[BiolinkEntity, OperationNode],
+        tier: TierNumber,
+    ) -> None:
+        """Merge new nodes into the existing nodes."""
+        for entity, node in new_nodes.items():
+            if entity not in nodes:
+                nodes[entity] = {}
+            if tier not in nodes[entity]:
+                nodes[entity][tier] = node
+            # Merge nodes
+            # APIs won't overlap so just pull in info from new API
+            nodes[entity][tier].prefixes.update(node.prefixes)
+            nodes[entity][tier].attributes.update(node.attributes)
+
+        for tier_nodes in nodes.values():
+            for node in tier_nodes.values():
+                for attr in itertools.chain(*node.attributes.values()):
+                    attr["constraint_use"] = True
+                    attr["constraint_name"] = biolink.rmprefix(
+                        attr["attribute_type_id"]
+                    )
+
     async def build_operation_table(self) -> None:
-        """Build Retriever's internal MetaKG and store it to Redis."""
+        """Build Retriever's internal OperationTable and store it to Redis."""
         if CONFIG.instance_idx != 0:
             return
 
@@ -122,29 +200,15 @@ class OPTableManager:
 
         operations_flat = FlatOperations()
         operations_sorted = SortedOperations()
-        nodes = dict[BiolinkEntity, OperationNode]()
+        nodes = dict[BiolinkEntity, dict[TierNumber, OperationNode]]()
 
         driver_ops = [
             await tier_manager.get_driver(tier).get_operations() for tier in range(0, 2)
         ]
 
-        for new_operations, new_nodes in driver_ops:
-            for op in new_operations:
-                operations_flat[op.hash] = op
-                if op.subject not in operations_sorted:
-                    operations_sorted[op.subject] = {}
-                if op.predicate not in operations_sorted[op.subject]:
-                    operations_sorted[op.subject][op.predicate] = {}
-                if op.object not in operations_sorted[op.subject][op.predicate]:
-                    operations_sorted[op.subject][op.predicate][op.object] = []
-                operations_sorted[op.subject][op.predicate][op.object].append(op)
-            for entity, node in new_nodes.items():
-                if entity in nodes:  # Have to merge nodes
-                    # APIs won't overlap so just pull in info from new API
-                    nodes[entity].prefixes.update(node.prefixes)
-                    nodes[entity].attributes.update(node.attributes)
-                    continue
-                nodes[entity] = node
+        for tier, (new_operations, new_nodes) in enumerate(driver_ops):
+            self.merge_operations(operations_flat, operations_sorted, new_operations)
+            self.merge_nodes(nodes, new_nodes, tier)
 
         async with self.update_lock:
             self._operation_table = OperationTable(
@@ -205,7 +269,11 @@ class OPTableManager:
     async def find_operations(
         self, edge: QEdgeDict, qgraph: QueryGraphDict, tiers: set[TierNumber]
     ) -> list[Operation]:
-        """Find a list of operations that match a given Branch."""
+        """Find a list of operations that match a given Branch.
+
+        Raises either QueryNotTraversable or UnsupportedConstraint if no appropriate
+        operations could be found.
+        """
         input_node = qgraph["nodes"][edge["subject"]]
         output_node = qgraph["nodes"][edge["object"]]
 
@@ -238,40 +306,117 @@ class OPTableManager:
                 if BiolinkPredicate(predicate) in table
             )
         operations = list[Operation]()
+
+        unmet_constraints = defaultdict[str, int](int)
         for obj_cat in output_categories:
             for table in object_tables:
-                if op_list := table.get(BiolinkEntity(obj_cat)):
-                    # TODO: filtering by attribute constraints?
-                    operations.extend(
-                        op
-                        for op in op_list
-                        if op.tier in tiers
-                        and meta_qualifier_meets_constraints(
-                            op.qualifiers, edge.get("qualifier_constraints", [])
-                        )
-                    )
+                op_list = table.get(BiolinkEntity(obj_cat))
+                if op_list is None:
+                    continue
+                for op in op_list:
+                    if op.tier not in tiers or not meta_qualifier_meets_constraints(
+                        op.qualifiers, edge.get("qualifier_constraints", [])
+                    ):
+                        continue
+                    op_attr_types = {
+                        mattr["attribute_type_id"]
+                        for mattr in (op.attributes or [])
+                        if mattr.get("constraint_use", False)
+                    }
+                    attr_constraints_met = True
+                    for constr in edge.get("attribute_constraints", []) or []:
+                        if constr["id"] not in op_attr_types:
+                            unmet_constraints[constr["name"]] += 1
+                            attr_constraints_met = False
+                    if attr_constraints_met:
+                        operations.append(op)
 
+        if len(operations) == 0:
+            if len(unmet_constraints) > 0:
+                raise UnsupportedConstraint(unmet=unmet_constraints.keys())
+            else:
+                raise QueryNotTraversable
         return operations
 
     @tracer.start_as_current_span("operation_plan")
     async def create_operation_plan(
         self, qgraph: QueryGraphDict, tiers: set[TierNumber]
-    ) -> OperationPlan | list[QEdgeID]:
+    ) -> tuple[
+        bool, OperationPlan | dict[QEdgeID, UnsupportedConstraint | QueryNotTraversable]
+    ]:
         """Obtain a list of supporting operations for each edge in the query graph.
 
-        Returns None if any QEdge is unsupported by the current operation table.
+        If any qedge is unsupported, instead returns a dict of unsupported edges and the relevant error code.
         """
         plan = OperationPlan()
-        unsupported_qedges = list[QEdgeID]()
+        unsupported_qedges = dict[
+            QEdgeID, UnsupportedConstraint | QueryNotTraversable
+        ]()
         for qedge_id, qedge in qgraph["edges"].items():
-            operations = await self.find_operations(qedge, qgraph, tiers)
-            if len(operations) == 0:
-                unsupported_qedges.append(QEdgeID(qedge_id))
+            operations = []
+            try:
+                operations = await self.find_operations(qedge, qgraph, tiers)
+            except (UnsupportedConstraint, QueryNotTraversable) as e:
+                unsupported_qedges[qedge_id] = e
             plan[QEdgeID(qedge_id)] = operations
 
         if len(unsupported_qedges) > 0:
-            return unsupported_qedges
-        return plan
+            return False, unsupported_qedges
+        return True, plan
+
+    async def qnodes_supported(
+        self, qgraph: QueryGraphDict, tiers: set[TierNumber]
+    ) -> None | dict[QNodeID, UnsupportedConstraint]:
+        """Check if any nodes contain unsupported constraints, returning a dictionary of any that are unsupported."""
+        unmet_nodes = defaultdict[QNodeID, set[str]](set)
+        op_table = await self.get_op_table()
+        nodes_met = dict.fromkeys(qgraph["nodes"], False)
+        for qnode_id, node in qgraph["nodes"].items():
+            constraints = node.get("constraints", []) or []
+            if len(constraints) == 0:
+                nodes_met[qnode_id] = True
+                continue
+            categories = expand(
+                set(
+                    node.get("categories", ["biolink:NamedThing"])
+                    or ["biolink:NamedThing"]
+                )
+            )
+            for category in categories:
+                op_tier_nodes = op_table.nodes.get(category)
+                if op_tier_nodes is None:
+                    continue
+                for tier, op_node in op_tier_nodes.items():
+                    if tier not in tiers:
+                        continue
+
+                    available_attrs = itertools.chain(
+                        *(
+                            (
+                                attr["attribute_type_id"]
+                                for attr in attrs
+                                if attr.get("constraint_use", False)
+                            )
+                            for attrs in op_node.attributes.values()
+                        )
+                    )
+                    met = True
+                    for constr in constraints:
+                        if constr["id"] not in available_attrs:
+                            unmet_nodes[qnode_id].add(constr["name"])
+                            met = False
+                    if met:
+                        nodes_met[qnode_id] = True
+                        break
+                if nodes_met[qnode_id]:
+                    break
+
+        if all(nodes_met.values()):
+            return None
+        return {
+            qnode_id: UnsupportedConstraint(unmet=unmet)
+            for qnode_id, unmet in unmet_nodes.items()
+        }
 
 
 OP_TABLE_MANAGER = OPTableManager()
@@ -281,15 +426,15 @@ async def build_edges(
     op_table: OperationTable,
     tiers: tuple[TierNumber, ...],
 ) -> tuple[
-    dict[str, MetaEdgeDict],
-    dict[str, dict[str, set[str]]],
-    dict[str, dict[int, MetaAttributeDict]],
+    dict[SPO, MetaEdgeDict],
+    dict[SPO, dict[str, set[str]]],
+    dict[SPO, dict[int, MetaAttributeDict]],
     set[BiolinkEntity],
 ]:
     """Build merged TRAPI MetaEdges from the operation table."""
-    edges = dict[str, MetaEdgeDict]()
-    edge_qualifiers = dict[str, dict[str, set[str]]]()
-    edge_attributes = dict[str, dict[int, MetaAttributeDict]]()
+    edges = dict[SPO, MetaEdgeDict]()
+    edge_qualifiers = dict[SPO, dict[str, set[str]]]()
+    edge_attributes = dict[SPO, dict[int, MetaAttributeDict]]()
     mentioned_nodes = set[BiolinkEntity]()
     for op in op_table.operations_flat.values():
         if op.tier not in tiers:
@@ -298,7 +443,7 @@ async def build_edges(
         sbj, obj, pred = op.subject, op.object, op.predicate
         mentioned_nodes.update((sbj, obj))
 
-        spo = f"{sbj} {pred} {obj}"
+        spo = (sbj, pred, obj)
         if spo in edges:
             meta_edge = edges[spo]
             qualifiers = edge_qualifiers[spo]
@@ -334,7 +479,7 @@ async def build_edges(
 async def get_trapi_metakg(tiers: tuple[TierNumber, ...]) -> MetaKnowledgeGraphDict:
     """Convert an OperationTable to a TRAPI MetaKG dict.
 
-    Because it depends on METAKG_MANAGER, it can't be used with the lead manager.
+    Because it depends on OP_TABLE_MANAGER, it can't be used with the lead manager.
     This shouldn't be a problem because the lead manager isn't used to answer API calls.
     """
     op_table = await OP_TABLE_MANAGER.get_op_table()
@@ -357,15 +502,23 @@ async def get_trapi_metakg(tiers: tuple[TierNumber, ...]) -> MetaKnowledgeGraphD
         if len(edge_attributes[spo]):
             edge["attributes"] = list(edge_attributes[spo].values())
 
-    for category, node in op_table.nodes.items():
+    for category, tier_nodes in op_table.nodes.items():
         if category not in mentioned_nodes:
             continue
-        attributes = {
-            hash_meta_attribute(attr): attr
-            for attr in itertools.chain(*node.attributes.values())
-        }
+        id_prefixes = set[str]()
+        attributes = dict[int, MetaAttributeDict]()
+        for tier, node in tier_nodes.items():
+            if tier not in tiers:
+                continue
+            id_prefixes.update(itertools.chain(*node.prefixes.values()))
+            attributes.update(
+                {
+                    hash_meta_attribute(attr): attr
+                    for attr in itertools.chain(*node.attributes.values())
+                }
+            )
         nodes[category] = MetaNodeDict(
-            id_prefixes=list(set(itertools.chain(*node.prefixes.values()))),
+            id_prefixes=list(id_prefixes),
             attributes=list(attributes.values()),
         )
 

--- a/src/retriever/types/metakg.py
+++ b/src/retriever/types/metakg.py
@@ -60,4 +60,4 @@ class OperationTable(NamedTuple):
 
     operations_sorted: SortedOperations
     operations_flat: FlatOperations
-    nodes: dict[BiolinkEntity, OperationNode]
+    nodes: dict[BiolinkEntity, dict[TierNumber, OperationNode]]

--- a/src/retriever/utils/trapi.py
+++ b/src/retriever/utils/trapi.py
@@ -440,6 +440,24 @@ def meta_qualifier_meets_constraints(
     return False
 
 
+def meta_attributes_meet_constraints(
+    constraints: list[AttributeConstraintDict], meta_attributes: list[MetaAttributeDict]
+) -> bool:
+    """Check whether the the given meta_attributes can potentially satisfy the given constraints."""
+    if len(constraints) == 0:
+        return True  # No constraints, can't fail to satisfy them
+    if len(meta_attributes) == 0:
+        return False  # Can't possibly satisfy constraints without attributes
+
+    attribute_type_ids = {
+        mattr["attribute_type_id"]
+        for mattr in meta_attributes
+        if mattr.get("constraint_use", False)
+    }
+
+    return all(constr["id"] in attribute_type_ids for constr in constraints)
+
+
 def attribute_meets_constraint(
     constraint: AttributeConstraintDict, attribute: AttributeDict
 ) -> bool:


### PR DESCRIPTION
This PR represents my combing through the descriptions within the TRAPI spec and outside it in the implementation guidance, and checking off the last few inconsistencies.

Primarily, this involves a refactor of the Operation system to be able to more thoroughly check and report MetaAttribute support of both QEdges and QNodes.

Additionally, unknown fields on QNodes/QEdges now produce warnings, and the validation methods have been refactored to handle the difference between warnings and errors.

The only thing left out is `bypass_cache` handling, as it's not particularly feasible as of yet. It's not in keeping nor useful to force a bypass of the Operation cache, and it's unworth dev time in the face of present priorities to implement transpiler/driver-level cache bypass for backend access. So, this will be left to the future.