### PR TITLE
Several refactors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.13, <3.14"
 dependencies = [
-    "redis>=5.0.4,<6",
+    "redis>=7,<8",
     "httpx>=0.28.1,<0.29",
     "uvicorn[standard]>=0.32.1,<0.33",
     "fastapi[standard-no-fastapi-cloud-cli]>=0.118,<0.119",

--- a/src/retriever/__main__.py
+++ b/src/retriever/__main__.py
@@ -12,7 +12,7 @@ from retriever.config.general import CONFIG
 from retriever.config.logger import configure_logging
 from retriever.config.write_configs import write_default_configs
 from retriever.utils.logs import add_mongo_sink, cleanup
-from retriever.utils.mongo import MONGO_CLIENT, MONGO_QUEUE
+from retriever.utils.mongo import MongoClient, MongoQueue
 from retriever.utils.uvicorn_multiprocess import AsyncMultiprocess
 
 
@@ -26,8 +26,8 @@ async def _main_inner() -> None:
 
     # For main process logging
     if not CONFIG.debug:
-        await MONGO_CLIENT.initialize()
-        await MONGO_QUEUE.start_process_task()
+        await MongoClient().initialize()
+        await MongoQueue().initialize()
         add_mongo_sink()
 
     logger.debug(
@@ -71,8 +71,8 @@ async def _main_inner() -> None:
 
     await background_manager.wrapup()
     if not CONFIG.debug:
-        await MONGO_QUEUE.stop_process_task()
-        await MONGO_CLIENT.close()
+        await MongoQueue().wrapup()
+        await MongoClient().close()
 
     # Wait for loguru to complete
     await cleanup()

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -10,10 +10,10 @@ from uvicorn.supervisors.multiprocess import SIGNALS
 
 from retriever.config.logger import configure_logging
 from retriever.data_tiers import tier_manager
-from retriever.metadata.optable import OPTableManager
+from retriever.metadata.optable import OpTableManager
 from retriever.utils.logs import add_mongo_sink
-from retriever.utils.mongo import MONGO_CLIENT, MONGO_QUEUE
-from retriever.utils.redis import REDIS_CLIENT
+from retriever.utils.mongo import MongoClient, MongoQueue
+from retriever.utils.redis import RedisClient
 from retriever.utils.telemetry import configure_telemetry
 
 
@@ -24,12 +24,12 @@ async def _background_async() -> None:
     # /// SETUP ///
 
     logger.info("Initializing background process...")
-    await MONGO_CLIENT.initialize()
-    await MONGO_QUEUE.start_process_task()
+    await MongoClient().initialize()
+    await MongoQueue().initialize()
     add_mongo_sink()
-    await REDIS_CLIENT.initialize()
+    await RedisClient().initialize()
     await tier_manager.connect_drivers()
-    metakg_manager = OPTableManager(leader=True)
+    metakg_manager = OpTableManager(leader=True)
     await metakg_manager.initialize()
     logger.success("Background process setup complete!")
 
@@ -45,9 +45,9 @@ async def _background_async() -> None:
     # /// WRAPUP ///
 
     await metakg_manager.wrapup()
-    await REDIS_CLIENT.close()
-    await MONGO_QUEUE.stop_process_task()
-    await MONGO_CLIENT.close()
+    await RedisClient().wrapup()
+    await MongoQueue().wrapup()
+    await MongoClient().close()
 
 
 def background_process() -> None:

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -10,6 +10,7 @@ from uvicorn.supervisors.multiprocess import SIGNALS
 
 from retriever.config.logger import configure_logging
 from retriever.data_tiers import tier_manager
+from retriever.lookup.subclass import SubclassMapping
 from retriever.metadata.optable import OpTableManager
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MongoClient, MongoQueue
@@ -31,6 +32,7 @@ async def _background_async() -> None:
     await tier_manager.connect_drivers()
     metakg_manager = OpTableManager(leader=True)
     await metakg_manager.initialize()
+    await SubclassMapping(leader=True).initialize()
     logger.success("Background process setup complete!")
 
     # /// MAIN LOOP ///
@@ -44,6 +46,7 @@ async def _background_async() -> None:
 
     # /// WRAPUP ///
 
+    await SubclassMapping().wrapup()
     await metakg_manager.wrapup()
     await RedisClient().wrapup()
     await MongoQueue().wrapup()

--- a/src/retriever/data_tiers/base_driver.py
+++ b/src/retriever/data_tiers/base_driver.py
@@ -51,4 +51,4 @@ class DatabaseDriver(ABC, metaclass=Singleton):
 
     @abstractmethod
     async def get_subclass_mapping(self) -> EntityToEntityMapping:
-        """Return a mapping of nodes to their ontological descendents."""
+        """Return a mapping of nodes to their ontological descendants."""

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -1076,12 +1076,7 @@ class DgraphTranspiler(Tier0Transpiler):
         attributes: list[AttributeDict] = []
 
         # Cases that require additional formatting to be TRAPI-compliant
-        special_cases: dict[str, tuple[str, Any]] = {
-            "equivalent_identifiers": (
-                "biolink:xref",
-                [CURIE(i) for i in node.attributes.get("equivalent_identifiers", [])],
-            )
-        }
+        special_cases: dict[str, tuple[str, Any]] = {}
 
         for attr_id, value in node.attributes.items():
             if attr_id in special_cases:

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -34,7 +34,7 @@ from retriever.types.general import EntityToEntityMapping
 from retriever.types.metakg import Operation, OperationNode
 from retriever.types.trapi import BiolinkEntity, Infores
 from retriever.utils.calls import get_metadata_client
-from retriever.utils.redis import REDIS_CLIENT
+from retriever.utils.redis import RedisClient
 from retriever.utils.trapi import hash_hex
 
 tracer = trace.get_tracer("lookup.execution.tracer")
@@ -200,7 +200,7 @@ class ElasticSearchDriver(DatabaseDriver):
         raw_data = response.json()
         metadata = DINGO_ADAPTER.validate_python(raw_data)
 
-        await REDIS_CLIENT.set(
+        await RedisClient().set(
             hash_hex(hash(url)),
             ormsgpack.packb(metadata),
             compress=True,
@@ -210,7 +210,7 @@ class ElasticSearchDriver(DatabaseDriver):
 
     async def _get_metadata(self, url: str, retries: int = 0) -> dict[str, Any] | None:
         """Obtain metadata for a given DINGO ingest."""
-        metadata_pack = await REDIS_CLIENT.get(hash_hex(hash(url)), compressed=True)
+        metadata_pack = await RedisClient().get(hash_hex(hash(url)), compressed=True)
 
         if metadata_pack is None:
             await self._pull_metadata(url)

--- a/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
@@ -20,7 +20,7 @@ from retriever.types.dingo import DINGOMetadata
 from retriever.types.general import EntityToEntityMapping
 from retriever.types.metakg import Operation, OperationNode, UnhashedOperation
 from retriever.types.trapi import BiolinkEntity, Infores, MetaAttributeDict
-from retriever.utils.redis import REDIS_CLIENT
+from retriever.utils.redis import RedisClient
 
 T1MetaData = dict[str, Any]
 
@@ -54,7 +54,7 @@ def get_stable_hash(key: str) -> str:
 
 async def save_metadata_cache(key: str, payload: T1MetaData) -> None:
     """Wrapper for persist metadata in Redis."""
-    await REDIS_CLIENT.set(
+    await RedisClient().set(
         get_stable_hash(key),
         ormsgpack.packb(payload),
         compress=True,
@@ -65,7 +65,7 @@ async def save_metadata_cache(key: str, payload: T1MetaData) -> None:
 async def read_metadata_cache(key: str) -> T1MetaData | None:
     """Wrapper for retrieving persisted metadata in Redis."""
     redis_key = get_stable_hash(key)
-    metadata_pack = await REDIS_CLIENT.get(redis_key, compressed=True)
+    metadata_pack = await RedisClient().get(redis_key, compressed=True)
     if metadata_pack is not None:
         return ormsgpack.unpackb(metadata_pack)
 

--- a/src/retriever/data_tiers/tier_1/elasticsearch/transpiler.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/transpiler.py
@@ -291,15 +291,7 @@ class ElasticsearchTranspiler(Tier1Transpiler):
                 attributes: list[AttributeDict] = []
 
                 # Cases that require additional formatting to be TRAPI-compliant
-                special_cases: SpecialCaseDict = {
-                    "equivalent_identifiers": (
-                        "biolink:xref",
-                        [
-                            CURIE(i)
-                            for i in node.attributes.get("equivalent_identifiers", [])
-                        ],
-                    )
-                }
+                special_cases: SpecialCaseDict = {}
 
                 attributes = self.build_attributes(node, special_cases)
 

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -3,7 +3,7 @@ import math
 import time
 from collections import deque
 from copy import deepcopy
-from typing import Any, Literal, cast, overload
+from typing import Literal, overload
 
 import bmt
 import httpx
@@ -16,7 +16,7 @@ from retriever.lookup.qgx import QueryGraphExecutor
 from retriever.lookup.utils import expand_qgraph, get_submitter
 from retriever.lookup.validate import validate
 from retriever.metadata.optable import (
-    OP_TABLE_MANAGER,
+    OpTableManager,
     QueryNotTraversable,
     UnsupportedConstraint,
 )
@@ -37,11 +37,13 @@ from retriever.types.trapi import (
 from retriever.types.trapi_pydantic import TierNumber
 from retriever.utils.calls import get_callback_client
 from retriever.utils.logs import TRAPILogger, trapi_level_to_int
-from retriever.utils.mongo import MONGO_QUEUE
+from retriever.utils.mongo import MongoQueue
 from retriever.utils.trapi import merge_results, prune_kg, update_kgraph
 
 tracer = trace.get_tracer("lookup.execution.tracer")
 biolink = bmt.Toolkit()
+MONGO_QUEUE = MongoQueue()
+OP_TABLE_MANAGER = OpTableManager()
 
 
 async def async_lookup(query: QueryInfo) -> None:
@@ -364,5 +366,5 @@ def tracked_response(
     ]
 
     # Cast because TypedDict has some *really annoying* interactions with more general dicts
-    MONGO_QUEUE.put("job_state", cast(dict[str, Any], cast(object, response)))
+    MONGO_QUEUE.put("job_state", response)
     return status, response

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -17,7 +17,7 @@ from retriever.lookup.branch import (
 )
 from retriever.lookup.partial import Partial
 from retriever.lookup.subclass import SubclassMapping
-from retriever.lookup.subquery import get_subgraph, subquery
+from retriever.lookup.subquery import SubqueryDispatcher
 from retriever.lookup.utils import make_mappings
 from retriever.metadata.optable import OperationPlan, OpTableManager
 from retriever.types.general import (
@@ -58,6 +58,7 @@ from retriever.utils.trapi import (
 tracer = trace.get_tracer("lookup.execution.tracer")
 OP_TABLE_MANAGER = OpTableManager()
 SUBCLASS_MAPPING = SubclassMapping()
+DISPATCHER = SubqueryDispatcher()
 
 # TODO: Set interpretation
 
@@ -318,14 +319,14 @@ class QueryGraphExecutor:
         ):
             if partial is None:  # A branch terminated with nothing
                 if self.terminate:  # Termination case, no handling needed
-                    self.job_log.debug(
+                    self.job_log.trace(
                         f"Branch {branch.superposition_name} terminated due to QGX wrapup."
                     )
                     break
 
                 # Either this is just one of several on the same starting node
                 # Meaning we can continue, business as usual
-                self.job_log.debug(
+                self.job_log.trace(
                     f"Branch {branch.superposition_name} terminated with no partials."
                 )
                 self.dead_superpositions.add(branch.superposition_id)
@@ -484,7 +485,7 @@ class QueryGraphExecutor:
             async with self.locks["kgraph"]:
                 subquery_tasks = [
                     asyncio.create_task(
-                        get_subgraph(
+                        DISPATCHER.get_subgraph(
                             current_branch,
                             current_branch.hop_id,
                             self.kedges_by_input,
@@ -500,7 +501,7 @@ class QueryGraphExecutor:
 
             subquery_tasks = [
                 asyncio.create_task(
-                    subquery(self.ctx.job_id, current_branch, self.qgraph),
+                    DISPATCHER.subquery(self.ctx.job_id, current_branch),
                     name="subquery",
                 )
                 # for operation in current_branch.operations
@@ -984,7 +985,7 @@ class QueryGraphExecutor:
             )
 
         self.job_log.debug(
-            f"Found and reformated dependents for {len(edges_to_fix)} edges."
+            f"Found and reformated dependents for subclass-derived {len(edges_to_fix)} edges."
         )
 
         self.insert_constructs(results, aux_graphs, edges_to_fix, construct_edges)

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -19,7 +19,7 @@ from retriever.lookup.partial import Partial
 from retriever.lookup.subclass import SubclassMapping
 from retriever.lookup.subquery import get_subgraph, subquery
 from retriever.lookup.utils import make_mappings
-from retriever.metadata.optable import OP_TABLE_MANAGER, OperationPlan
+from retriever.metadata.optable import OperationPlan, OpTableManager
 from retriever.types.general import (
     AdjacencyGraph,
     KAdjacencyGraph,
@@ -56,6 +56,7 @@ from retriever.utils.trapi import (
 )
 
 tracer = trace.get_tracer("lookup.execution.tracer")
+OP_TABLE_MANAGER = OpTableManager()
 
 # TODO: Set interpretation
 

--- a/src/retriever/lookup/subclass.py
+++ b/src/retriever/lookup/subclass.py
@@ -1,56 +1,118 @@
 import asyncio
+from collections.abc import Callable
+from typing import cast, override
 
+import ormsgpack
 from loguru import logger
 
 from retriever.config.general import CONFIG
 from retriever.data_tiers import tier_manager
-from retriever.types.general import EntityToEntityMapping
-from retriever.utils.general import Singleton
+from retriever.types.trapi import CURIE
+from retriever.utils.general import BatchedAction
+from retriever.utils.redis import RedisClient
+
+REDIS_CLIENT = RedisClient()
+
+MAPPING_ID = "SubclassHashMap"
 
 
-class SubclassMapping(metaclass=Singleton):
-    """A mapping from primary node ID to its ontological descendents."""
+class SubclassMapping(BatchedAction):
+    """A redis-backed mapping from primary node CURIE to its ontological descendants."""
 
-    _timeout_task: asyncio.Task[None] | None = None
-    _initialized: bool = False
-    _mapping: EntityToEntityMapping | None = None
+    queue_delay: float = 0.05
+    # Essentially should flush every interval
+    batch_size: int = 1000
+    flush_time: float = 0
 
+    is_leader: bool = False
+    subscriptions: dict[CURIE, list[Callable[[list[CURIE]], None]]]
+
+    redis_setup_batch_size: int = 5000
+
+    def __init__(self, leader: bool = False) -> None:
+        """Initialize an instance."""
+        self.is_leader = leader
+        self.subscriptions = {}
+        super().__init__()
+
+    @override
     async def initialize(self) -> None:
-        """Obtain the mapping from the tier 1 driver."""
-        logger.info("Initializing subclass mapping...")
-        if CONFIG.job.lookup.implicit_subclassing:
-            try:
-                self._mapping = await tier_manager.get_driver(1).get_subclass_mapping()
-                logger.success("Subclass mapping initialized!")
-            except Exception:
-                logger.error(
-                    "Unable to initialize subclass mapping, proceeding without implicit subclassing..."
-                )
-        else:
+        """Set up the redis hash and initialize the batch handler."""
+        if not CONFIG.job.lookup.implicit_subclassing:
             logger.info("Implicit subclassing disabled, skipping initialization.")
+            return await super().initialize()
 
-        self._initialized = True
-        self._timeout_task = asyncio.create_task(
-            self.expire(CONFIG.job.metakg.build_time)
-        )
+        if not self.is_leader:  # Only need leader to update the redis setup
+            return await super().initialize()
 
-    async def get(self) -> EntityToEntityMapping | None:
-        """Safely get the mapping."""
-        if not self._initialized:
-            await self.initialize()
-        return self._mapping
-
-    async def expire(self, timeout: float = 0) -> None:
-        """Expire the initialization, requiring a new update."""
-        if timeout < 1:
-            return
         try:
-            await asyncio.sleep(timeout)
-            self._initialized = False
+            logger.info("Initializing subclass mapping...")
+            mapping = await tier_manager.get_driver(1).get_subclass_mapping()
+
+            # Send to redis in batches to avoid overwhelming it
+            packed_mapping = dict[str, bytes]()
+            for curie, descendants in mapping.items():
+                packed_mapping[curie] = ormsgpack.packb(descendants)
+
+                if len(packed_mapping) >= self.redis_setup_batch_size:
+                    await REDIS_CLIENT.hset(
+                        MAPPING_ID,
+                        mapping=packed_mapping,
+                        ttl=CONFIG.job.metakg.build_time,
+                    )
+                    packed_mapping = {}
+
+            logger.success(
+                f"Subclass mapping initialized with {len(mapping)} ancestors."
+            )
+
+            self.tasks.append(asyncio.create_task(self.rebuild()))
+        except Exception:
+            logger.exception(
+                "Unable to initialize subclass mapping due to below error, proceeding without implicit subclassing..."
+            )
+
+        return await super().initialize()
+
+    async def get(self, curie: CURIE) -> list[CURIE]:
+        """Get the descendants of a given CURIE."""
+        future = asyncio.Future[list[CURIE]]()
+
+        def return_result(curies: list[CURIE]) -> None:
+            self.subscriptions[curie].remove(return_result)
+            future.set_result(curies)
+
+        if curie not in self.subscriptions:
+            self.subscriptions[curie] = []
+        self.subscriptions[curie].append(return_result)
+
+        self.put("batch_expand", curie)
+
+        return await future
+
+    async def batch_expand(self, batch: list[CURIE]) -> None:
+        """Get a batch of expanded curies and propagate them to original callers."""
+        if len(batch) == 0:
+            return
+        logger.trace(f"Batch expand batch of {len(batch)}")
+        descendants_packed = await REDIS_CLIENT.hmget(MAPPING_ID, *batch)
+        for curie, desc_packed in zip(batch, descendants_packed, strict=True):
+            descs = []
+            if desc_packed is not None:
+                descs = cast(list[CURIE], ormsgpack.unpackb(desc_packed))
+
+            for callback in self.subscriptions.get(curie, []):
+                callback(descs)
+
+        # return ormsgpack.unpackb(descendants_packed[0])
+
+    async def rebuild(self) -> None:
+        """Periodically rebuild the mapping."""
+        try:
+            timeout = CONFIG.job.metakg.build_time
+            if timeout < 0:
+                return  # Rebuilding disabled
+            await asyncio.sleep(CONFIG.job.metakg.build_time)
+            await self.initialize()
         except asyncio.CancelledError:
             return
-
-    async def wrapup(self) -> None:
-        """Stop the expire task."""
-        if self._timeout_task:
-            self._timeout_task.cancel()

--- a/src/retriever/lookup/subquery.py
+++ b/src/retriever/lookup/subquery.py
@@ -1,12 +1,15 @@
 import asyncio
 import math
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, NamedTuple, cast
 
+from loguru import logger
 from opentelemetry import trace
 
 from retriever.data_tiers import tier_manager
 from retriever.data_tiers.base_transpiler import Transpiler
+from retriever.data_tiers.tier_1.elasticsearch.types import ESEdge
 from retriever.lookup.branch import Branch, SuperpositionHop
 from retriever.types.general import BackendResult
 from retriever.types.trapi import (
@@ -20,6 +23,7 @@ from retriever.types.trapi import (
     QueryGraphDict,
 )
 from retriever.utils import biolink
+from retriever.utils.general import BatchedAction
 from retriever.utils.logs import TRAPILogger
 from retriever.utils.trapi import (
     append_aggregator_source,
@@ -31,209 +35,297 @@ from retriever.utils.trapi import (
 tracer = trace.get_tracer("lookup.execution.tracer")
 
 
-def make_payloads(
-    branch: Branch, qg: QueryGraphDict, job_log: TRAPILogger
-) -> tuple[list[QueryGraphDict], list[Transpiler], list[Any]]:
-    """Convert the existing branch edge to query payloads.
+class SubqContext(NamedTuple):
+    """All the context required to generate a subquery."""
 
-    Produces multiple if symmetric predicates are present.
+    job: str
+    branch: Branch
+
+
+class SubqueryDispatcher(BatchedAction):
+    """A simple batcher for queries going to Tier 1/2.
+
+    Currently does nothing intelligent for multi-tier use.
+    Will have to refactor for this.
     """
-    edge_id = branch.current_edge
-    current_edge = qg["edges"][edge_id]
-    subject_node = qg["nodes"][current_edge["subject"]]
-    object_node = qg["nodes"][current_edge["object"]]
-    if not branch.reversed:
-        subject_node["ids"] = [branch.input_curie]
-    else:
-        object_node["ids"] = [branch.input_curie]
 
-    qgraph = QueryGraphDict(
-        nodes={
-            current_edge["subject"]: subject_node,
-            current_edge["object"]: object_node,
-        },
-        edges={edge_id: current_edge},
-    )
+    queue_delay: float = 0.05
+    # Essentially should flush every interval
+    batch_size: int = 100
+    flush_time: float = 0
 
-    subject_info = (
-        subject_node.get("ids", None) or subject_node.get("categories", []) or []
-    )
-    if "biolink:NamedThing" in subject_info:
-        subject_info = ["biolink:NamedThing"]
-    object_info = (
-        object_node.get("ids", None) or object_node.get("categories", []) or []
-    )
-    if "biolink:NamedThing" in object_info:
-        object_info = ["biolink:NamedThing"]
-    predicate_info = current_edge.get("predicates", ["biolink:related_to"]) or [
-        "biolink:related_to"
-    ]
-    if "biolink:related_to" in predicate_info:
-        predicate_info = ["biolink:related_to"]
-    job_log.debug(
-        f"Subquerying Tier 1 for {subject_info} -{predicate_info}-> {object_info}..."
-    )
-
-    # Check the symmetric predicate case
-    symmetrics = list[BiolinkPredicate]()
-    for predicate in current_edge.get("predicates") or [
-        BiolinkPredicate("biolink:related_to")
-    ]:
-        if biolink.is_symmetric(str(predicate)):
-            symmetrics.append(predicate)
-
-    transpiler = tier_manager.get_transpiler(1)
-    query_payload = transpiler.process_qgraph(qgraph)
-    job_log.trace(str(query_payload))
-    qgraphs = [qgraph]
-    queries = [query_payload]
-    transpilers = [transpiler]  # keep transpilers in case they store anything
-
-    if len(symmetrics):
-        symmetrics_info = (
-            symmetrics
-            if "biolink:related_to" not in symmetrics
-            else ["biolink:related_to"]
-        )
-        job_log.debug("Symmetric predicates found, adding reverse subquery.")
-        job_log.debug(
-            f"Subquerying Tier 1 for {object_info} -{symmetrics_info}-> {subject_info}..."
-        )
-        reverse_edge = QEdgeDict(
-            subject=current_edge["subject"],
-            object=current_edge["object"],
-            predicates=current_edge.get(
-                "predicates", [BiolinkPredicate("biolink:related_to")]
-            ),
-        )
-        if qualifiers := current_edge.get("qualifier_constraints"):
-            reverse_edge["qualifier_constraints"] = (
-                biolink.reverse_qualifier_constraints(qualifiers)
-            )
-        # BUG: doesn't reverse attribute constraints. But this is vanishingly unlikely.
-        reverse_qg = QueryGraphDict(
-            nodes={
-                current_edge["subject"]: object_node,
-                current_edge["object"]: subject_node,
-            },
-            edges={edge_id: reverse_edge},
-        )
-        transpiler = tier_manager.get_transpiler(1)  # Transpiler isn't singleton
-        reverse_query_payload = transpiler.process_qgraph(reverse_qg)
-        qgraphs.append(reverse_qg)
-        queries.append(reverse_query_payload)
-        transpilers.append(transpiler)
-
-    return qgraphs, transpilers, queries
-
-
-async def run_queries(
-    qgraphs: list[QueryGraphDict],
-    transpilers: list[Transpiler],
-    query_payloads: list[Any],
-    job_log: TRAPILogger,
-) -> list[BackendResult]:
-    """Given a set of query payloads, run them and combine their results."""
-    query_driver = tier_manager.get_driver(1)
-
-    subqueries = [
-        asyncio.create_task(query_driver.run_query(payload))
-        for payload in query_payloads
+    subscriptions: dict[
+        int, list[Callable[[tuple[KnowledgeGraphDict, list[LogEntryDict]]], None]]
     ]
 
-    response_records = await asyncio.gather(*subqueries, return_exceptions=True)
-    results = list[BackendResult]()
-    for i, record in enumerate(response_records):
-        if isinstance(record, Exception):
-            print(record)
-            job_log.with_exception(
-                "An unhandled error occurred in the query driver.", exception=record
+    def __init__(self) -> None:
+        """Initialize an instance."""
+        self.subscriptions = {}
+        super().__init__()
+
+    async def subquery(
+        self, job_id: str, branch: Branch
+    ) -> tuple[KnowledgeGraphDict, list[LogEntryDict]]:
+        """Make a subquery."""
+        subq_id = hash((job_id, branch.superposition_id))
+        job_log = TRAPILogger(job_id)
+        try:
+            start = time.time()
+            job_log.debug(
+                f"Subquery against Tier 1 {branch.superposition_id_to_name(branch.superposition_id[-2:])}"
             )
-            continue
-        result = transpilers[i].convert_results(qgraphs[i], record)
+            future = asyncio.Future[tuple[KnowledgeGraphDict, list[LogEntryDict]]]()
 
-        # Add Retriever to the provenance chain
-        for edge_id, edge in result["knowledge_graph"]["edges"].items():
-            try:
-                append_aggregator_source(edge, Infores("infores:retriever"))
-            except ValueError:
-                job_log.warning(f"Edge f{edge_id} has an invalid provenance chain.")
+            def return_result(
+                subq_result: tuple[KnowledgeGraphDict, list[LogEntryDict]],
+            ) -> None:
+                self.subscriptions[subq_id].remove(return_result)
+                # Have to clean up or else memory leak since superpositions are MANY
+                if len(self.subscriptions[subq_id]) == 0:
+                    del self.subscriptions[subq_id]
 
-        results.append(result)
+                end = time.time()
+                kg, logs = subq_result
+                job_log.debug(
+                    f"Subquery got {len(kg['edges'])} records as part of batched query in {math.ceil((end - start) * 1000)}ms"
+                )
+                logs.extend(job_log.get_logs())
 
-    # Have to do this for each
-    for result in results:
-        normalize_kgraph(
-            result["knowledge_graph"], result["results"], result["auxiliary_graphs"]
-        )
+                future.set_result(subq_result)
 
-    return results
+            if subq_id not in self.subscriptions:
+                self.subscriptions[subq_id] = []
+            self.subscriptions[subq_id].append(return_result)
 
+            self.put("batch_subquery", SubqContext(job=job_id, branch=branch))
 
-@tracer.start_as_current_span("subquery")
-async def subquery(
-    job_id: str, branch: Branch, qg: QueryGraphDict
-) -> tuple[KnowledgeGraphDict, list[LogEntryDict]]:
-    """Basic subquery function for retrieving from Tier 1.
+            return await future
+        except asyncio.CancelledError:
+            return KnowledgeGraphDict(nodes={}, edges={}), []
 
-    Intended to be replaced by subquery dispatcher in the future.
+    async def batch_subquery(self, batch: list[SubqContext]) -> None:
+        """Produce query payloads and make them as a single batch query to the backend(s)."""
+        loggers = dict[int, TRAPILogger]()
 
-    Assumptions:
-        Returns KEdges in the direction of the QEdge
-    """
-    try:
-        job_log: TRAPILogger = TRAPILogger(job_id)
+        query_mapping = list[tuple[SubqContext, QueryGraphDict, Transpiler]]()
+        payloads = list[Any]()
+        for subq in batch:
+            subq_id = hash((subq.job, subq.branch.superposition_id))
+            if subq_id not in loggers:
+                loggers[subq_id] = TRAPILogger(subq.job)
+
+            new_qgraphs, new_transpilers, new_payloads = self.make_payloads(
+                subq.branch, loggers[subq_id]
+            )
+            payloads.extend(new_payloads)
+            query_mapping.extend(
+                [
+                    (subq, qg, trans)
+                    for qg, trans in zip(new_qgraphs, new_transpilers, strict=True)
+                ]
+            )
+
         start = time.time()
+        logger.info(
+            f"Subquerying Tier 1 with batch of {len(payloads)} subqueries (originating from batch of {len(batch)})..."
+        )
+        query_driver = tier_manager.get_driver(1)
+        split = time.time()
+        logger.success(f"Got results in {math.ceil((split - start) * 1000)}ms")
+        try:
+            response_records = cast(
+                list[list[ESEdge]], await query_driver.run_query(payloads)
+            )
 
-        # branch comes in execution direction
-        # edge it refers to is in query direction
-        qgraphs, transpilers, query_payloads = make_payloads(branch, qg, job_log)
-        results = await run_queries(qgraphs, transpilers, query_payloads, job_log)
+            results = dict[int, BackendResult]()
+            for record, (subq, qgraph, transpiler) in zip(
+                response_records, query_mapping, strict=True
+            ):
+                subq_id = hash((subq.job, subq.branch.superposition_id))
 
-        if len(results) == 0:
-            kg = KnowledgeGraphDict(nodes={}, edges={})
-        else:
-            kg = results[0]["knowledge_graph"]
-        if len(results) > 1:
-            for result in results[1:]:
+                result = transpiler.convert_results(qgraph, record)
+
+                # Add Retriever to the provenance chain
+                for edge_id, edge in result["knowledge_graph"]["edges"].items():
+                    try:
+                        append_aggregator_source(edge, Infores("infores:retriever"))
+                    except ValueError:
+                        loggers[subq_id].warning(
+                            f"Edge f{edge_id} has an invalid provenance chain."
+                        )
+
+                # Normalize the result kgraph for merging
+                normalize_kgraph(
+                    result["knowledge_graph"],
+                    result["results"],
+                    result["auxiliary_graphs"],
+                )
+
+                if subq_id not in results:
+                    results[subq_id] = result
+                    continue
+
                 # We can only do this because we can guarantee both graphs are disjoint,
                 # except for nodes, but any two nodes that are the same ID should be
                 # exactly the same.
-                # update_kgraph() should be used in all other cases
-                kg["nodes"].update(result["knowledge_graph"]["nodes"])
-                kg["edges"].update(result["knowledge_graph"]["edges"])
-        end = time.time()
-        job_log.debug(
-            f"Subquery got {len(kg['edges'])} records in {math.ceil((end - start) * 1000)}ms"
+                # Additionally, we're doing nothing to update aux/results simple because
+                # we know they'll never be used in Tier 1/2
+                results[subq_id]["knowledge_graph"]["nodes"].update(
+                    result["knowledge_graph"]["nodes"]
+                )
+                results[subq_id]["knowledge_graph"]["edges"].update(
+                    result["knowledge_graph"]["edges"]
+                )
+
+            for subq_id, result in results.items():
+                for callback in self.subscriptions.get(subq_id, []):
+                    callback((result["knowledge_graph"], loggers[subq_id].get_logs()))
+            end = time.time()
+            logger.success(
+                f"Transformed results and sent to original callers in {math.ceil((end - split) * 1000)}ms"
+            )
+
+        except Exception as e:
+            for subq_id, job_log in loggers.items():
+                job_log.with_exception(
+                    "An unhandled error occurred in the query driver.", exception=e
+                )
+                for callback in self.subscriptions.get(subq_id, []):
+                    callback(
+                        (KnowledgeGraphDict(nodes={}, edges={}), job_log.get_logs())
+                    )
+
+    def make_payloads(
+        self, branch: Branch, job_log: TRAPILogger
+    ) -> tuple[list[QueryGraphDict], list[Transpiler], list[Any]]:
+        """Convert the existing branch edge to query payloads.
+
+        Produces multiple if symmetric predicates are present.
+        """
+        current_edge = branch.qgraph["edges"][branch.current_edge]
+        subject_node = branch.qgraph["nodes"][current_edge["subject"]]
+        object_node = branch.qgraph["nodes"][current_edge["object"]]
+        if not branch.reversed:
+            subject_node["ids"] = [branch.input_curie]
+        else:
+            object_node["ids"] = [branch.input_curie]
+
+        qgraph = QueryGraphDict(
+            nodes={
+                current_edge["subject"]: subject_node,
+                current_edge["object"]: object_node,
+            },
+            edges={branch.current_edge: current_edge},
         )
 
-        return kg, job_log.get_logs()
+        # Check the symmetric predicate case
+        symmetrics = list[BiolinkPredicate]()
+        for predicate in current_edge.get("predicates") or [
+            BiolinkPredicate("biolink:related_to")
+        ]:
+            if biolink.is_symmetric(str(predicate)):
+                symmetrics.append(predicate)
 
-    except asyncio.CancelledError:
-        return KnowledgeGraphDict(nodes={}, edges={}), []
+        transpiler = tier_manager.get_transpiler(1)
+        query_payload = transpiler.process_qgraph(qgraph)
+        job_log.trace(str(query_payload))
+        qgraphs = [qgraph]
+        queries = [query_payload]
+        transpilers = [transpiler]  # keep transpilers in case they store anything
 
+        if len(symmetrics):
+            job_log.debug("Symmetric predicates found, adding reverse subquery.")
+            reverse_edge = QEdgeDict(
+                subject=current_edge["subject"],
+                object=current_edge["object"],
+                predicates=current_edge.get(
+                    "predicates", [BiolinkPredicate("biolink:related_to")]
+                ),
+            )
+            if qualifiers := current_edge.get("qualifier_constraints"):
+                reverse_edge["qualifier_constraints"] = (
+                    biolink.reverse_qualifier_constraints(qualifiers)
+                )
+            # BUG: doesn't reverse attribute constraints. But this is vanishingly unlikely.
+            reverse_qg = QueryGraphDict(
+                nodes={
+                    current_edge["subject"]: object_node,
+                    current_edge["object"]: subject_node,
+                },
+                edges={branch.current_edge: reverse_edge},
+            )
+            transpiler = tier_manager.get_transpiler(1)  # Transpiler isn't singleton
+            reverse_query_payload = transpiler.process_qgraph(reverse_qg)
+            qgraphs.append(reverse_qg)
+            queries.append(reverse_query_payload)
+            transpilers.append(transpiler)
 
-async def get_subgraph(
-    branch: Branch,
-    key: SuperpositionHop,
-    kedges: dict[SuperpositionHop, list[EdgeDict]],
-    kgraph: KnowledgeGraphDict,
-) -> tuple[KnowledgeGraphDict, list[LogEntryDict]]:
-    """Get a subgraph from a given set of kedges.
+        return qgraphs, transpilers, queries
 
-    Used to replace subquerying when a given hop has already been completed.
-    """
-    edges = kedges[key]
-    curies = list[str]()
-    for edge in edges:
-        if not branch.reversed:
-            curies.append(edge["object"])
-        else:
-            curies.append(edge["subject"])
+    async def run_queries(
+        self,
+        qgraphs: list[QueryGraphDict],
+        transpilers: list[Transpiler],
+        query_payloads: list[Any],
+        job_log: TRAPILogger,
+    ) -> list[BackendResult]:
+        """Given a set of query payloads, run them and combine their results."""
+        query_driver = tier_manager.get_driver(1)
 
-    kg = KnowledgeGraphDict(
-        edges={hash_hex(hash_edge(edge)): edge for edge in edges},
-        nodes={CURIE(curie): kgraph["nodes"][CURIE(curie)] for curie in curies},
-    )
+        subqueries = [
+            asyncio.create_task(query_driver.run_query(payload))
+            for payload in query_payloads
+        ]
 
-    return kg, list[LogEntryDict]()
+        response_records = await asyncio.gather(*subqueries, return_exceptions=True)
+        results = list[BackendResult]()
+        for i, record in enumerate(response_records):
+            if isinstance(record, Exception):
+                job_log.with_exception(
+                    "An unhandled error occurred in the query driver.", exception=record
+                )
+                continue
+            result = transpilers[i].convert_results(qgraphs[i], record)
+
+            # Add Retriever to the provenance chain
+            for edge_id, edge in result["knowledge_graph"]["edges"].items():
+                try:
+                    append_aggregator_source(edge, Infores("infores:retriever"))
+                except ValueError:
+                    job_log.warning(f"Edge f{edge_id} has an invalid provenance chain.")
+
+            results.append(result)
+
+        # Have to do this for each
+        for result in results:
+            normalize_kgraph(
+                result["knowledge_graph"], result["results"], result["auxiliary_graphs"]
+            )
+
+        return results
+
+    @staticmethod
+    async def get_subgraph(
+        branch: Branch,
+        key: SuperpositionHop,
+        kedges: dict[SuperpositionHop, list[EdgeDict]],
+        kgraph: KnowledgeGraphDict,
+    ) -> tuple[KnowledgeGraphDict, list[LogEntryDict]]:
+        """Get a subgraph from a given set of kedges.
+
+        Used to replace subquerying when a given hop has already been completed.
+        """
+        edges = kedges[key]
+        curies = list[str]()
+        for edge in edges:
+            if not branch.reversed:
+                curies.append(edge["object"])
+            else:
+                curies.append(edge["subject"])
+
+        kg = KnowledgeGraphDict(
+            edges={hash_hex(hash_edge(edge)): edge for edge in edges},
+            nodes={CURIE(curie): kgraph["nodes"][CURIE(curie)] for curie in curies},
+        )
+
+        return kg, list[LogEntryDict]()

--- a/src/retriever/metadata/trapi_metakg.py
+++ b/src/retriever/metadata/trapi_metakg.py
@@ -1,10 +1,12 @@
 import asyncio
 
-from retriever.metadata.optable import get_trapi_metakg
+from retriever.metadata.optable import OpTableManager
 from retriever.types.general import ErrorDetail, QueryInfo
 from retriever.types.trapi import (
     MetaKnowledgeGraphDict,
 )
+
+OP_TABLE_MANAGER = OpTableManager()
 
 
 async def trapi_metakg(
@@ -19,7 +21,7 @@ async def trapi_metakg(
         async with asyncio.timeout(
             query.timeout[-1] if query.timeout[-1] is not -1 else None
         ):
-            metakg = await get_trapi_metakg(tuple(query.tiers))
+            metakg = await OP_TABLE_MANAGER.get_trapi_metakg(tuple(query.tiers))
             return 200, metakg
     except TimeoutError:
         return 500, ErrorDetail(detail="Building TRAPI MetaKG timed out.")

--- a/src/retriever/query.py
+++ b/src/retriever/query.py
@@ -26,9 +26,10 @@ from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import TierNumber
 from retriever.utils import telemetry
 from retriever.utils.logs import TRAPILogger, structured_log_to_trapi
-from retriever.utils.mongo import MONGO_CLIENT, MONGO_QUEUE
+from retriever.utils.mongo import MongoClient, MongoQueue
 
 tracer = trace.get_tracer("lookup.execution.tracer")
+MONGO_QUEUE = MongoQueue()
 
 
 @overload
@@ -195,7 +196,7 @@ async def get_job_state(
     ctx_log = TRAPILogger(job_id)
 
     try:
-        job_dict = await MONGO_CLIENT.get_job_doc(job_id)
+        job_dict = await MongoClient().get_job_doc(job_id)
         if job_dict:
             ctx_log.debug(f"Got job {job_id} result from MongoDB.")
         else:
@@ -211,7 +212,7 @@ async def get_job_state(
         job_logs = [
             log
             async for log in structured_log_to_trapi(
-                MONGO_CLIENT.get_logs(job_id=job_id)
+                MongoClient().get_logs(job_id=job_id)
             )
         ]
         if len(job_logs) > 0:

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -17,6 +17,7 @@ from retriever.config.logger import configure_logging
 from retriever.config.openapi import OPENAPI_CONFIG, TRAPI
 from retriever.data_tiers import tier_manager
 from retriever.lookup.subclass import SubclassMapping
+from retriever.lookup.subquery import SubqueryDispatcher
 from retriever.lookup.utils import QueryDumper
 from retriever.metadata.optable import OpTableManager
 from retriever.query import get_job_state, make_query
@@ -56,10 +57,12 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     query_dumper = QueryDumper()
     if CONFIG.tier0.dump_queries or CONFIG.tier1.dump_queries:
         await query_dumper.initialize()
+    await SubqueryDispatcher().initialize()
 
     yield  # Separates startup/shutdown phase
 
     # Shutdown
+    await SubqueryDispatcher().wrapup()
     if query_dumper.initialized:
         await query_dumper.wrapup()
     await SubclassMapping().wrapup()

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -52,13 +52,10 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     await RedisClient().initialize()
     await OpTableManager().initialize()
     await tier_manager.connect_drivers()
+    await SubclassMapping().initialize()
     query_dumper = QueryDumper()
     if CONFIG.tier0.dump_queries or CONFIG.tier1.dump_queries:
         await query_dumper.initialize()
-
-    # TODO: make this a background task that stores hashed to redis
-    # instead of keeping in local memory for each worker
-    await SubclassMapping().initialize()
 
     yield  # Separates startup/shutdown phase
 

--- a/src/retriever/utils/general.py
+++ b/src/retriever/utils/general.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import time
 from abc import ABC, ABCMeta, abstractmethod
@@ -10,10 +12,10 @@ from loguru import logger
 class Singleton(ABCMeta):
     """Singleton metaclass that ensures classes using it have only one instance."""
 
-    _instances: ClassVar[dict["Singleton", "Singleton"]] = {}
+    _instances: ClassVar[dict[Singleton, Singleton]] = {}
 
     @override
-    def __call__(cls, *args: Any, **kwargs: Any) -> "Singleton":
+    def __call__(cls, *args: Any, **kwargs: Any) -> Singleton:
         """Ensure calls go to one instance."""
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)  # noqa:UP008
@@ -80,8 +82,14 @@ async def merge_iterators[T](
 class AsyncDaemon(ABC, metaclass=Singleton):
     """A base class for handling a number of lifetime-running async tasks."""
 
-    tasks: ClassVar[list[asyncio.Task[None]]] = []
-    initialized: bool = False
+    tasks: list[asyncio.Task[None]]
+    initialized: bool
+
+    def __init__(self) -> None:
+        """Instantiate a new AsyncDaemon."""
+        super().__init__()
+        self.tasks = []
+        self.initialized = False
 
     async def initialize(self) -> None:
         """Start up long-running tasks."""
@@ -105,13 +113,18 @@ class AsyncDaemon(ABC, metaclass=Singleton):
         """Return a list of long-running task functions."""
 
 
-class BatchedAction(AsyncDaemon):
+class BatchedAction(AsyncDaemon, metaclass=Singleton):
     """A base class for queuing and batching a number of different sink types."""
 
     batch_size: int = 100
     queue_delay: float = 0.1
     flush_time: float = 1
-    action_queues: ClassVar[dict[str, asyncio.Queue[Any]]] = {}
+    action_queues: dict[str, asyncio.Queue[Any]]
+
+    def __init__(self) -> None:
+        """Instantiate a new BatchedAction."""
+        self.action_queues = {}
+        super().__init__()
 
     @override
     def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:

--- a/src/retriever/utils/general.py
+++ b/src/retriever/utils/general.py
@@ -82,20 +82,19 @@ class AsyncDaemon(ABC, metaclass=Singleton):
 
     tasks: ClassVar[list[asyncio.Task[None]]] = []
     initialized: bool = False
-    namespace: str = "AsyncDaemon"
 
-    def initialize(self) -> None:
+    async def initialize(self) -> None:
         """Start up long-running tasks."""
         if self.initialized:
             return
         logger.info(f"{self.__class__.__name__} starting tasks.")
         for i, func in enumerate(self.get_task_funcs()):
             self.tasks.append(
-                asyncio.create_task(func(), name=f"{self.namespace}:task_{i}")
+                asyncio.create_task(func(), name=f"{self.__class__.__name__}:task_{i}")
             )
         self.initialized = True
 
-    def wrapup(self) -> None:
+    async def wrapup(self) -> None:
         """Cancel all long-running tasks."""
         logger.info(f"{self.__class__.__name__} wrapping up.")
         for task in self.tasks:

--- a/src/retriever/utils/logs.py
+++ b/src/retriever/utils/logs.py
@@ -15,7 +15,9 @@ from retriever.config.general import CONFIG
 from retriever.types.general import LogLevel
 from retriever.types.trapi import LogEntryDict
 from retriever.types.trapi import LogLevel as TRAPILogLevel
-from retriever.utils.mongo import MONGO_QUEUE
+from retriever.utils.mongo import MongoQueue
+
+MONGO_QUEUE = MongoQueue()
 
 
 def log_level_to_trapi(level: LogLevel) -> TRAPILogLevel:

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -230,7 +230,7 @@ class MongoQueue(BatchedAction):
     """An asynchronous queue for sending items to MongoDB."""
 
     # Essentially should flush every interval
-    batch_size: int = 1
+    batch_size: int = 1000
     flush_time: float = 0
 
     client: ClassVar[MongoClient] = MongoClient()

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections import deque
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from time import time
-from typing import Any
+from typing import Any, ClassVar
 
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from loguru import logger as log
@@ -15,11 +13,12 @@ from pymongo.server_api import ServerApi
 
 from retriever.config.general import CONFIG
 from retriever.types.general import LogLevel
+from retriever.utils.general import BatchedAction, Singleton
 
 CODEC_OPTIONS = DEFAULT_CODEC_OPTIONS.with_options(tz_aware=True)
 
 
-class MongoClient:
+class MongoClient(metaclass=Singleton):
     """A client abstraction layer for basic operations."""
 
     def __init__(self) -> None:
@@ -227,107 +226,21 @@ class MongoClient:
         self.client.close()
 
 
-class MongoQueue:
+class MongoQueue(BatchedAction):
     """An asynchronous queue for sending items to MongoDB."""
 
-    def __init__(self, client: MongoClient) -> None:
-        """Initialize a mongo client and multiprocessing queue."""
-        self.queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
-        self.client: MongoClient = client
-        self.process_tasks: list[asyncio.Task[None]] | None = None
-        self.task_deques: dict[str, tuple[asyncio.Lock, deque[Any]]] = {
-            "job_state": (asyncio.Lock(), deque()),
-            "log_dump": (asyncio.Lock(), deque()),
-        }
+    # Essentially should flush every interval
+    batch_size: int = 1
+    flush_time: float = 0
 
-    async def process_queue(self) -> None:
-        """Periodically poll the queue for a task and handle it accordingly."""
-        while True:
-            try:
-                target, doc = self.queue.get_nowait()
-                if not hasattr(self.client, target):
-                    log.error(
-                        f"MongoClient has no operation {target}. Operation skipped.",
-                        extra={"no_mongo_log": True},
-                    )
-                try:
-                    task = getattr(self.client, target)(doc)
-                    lock, task_deque = self.task_deques[target]
-                    async with lock:
-                        task_deque.append(task)
-                    self.queue.task_done()
-                except Exception:
-                    log.exception(
-                        f"An exception occurred in the operation {target}",
-                        extra={"doc": doc, "no_mongo_log": True},
-                    )
-            except asyncio.QueueEmpty:
-                try:
-                    await asyncio.sleep(0.1)
-                    continue
-                except asyncio.CancelledError:  # likely to be cancelled while waiting
-                    break
-            except (ValueError, asyncio.CancelledError):  # Queue is closed
-                break
+    client: ClassVar[MongoClient] = MongoClient()
 
-    async def process_batch_tasks(self) -> None:
-        """Periodically grab a batch of mongo tasks and run them."""
-        while True:
-            try:
-                for target, (lock, task_deque) in self.task_deques.items():
-                    async with lock:
-                        tasks = [
-                            task_deque.popleft()
-                            for _ in range(
-                                min(len(task_deque), CONFIG.mongo.flood_batch_size)
-                            )
-                        ]
-                    if len(tasks) == 0:
-                        continue
-                    await getattr(self.client, f"batch_{target}")(tasks)
+    async def job_state(self, batch: list[dict[str, Any]]) -> None:
+        """Send a batch of job states to MongoDB."""
+        await self.client.batch_job_state(
+            [self.client.job_state(state) for state in batch]
+        )
 
-                await asyncio.sleep(0.1)
-            except (ValueError, asyncio.CancelledError):
-                break
-
-    async def start_process_task(self) -> None:
-        """Start a processing loop to serialize documents to MongoDB."""
-        if self.process_tasks is not None:
-            raise ValueError("Cannot start second MongoDB queue process task.")
-        self.process_tasks = [
-            asyncio.create_task(self.process_queue(), name="mongo_process_loop"),
-            asyncio.create_task(self.process_batch_tasks(), name="mongo_batch_loop"),
-        ]
-        log.info("Started MongoDB serialize task.")
-
-    async def stop_process_task(self) -> None:
-        """Close the queue and stop the process loop task."""
-        start = time()
-        while not self.queue.empty():
-            # Don't wait forever
-            if time() - start > CONFIG.mongo.shutdown_timeout:
-                break
-            await asyncio.sleep(0.1)
-        self.queue.shutdown()
-        await self.queue.join()
-
-        try:
-            if self.process_tasks is None:
-                return
-            for task in self.process_tasks:
-                task.cancel()
-                await task
-            log.info("Stopped MongoDB serialize task.")
-        except Exception:
-            log.exception("Exception occurred while stopping MongoDB serialize task.")
-
-    def put(self, task_name: str, doc: dict[str, Any]) -> None:
-        """Add a document to the queue."""
-        try:
-            self.queue.put_nowait((task_name, doc))
-        except (asyncio.QueueShutDown, asyncio.QueueFull):
-            return
-
-
-MONGO_CLIENT = MongoClient()
-MONGO_QUEUE = MongoQueue(MONGO_CLIENT)
+    async def log_dump(self, batch: list[dict[str, Any]]) -> None:
+        """Send a batch of logs to MongoDB."""
+        await self.client.batch_log_dump([self.client.log_dump(log) for log in batch])

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -1,6 +1,16 @@
 import asyncio
-from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, cast, override
+from abc import ABCMeta, abstractmethod
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from types import CoroutineType, TracebackType
+from typing import (
+    Any,
+    Protocol,
+    Self,
+    TypedDict,
+    cast,
+    overload,
+    override,
+)
 
 import redis.asyncio as redis
 import zstandard
@@ -9,6 +19,7 @@ from loguru import logger as log
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.typing import AbsExpiryT, ChannelT, EncodableT, ExpiryT, KeyT, ResponseT
 
 from retriever.config.general import CONFIG
 from retriever.utils.general import AsyncDaemon
@@ -26,16 +37,285 @@ ZSTD_COMPRESSOR = zstandard.ZstdCompressor()
 ZSTD_DECOMPRESSOR = zstandard.ZstdDecompressor()
 
 
+class PubSubMessage(TypedDict):
+    """The message type returned from pubsub.get_message()."""
+
+    pattern: str | None
+    type: str
+    channel: bytes
+    data: Any
+
+
+class PubSub(Protocol, metaclass=ABCMeta):
+    """A protocol surfacing correct type hinting for an async PubSub's methods.
+
+    I'm lazy so I'm only adding what gets used. ~ Willow
+    """
+
+    @abstractmethod
+    async def __aenter__(self) -> Self:
+        """`async with...` support."""
+
+    @abstractmethod
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """`async with...` support."""
+
+    @abstractmethod
+    async def subscribe(
+        self,
+        *args: ChannelT,
+        **kwargs: Callable[[PubSubMessage | None], CoroutineType[None, None, None]],
+    ) -> None:
+        """Subscribe to channels.
+
+        Channels supplied as keyword arguments expect
+        a channel name as the key and a callable as the value. A channel's
+        callable will be invoked automatically when a message is received on
+        that channel rather than producing a message via ``listen()`` or
+        ``get_message()``.
+        """
+
+    @abstractmethod
+    async def unsubscribe(self, *args: ChannelT) -> None:
+        """Unsubscribe from the supplied channels.
+
+        If empty, unsubscribe from all channels.
+        """
+
+    @abstractmethod
+    async def get_message(
+        self, ignore_subscribe_messages: bool = False, timeout: float = 0.0
+    ) -> PubSubMessage | None:
+        """Get the next message if one is available, otherwise None.
+
+        If timeout is specified, the system will wait for `timeout` seconds
+        before returning. Timeout should be specified as a floating point
+        number or None to wait indefinitely.
+        """
+
+
+class AsyncRedis(Protocol, metaclass=ABCMeta):
+    """A protocol surfacing correct type hinting for Redis's methods.
+
+    I'm lazy so I'm only adding what gets used. ~ Willow
+    """
+
+    @abstractmethod
+    async def initialize(self) -> Self:
+        """Initialize the client."""
+
+    @abstractmethod
+    async def ping(self) -> bool:
+        """Ping the Redis server to test connectivity.
+
+        Sends a PING command to the Redis server and returns True if the server
+        responds with "PONG".
+
+        This command is useful for:
+        - Testing whether a connection is still alive
+        - Verifying the server's ability to serve data
+
+        For more information on the underlying ping command see https://redis.io/commands/ping
+        """
+
+    @abstractmethod
+    async def aclose(self, close_connection_pool: bool | None = None) -> None:
+        """Closes Redis client connection.
+
+        Args:
+            close_connection_pool:
+                decides whether to close the connection pool used by this Redis client,
+                overriding Redis.auto_close_connection_pool.
+                By default, let Redis.auto_close_connection_pool decide
+                whether to close the connection pool.
+        """
+
+    @abstractmethod
+    async def publish(
+        self, channel: ChannelT, message: EncodableT, **kwargs: Any
+    ) -> ResponseT:
+        """Publish ``message`` on ``channel``.
+
+        Returns the number of subscribers the message was delivered to.
+
+        For more information, see https://redis.io/commands/publish
+        """
+
+    @abstractmethod
+    def pubsub(self, **kwargs: Any) -> PubSub:
+        """Return a Publish/Subscribe object.
+
+        With this object, you can
+        subscribe to channels and listen for messages that get published to
+        them.
+        """
+
+    @abstractmethod
+    async def set(  # noqa:PLR0913
+        self,
+        name: KeyT,
+        value: EncodableT,
+        ex: ExpiryT | None = None,
+        px: ExpiryT | None = None,
+        nx: bool = False,
+        xx: bool = False,
+        keepttl: bool = False,
+        get: bool = False,
+        exat: AbsExpiryT | None = None,
+        pxat: AbsExpiryT | None = None,
+        ifeq: bytes | str | None = None,
+        ifne: bytes | str | None = None,
+        ifdeq: str | None = None,  # hex digest of current value
+        ifdne: str | None = None,  # hex digest of current value
+    ) -> bool:
+        """Set the value at key ``name`` to ``value``.
+
+        Warning:
+        **Experimental** since 7.1.
+        The usage of the arguments ``ifeq``, ``ifne``, ``ifdeq``, and ``ifdne``
+        is experimental. The API or returned results when those parameters are used
+        may change based on feedback.
+
+        ``ex`` sets an expire flag on key ``name`` for ``ex`` seconds.
+
+        ``px`` sets an expire flag on key ``name`` for ``px`` milliseconds.
+
+        ``nx`` if set to True, set the value at key ``name`` to ``value`` only
+            if it does not exist.
+
+        ``xx`` if set to True, set the value at key ``name`` to ``value`` only
+            if it already exists.
+
+        ``keepttl`` if True, retain the time to live associated with the key.
+            (Available since Redis 6.0)
+
+        ``get`` if True, set the value at key ``name`` to ``value`` and return
+            the old value stored at key, or None if the key did not exist.
+            (Available since Redis 6.2)
+
+        ``exat`` sets an expire flag on key ``name`` for ``ex`` seconds,
+            specified in unix time.
+
+        ``pxat`` sets an expire flag on key ``name`` for ``ex`` milliseconds,
+            specified in unix time.
+
+        ``ifeq`` set the value at key ``name`` to ``value`` only if the current
+            value exactly matches the argument.
+            If key doesn't exist - it won't be created.
+            (Requires Redis 8.4 or greater)
+
+        ``ifne`` set the value at key ``name`` to ``value`` only if the current
+            value does not exactly match the argument.
+            If key doesn't exist - it will be created.
+            (Requires Redis 8.4 or greater)
+
+        ``ifdeq`` set the value at key ``name`` to ``value`` only if the current
+            value XXH3 hex digest exactly matches the argument.
+            If key doesn't exist - it won't be created.
+            (Requires Redis 8.4 or greater)
+
+        ``ifdne`` set the value at key ``name`` to ``value`` only if the current
+            value XXH3 hex digest does not exactly match the argument.
+            If key doesn't exist - it will be created.
+            (Requires Redis 8.4 or greater)
+
+        For more information, see https://redis.io/commands/set
+        """
+
+    @abstractmethod
+    async def get(self, name: KeyT) -> bytes | None:
+        """Return the value at key ``name``, or None if the key doesn't exist.
+
+        For more information, see https://redis.io/commands/get
+        """
+
+    @abstractmethod
+    async def delete(self, *names: KeyT) -> bool:
+        """Delete one or more keys specified by ``names``."""
+
+    @abstractmethod
+    async def hset(
+        self,
+        name: str,
+        key: str | None = None,
+        value: str | bytes | None = None,
+        mapping: dict[str, bytes] | None = None,
+        items: list[tuple[str, bytes]] | None = None,
+    ) -> int:
+        """Set ``key`` to ``value`` within hash ``name``.
+
+        ``mapping`` accepts a dict of key/value pairs that will be
+        added to hash ``name``.
+        ``items`` accepts a list of key/value pairs that will be
+        added to hash ``name``.
+        Returns the number of fields that were added.
+
+        For more information, see https://redis.io/commands/hset
+        """
+
+    @abstractmethod
+    async def hmget(self, name: str, keys: Iterable[KeyT]) -> list[bytes | None]:
+        """Returns a list of values ordered identically to ``keys``.
+
+        For more information, see https://redis.io/commands/hmget
+        """
+
+    @abstractmethod
+    async def hexpire(  # noqa:PLR0913
+        self,
+        name: KeyT,
+        seconds: ExpiryT,
+        *fields: str,
+        nx: bool = False,
+        xx: bool = False,
+        gt: bool = False,
+        lt: bool = False,
+    ) -> ResponseT:
+        """Sets or updates the expiration time for fields within a hash key, using relative time in seconds.
+
+        If a field already has an expiration time, the behavior of the update can be
+        controlled using the `nx`, `xx`, `gt`, and `lt` parameters.
+
+        The return value provides detailed information about the outcome for each field.
+
+        For more information, see https://redis.io/commands/hexpire
+
+        Args:
+            name: The name of the hash key.
+            seconds: Expiration time in seconds, relative. Can be an integer, or a
+                     Python `timedelta` object.
+            fields: List of fields within the hash to apply the expiration time to.
+            nx: Set expiry only when the field has no expiry.
+            xx: Set expiry only when the field has an existing expiry.
+            gt: Set expiry only when the new expiry is greater than the current one.
+            lt: Set expiry only when the new expiry is less than the current one.
+
+        Returns:
+            Returns a list which contains for each field in the request:
+                - `-2` if the field does not exist, or if the key does not exist.
+                - `0` if the specified NX | XX | GT | LT condition was not met.
+                - `1` if the expiration time was set or updated.
+                - `2` if the field was deleted because the specified expiration time is
+                  in the past.
+        """
+
+
 class RedisClient(AsyncDaemon):
     """A client abstraction layer for basic operations."""
 
+    _client: redis.Redis
+    client: AsyncRedis
+
     def __init__(self) -> None:
         """Instantiate a client class without initializing the Redis connection."""
-        self.client: redis.Redis
-
         super().__init__()
         retry = Retry(ExponentialBackoff(), CONFIG.redis.attempts)
-        self.client = redis.Redis(
+        self._client = redis.Redis(
             host=CONFIG.redis.host,
             port=CONFIG.redis.port,
             password=CONFIG.redis.password.get_secret_value()
@@ -44,6 +324,10 @@ class RedisClient(AsyncDaemon):
             ssl=CONFIG.redis.ssl_enabled,
             ssl_cert_reqs="none",
             retry=retry,
+        )
+        self.client = cast(
+            AsyncRedis,
+            cast(object, self._client),
         )
         self.subscriptions: dict[str, list[Callable[[str], Awaitable[None]]]] = {}
 
@@ -57,7 +341,7 @@ class RedisClient(AsyncDaemon):
         try:
             log.info("Checking redis connection...")
             await self.client.initialize()
-            await self.client.ping()  # pyright: ignore[reportUnknownMemberType] redis uses unknowns :/
+            await self.client.ping()
             log.success("Redis connection successful!")
         except RedisConnectionError as error:
             log.critical(
@@ -73,7 +357,7 @@ class RedisClient(AsyncDaemon):
 
     async def publish(self, channel: str, message: Any) -> None:
         """Publish a message to a given channel."""
-        await cast(Awaitable[Any], self.client.publish(f"{PREFIX}{channel}", message))  # pyright:ignore[reportUnknownMemberType] redis-py uses Unknown :(
+        await self.client.publish(f"{PREFIX}{channel}", message)
 
     async def subscribe(
         self, channel: str, callback: Callable[[str], Awaitable[None]]
@@ -106,15 +390,19 @@ class RedisClient(AsyncDaemon):
         return True
 
     async def subscriber(self, channel_key: str) -> None:
-        """A subscriber function that should be wrapped in an asyncio task."""
-        async with self.client.pubsub() as pubsub:  # pyright:ignore[reportUnknownMemberType] redis-py uses Unknown :(
-            await pubsub.subscribe(channel_key)  # pyright:ignore[reportUnknownMemberType] redis-py uses Unknown :(
+        """A subscriber function that should be wrapped in an asyncio task.
+
+        We wrap in an asyncio task rather than using redis-py's built in handling
+        specifically so that we can unsubscribe method-wise instead of channel-wise.
+        """
+        async with self.client.pubsub() as pubsub:
+            await pubsub.subscribe(channel_key)
             logger.trace(f"Subscribed to channel {channel_key}")
             while True:
                 # if len(self.subscriptions[channel_key]) == 0:
                 #     break
                 try:
-                    message = await pubsub.get_message(  # pyright:ignore[reportUnknownVariableType] redis-py uses Unknown :(
+                    message = await pubsub.get_message(
                         ignore_subscribe_messages=True, timeout=0.01
                     )
                     if message is not None:
@@ -123,13 +411,13 @@ class RedisClient(AsyncDaemon):
                         elif isinstance(message["data"], bytes):
                             data = message["data"].decode()
                         else:
-                            data = str(message["data"])  # pyright:ignore[reportUnknownArgumentType] redis-py uses Unknown :(
+                            data = str(message["data"])
 
                         for callback in self.subscriptions[channel_key]:
                             await callback(data)
 
                 except (ValueError, asyncio.CancelledError):
-                    await pubsub.unsubscribe(channel_key)  # pyright:ignore[reportUnknownMemberType] redis-py uses Unknown :(
+                    await pubsub.unsubscribe(channel_key)
                     break
 
     async def set(
@@ -138,7 +426,7 @@ class RedisClient(AsyncDaemon):
         value: bytes,
         *,
         compress: bool = False,
-        ttl: int = 0,
+        ttl: int = 0,  # Redis requires int
     ) -> None:
         """Generically set a key-value pair."""
         value_to_set = value
@@ -164,3 +452,94 @@ class RedisClient(AsyncDaemon):
         """Generically delete a key-value pair."""
         response = await self.client.delete(f"{PREFIX}{key}")
         return response > 0
+
+    @overload
+    async def hset(self, key: str, field: str, value: bytes) -> None: ...
+
+    @overload
+    async def hset(
+        self, key: str, field: str, value: bytes, *, compress: bool
+    ) -> None: ...
+
+    @overload
+    async def hset(self, key: str, field: str, value: bytes, *, ttl: int) -> None: ...
+
+    @overload
+    async def hset(
+        self, key: str, field: str, value: bytes, *, compress: bool, ttl: int
+    ) -> None: ...
+
+    @overload
+    async def hset(self, key: str, *, mapping: dict[str, bytes]) -> None: ...
+
+    @overload
+    async def hset(
+        self, key: str, *, mapping: dict[str, bytes], compress: bool
+    ) -> None: ...
+
+    @overload
+    async def hset(self, key: str, *, mapping: dict[str, bytes], ttl: int) -> None: ...
+
+    @overload
+    async def hset(
+        self,
+        key: str,
+        *,
+        mapping: dict[str, bytes],
+        compress: bool,
+        ttl: int,
+    ) -> None: ...
+
+    async def hset(  # noqa: PLR0913
+        self,
+        key: str,
+        field: str | None = None,
+        value: bytes | None = None,
+        *,
+        mapping: dict[str, bytes] | None = None,
+        compress: bool = False,
+        ttl: int = 0,
+    ) -> None:
+        """Generically set a mapping or field of a mapping."""
+        if value is not None:
+            value_to_set = value
+        elif mapping is not None:
+            value_to_set = mapping
+        else:
+            raise ValueError("Must provide either value or mapping.")
+        if compress:
+            value_to_set = (
+                ZSTD_COMPRESSOR.compress(value_to_set)
+                if isinstance(value_to_set, bytes)
+                else {k: ZSTD_COMPRESSOR.compress(v) for k, v in value_to_set.items()}
+            )
+
+        if isinstance(value_to_set, bytes):
+            if field is None:
+                raise ValueError("Must provide a field if setting a specific value.")
+            await self.client.hset(
+                f"{PREFIX}{key}",
+                field,
+                value_to_set,
+            )
+            if ttl > 0:
+                await self.client.hexpire(f"{PREFIX}{key}", ttl, field)
+        else:
+            await self.client.hset(
+                key,
+                mapping=value_to_set,
+            )
+            if ttl > 0:
+                await self._client.hexpire(f"{PREFIX}{key}", ttl, *value_to_set.keys())
+
+    async def hmget(
+        self, key: str, *field: str, compressed: bool = False
+    ) -> list[bytes | None]:
+        """Generically get a field of a mapping."""
+        values = await self.client.hmget(key, field)
+        if compressed:
+            return [
+                ZSTD_DECOMPRESSOR.decompress(val) if val is not None else val
+                for val in values
+            ]
+        return values

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -33,6 +33,7 @@ class RedisClient(AsyncDaemon):
         """Instantiate a client class without initializing the Redis connection."""
         self.client: redis.Redis
 
+        super().__init__()
         retry = Retry(ExponentialBackoff(), CONFIG.redis.attempts)
         self.client = redis.Redis(
             host=CONFIG.redis.host,

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -8,7 +8,7 @@ from retriever.data_tiers.tier_1.elasticsearch.meta import extract_metadata_entr
 from retriever.data_tiers.tier_1.elasticsearch.transpiler import ElasticsearchTranspiler
 from retriever.data_tiers.tier_1.elasticsearch.types import ESPayload, ESEdge
 from payload.trapi_qgraphs import DINGO_QGRAPH, VALID_REGEX_QGRAPHS, INVALID_REGEX_QGRAPHS, ID_BYPASS_PAYLOAD
-from retriever.utils.redis import RedisClient()
+from retriever.utils.redis import RedisClient
 from test_tier1_transpiler import _convert_triple, _convert_batch_triple
 
 

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -8,7 +8,7 @@ from retriever.data_tiers.tier_1.elasticsearch.meta import extract_metadata_entr
 from retriever.data_tiers.tier_1.elasticsearch.transpiler import ElasticsearchTranspiler
 from retriever.data_tiers.tier_1.elasticsearch.types import ESPayload, ESEdge
 from payload.trapi_qgraphs import DINGO_QGRAPH, VALID_REGEX_QGRAPHS, INVALID_REGEX_QGRAPHS, ID_BYPASS_PAYLOAD
-from retriever.utils.redis import REDIS_CLIENT
+from retriever.utils.redis import RedisClient()
 from test_tier1_transpiler import _convert_triple, _convert_batch_triple
 
 
@@ -233,7 +233,7 @@ async def test_ubergraph_info_retrieval():
     # --- MANUAL LOOP RESET ---
     # Since REDIS_CLIENT can retain stale connections/loop references from previous tests,
     # we need to force-reset the Redis connection pool to prevent 'Event loop is closed' errors.
-    REDIS_CLIENT.client.connection_pool.reset()
+    RedisClient().client.connection_pool.reset()
 
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -229,24 +229,25 @@ wheels = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989, upload-time = "2024-09-04T20:44:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802, upload-time = "2024-09-04T20:44:30.289Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
 ]
 
 [[package]]
@@ -1655,15 +1656,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjwt"
-version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
-]
-
-[[package]]
 name = "pymongo"
 version = "4.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1920,14 +1912,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "5.3.1"
+version = "7.2.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyjwt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/31/1476f206482dd9bc53fdbbe9f6fbd5e05d153f18e54667ce839df331f2e6/redis-7.2.1.tar.gz", hash = "sha256:6163c1a47ee2d9d01221d8456bc1c75ab953cbda18cfbc15e7140e9ba16ca3a5", size = 4906735, upload-time = "2026-02-25T20:05:18.171Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/98/1dd1a5c060916cf21d15e67b7d6a7078e26e2605d5c37cbc9f4f5454c478/redis-7.2.1-py3-none-any.whl", hash = "sha256:49e231fbc8df2001436ae5252b3f0f3dc930430239bfeb6da4c7ee92b16e5d33", size = 396057, upload-time = "2026-02-25T20:05:16.533Z" },
 ]
 
 [[package]]
@@ -2057,7 +2046,7 @@ requires-dist = [
     { name = "pymongo", specifier = ">=4.12.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "reasoner-pydantic", specifier = ">=6.0.0,<7" },
-    { name = "redis", specifier = ">=5.0.4,<6" },
+    { name = "redis", specifier = ">=7,<8" },
     { name = "ruamel-yaml", specifier = ">=0.18.14" },
     { name = "sentry-sdk", extras = ["fastapi", "httpx", "loguru"], specifier = ">=2.45.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.1,<0.33" },


### PR DESCRIPTION
- Use the new AsyncDaemon and BatchedAction subclasses in more of the use-cases they can address
- Finally make redis stop throwing so many type warnings
- Keep subclass mapping in redis rather than duplicating it in every worker (**significantly** smaller memory footprint), and batch calls to redis about it to avoid way too many simultaneous calls to redis.
- Batch Tier 1 calls within a given worker (doesn't do any special deduplication/etc., but decreases the overall number of calls going to Tier 1)