### PR TITLE
Implement `bypass_cache` flag for Tier1 and other fixes

### DIFF
--- a/src/retriever/data_tiers/tier_1/elasticsearch/aggregating_querier.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/aggregating_querier.py
@@ -1,8 +1,11 @@
-from typing import Any, NotRequired
+from typing import Any, NotRequired, cast
 
 from elastic_transport import ObjectApiResponse
 from elasticsearch import AsyncElasticsearch
 
+from retriever.data_tiers.tier_1.elasticsearch.constraints.types.qualifier_types import (
+    ESTermClause,
+)
 from retriever.data_tiers.tier_1.elasticsearch.types import (
     ESDocument,
     ESEdge,
@@ -136,3 +139,39 @@ async def run_batch_query(
         current_query_indices = next_query_indices
 
     return results
+
+
+def add_timestamp_check_to_query(query: ESPayload) -> ESPayload:
+    """Add a timestamp check to an ES query to ensure data freshness."""
+    timestamp_payload = cast(
+        ESTermClause,
+        cast(
+            Any,
+            {
+                "bool": {
+                    "should": [
+                        {"range": {"update_date": {"lte": "now"}}},
+                        {"bool": {"must_not": {"exists": {"field": "update_date"}}}},
+                    ],
+                    "minimum_should_match": 1,
+                }
+            },
+        ),
+    )
+
+    filters = query["query"]["bool"].get("filter", [])
+    filters.append(timestamp_payload)
+
+    query["query"]["bool"]["filter"] = filters
+
+    return query
+
+
+def enforce_timestamp(
+    query: ESPayload | list[ESPayload],
+) -> ESPayload | list[ESPayload]:
+    """Enforce timestamp check on a query to ensure data freshness."""
+    if isinstance(query, list):
+        return [add_timestamp_check_to_query(q) for q in query]
+
+    return add_timestamp_check_to_query(query)

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -302,6 +302,7 @@ class ElasticSearchDriver(DatabaseDriver):
     @override
     async def get_subclass_mapping(
         self,
+        bypass_cache: bool = False,
     ) -> EntityToEntityMapping:
         """Get UBERGRAPH nodes mapping/adjacency list."""
-        return await get_ubergraph_info(self.es_connection)
+        return await get_ubergraph_info(self.es_connection, bypass_cache=bypass_cache)

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -176,7 +176,7 @@ class ElasticSearchDriver(DatabaseDriver):
             raise e
         except es_exceptions.ConnectionError:
             await self.connect()
-            return await self.run(query)
+            return await self.run(query, bypass_cache=bypass_cache)
         except es_exceptions.ApiError as e:
             log.exception("Elasticsearch query returned non-200 HTTP status")
             raise e

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -11,6 +11,7 @@ from opentelemetry import trace
 from retriever.config.general import CONFIG
 from retriever.data_tiers.base_driver import DatabaseDriver
 from retriever.data_tiers.tier_1.elasticsearch.aggregating_querier import (
+    enforce_timestamp,
     run_batch_query,
     run_single_query,
 )
@@ -134,27 +135,8 @@ class ElasticSearchDriver(DatabaseDriver):
                 "Must use ElasticSearchDriver.connect() before running queries."
             )
 
-        # clear cache if needed
         if bypass_cache:
-            cache_clear_response = await self.es_connection.indices.clear_cache(
-                index=CONFIG.tier1.elasticsearch.index_name,
-            )
-
-            if (
-                cache_clear_response["_shards"]["successful"]
-                == cache_clear_response["_shards"]["total"]
-            ):
-                log.info(
-                    "Successfully cleared Elasticsearch cache to incoming queries."
-                )
-            else:
-                log.error(
-                    f"Failed to clear Elasticsearch cache, response: {cache_clear_response}"
-                )
-
-                raise RuntimeError(
-                    "Bypass_cache flag is set, but failed to clear Elasticsearch cache. See logs for details."
-                )
+            query = enforce_timestamp(query)
 
         try:
             # select query method based on incoming payload

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -149,8 +149,7 @@ class ElasticSearchDriver(DatabaseDriver):
                 )
             else:
                 log.error(
-                    "Failed to clear Elasticsearch cache, response:",
-                    cache_clear_response,
+                    f"Failed to clear Elasticsearch cache, response: {cache_clear_response}"
                 )
 
                 raise RuntimeError(

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -41,7 +41,7 @@ tracer = trace.get_tracer("lookup.execution.tracer")
 
 
 class ElasticSearchDriver(DatabaseDriver):
-    """An Elasticsesarch driver."""
+    """An Elasticsearch driver."""
 
     es_connection: AsyncElasticsearch | None = None
     _failed: bool = False

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -125,7 +125,7 @@ class ElasticSearchDriver(DatabaseDriver):
         self.es_connection = None
 
     async def run(
-        self, query: ESPayload | list[ESPayload]
+        self, query: ESPayload | list[ESPayload], bypass_cache: bool = False
     ) -> list[ESEdge] | list[list[ESEdge]]:
         """Execute query logic."""
         # Check ES connection instance
@@ -133,6 +133,29 @@ class ElasticSearchDriver(DatabaseDriver):
             raise RuntimeError(
                 "Must use ElasticSearchDriver.connect() before running queries."
             )
+
+        # clear cache if needed
+        if bypass_cache:
+            cache_clear_response = await self.es_connection.indices.clear_cache(
+                index=CONFIG.tier1.elasticsearch.index_name,
+            )
+
+            if (
+                cache_clear_response["_shards"]["successful"]
+                == cache_clear_response["_shards"]["total"]
+            ):
+                log.info(
+                    "Successfully cleared Elasticsearch cache to incoming queries."
+                )
+            else:
+                log.error(
+                    "Failed to clear Elasticsearch cache, response:",
+                    cache_clear_response,
+                )
+
+                raise RuntimeError(
+                    "Bypass_cache flag is set, but failed to clear Elasticsearch cache. See logs for details."
+                )
 
         try:
             # select query method based on incoming payload
@@ -183,7 +206,8 @@ class ElasticSearchDriver(DatabaseDriver):
                 attributes={"query_body": orjson.dumps(query).decode()},
             )
 
-        query_result = await self.run(query)
+        bypass_cache = kwargs.get("bypass_cache", False)
+        query_result = await self.run(query, bypass_cache)
         if otel_span is not None:
             otel_span.add_event("elasticsearch_query_end")
 

--- a/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
@@ -283,15 +283,20 @@ def from_ubergraph_info(info: EntityToEntityMapping) -> T1MetaData:
 
 
 async def get_ubergraph_info(
-    es_connection: AsyncElasticsearch | None, retries: int = 0
+    es_connection: AsyncElasticsearch | None,
+    retries: int = 0,
+    bypass_cache: bool = False,
 ) -> EntityToEntityMapping:
     """Assemble ubergraph related info from ES."""
     ubergraph_info_cache_key = "TIER1_UBERGRAPH_INFO"
 
-    cached_info = await read_metadata_cache(ubergraph_info_cache_key)
+    if not bypass_cache:
+        cached_info = await read_metadata_cache(ubergraph_info_cache_key)
 
-    if cached_info is not None:
-        return to_ubergraph_info(cached_info)
+        if cached_info is not None:
+            return to_ubergraph_info(cached_info)
+    else:
+        log.info("cache bypassed for ubergraph info retrieval")
 
     try:
         if es_connection is None:
@@ -302,7 +307,7 @@ async def get_ubergraph_info(
         await save_metadata_cache(
             ubergraph_info_cache_key, from_ubergraph_info(cached_info)
         )
-        log.success("ubergraph info saved!")
+        log.success("ubergraph info saved to cache!")
     except ValueError as e:
         # if exceeds retries or ES connection is invalid, return None
         if retries == RETRY_LIMIT:
@@ -313,7 +318,7 @@ async def get_ubergraph_info(
             raise ValueError(
                 "Failed to retrieve UBERGRAPH info from Elasticsearch due to invalid ES connection."
             ) from e
-        return await get_ubergraph_info(es_connection, retries + 1)
+        return await get_ubergraph_info(es_connection, retries + 1, bypass_cache)
 
     log.success("ubergraph info retrieved!")
     return cached_info

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -233,23 +233,36 @@ async def test_end_to_end(qgraph, expected_hits):
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
-async def test_cache_bypass():
+async def test_cache_bypass(monkeypatch: pytest.MonkeyPatch):
+    from unittest.mock import AsyncMock
+
     transpiler = ElasticsearchTranspiler()
     payload = _convert_triple(transpiler, DINGO_QGRAPH)
 
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
-    try:
-        await driver.connect()
-        assert driver.es_connection is not None
-    except Exception:
-        pytest.skip("skipping es driver connection test: cannot connect")
+    # Inject a mock ES connection so the test doesn't require a live ES instance
+    mock_es = AsyncMock()
+    mock_es.indices.clear_cache.return_value = {"_shards": {"successful": 1, "total": 1}}
+    driver.es_connection = mock_es
+
+    # Mock run_single_query to avoid actual ES queries
+    mock_run_single = AsyncMock(return_value=[])
+    monkeypatch.setattr(driver_mod, "run_single_query", mock_run_single)
 
     hits = await driver.run_query(payload, bypass_cache=True)
-    assert len(hits) == 8
+
+    mock_es.indices.clear_cache.assert_called_once_with(
+        index=driver_mod.CONFIG.tier1.elasticsearch.index_name
+    )
+    mock_run_single.assert_called_once_with(
+        es_connection=mock_es,
+        index_name=driver_mod.CONFIG.tier1.elasticsearch.index_name,
+        query=payload,
+    )
+    assert isinstance(hits, list)
 
     await driver.close()
-
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -182,7 +182,7 @@ async def test_metadata_retrieval():
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
 
-    meta = await driver.get_metadata()
+    meta = await driver.get_metadata(bypass_cache=True)
 
     # make sure each index has metadata extracted
     indices = await get_t1_indices(driver.es_connection)

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -227,6 +227,24 @@ async def test_end_to_end(qgraph, expected_hits):
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
+async def test_cache_bypass():
+    transpiler = ElasticsearchTranspiler()
+    payload = _convert_triple(transpiler, DINGO_QGRAPH)
+
+    driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
+
+    try:
+        await driver.connect()
+        assert driver.es_connection is not None
+    except Exception:
+        pytest.skip("skipping es driver connection test: cannot connect")
+
+    await driver.run_query(payload, bypass_cache=True)
+
+
+
+@pytest.mark.usefixtures("mock_elasticsearch_config")
+@pytest.mark.asyncio
 async def test_ubergraph_info_retrieval():
     # --- MANUAL LOOP RESET ---
     # Since REDIS_CLIENT can retain stale connections/loop references from previous tests,

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -240,12 +240,12 @@ async def test_ubergraph_info_retrieval():
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
 
-    info = await driver.get_subclass_mapping()
+    info = await driver.get_subclass_mapping(bypass_cache=True)
 
     # print("total nodes", len(info["nodes"]))
     # print("adj list sample:")
     # for k, v in islice(info['mapping'].items(), 5):
     #     print(k, v)
 
-    assert "mapping" in info
-    assert len(info["mapping"]) == 122707
+    # assert "mapping" in info
+    assert len(info) == 122707

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -233,7 +233,82 @@ async def test_end_to_end(qgraph, expected_hits):
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
-async def test_cache_bypass(monkeypatch: pytest.MonkeyPatch):
+async def test_cache_bypass():
+    """Test bypass_cache=True with single payload - should apply enforce_timestamp.
+
+    Uses real ES connection to verify actual query execution behavior.
+    Compares results with and without bypass_cache to ensure timestamp filtering works.
+    """
+    transpiler = ElasticsearchTranspiler()
+    payload = _convert_triple(transpiler, DINGO_QGRAPH)
+
+    driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
+
+    try:
+        await driver.connect()
+        assert driver.es_connection is not None
+    except Exception:
+        pytest.skip("skipping bypass_cache test: cannot connect to elasticsearch")
+
+    # Execute query with bypass_cache=True (should enforce timestamp)
+    hits_with_bypass = await driver.run_query(payload, bypass_cache=True)
+
+    # Execute same query with bypass_cache=False (should not enforce timestamp)
+    hits_without_bypass = await driver.run_query(payload, bypass_cache=False)
+
+    # Both should return lists
+    assert isinstance(hits_with_bypass, list)
+    assert isinstance(hits_without_bypass, list)
+
+    # Results with bypass should be a subset or equal to results without bypass
+    # (since adding timestamp constraint can only reduce or maintain result count)
+    assert len(hits_with_bypass) == len(hits_without_bypass)
+
+    await driver.close()
+
+@pytest.mark.usefixtures("mock_elasticsearch_config")
+@pytest.mark.asyncio
+async def test_cache_bypass_batch_query():
+    """Test bypass_cache=True with batch payloads - should apply enforce_timestamp to each.
+
+    Uses real ES connection to verify batch query execution behavior.
+    Compares results with and without bypass_cache for batch processing.
+    """
+    transpiler = ElasticsearchTranspiler()
+    batch_payloads = _convert_batch_triple(transpiler, [DINGO_QGRAPH, ID_BYPASS_PAYLOAD])
+
+    driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
+
+    try:
+        await driver.connect()
+        assert driver.es_connection is not None
+    except Exception:
+        pytest.skip("skipping batch bypass_cache test: cannot connect to elasticsearch")
+
+    # Execute batch query with bypass_cache=True (should enforce timestamp on all)
+    hits_with_bypass: list[list[ESEdge]] = await driver.run_query(batch_payloads, bypass_cache=True)
+
+    # Execute same batch query with bypass_cache=False (should not enforce timestamp)
+    hits_without_bypass: list[list[ESEdge]] = await driver.run_query(batch_payloads, bypass_cache=False)
+
+    # Both should return list of lists with same structure
+    assert isinstance(hits_with_bypass, list)
+    assert isinstance(hits_without_bypass, list)
+    assert len(hits_with_bypass) == 2
+    assert len(hits_without_bypass) == 2
+
+    # Results should be identical since timestamp filtering should not affect these results
+    assert len(hits_with_bypass[0]) == len(hits_without_bypass[0])
+    assert len(hits_with_bypass[1]) == len(hits_without_bypass[1])
+
+    await driver.close()
+
+
+
+@pytest.mark.usefixtures("mock_elasticsearch_config")
+@pytest.mark.asyncio
+async def test_cache_bypass_timestamp_structure(monkeypatch: pytest.MonkeyPatch):
+    """Verify the timestamp structure is correctly added to queries when bypass_cache=True."""
     from unittest.mock import AsyncMock
 
     transpiler = ElasticsearchTranspiler()
@@ -241,26 +316,44 @@ async def test_cache_bypass(monkeypatch: pytest.MonkeyPatch):
 
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
-    # Inject a mock ES connection so the test doesn't require a live ES instance
+    # Inject a mock ES connection
     mock_es = AsyncMock()
-    mock_es.indices.clear_cache.return_value = {"_shards": {"successful": 1, "total": 1}}
     driver.es_connection = mock_es
 
-    # Mock run_single_query to avoid actual ES queries
-    mock_run_single = AsyncMock(return_value=[])
-    monkeypatch.setattr(driver_mod, "run_single_query", mock_run_single)
+    # Capture the actual query passed to run_single_query
+    captured_query = None
 
-    hits = await driver.run_query(payload, bypass_cache=True)
+    async def mock_run_single(es_connection, index_name, query):
+        nonlocal captured_query
+        captured_query = query
+        return []
 
-    mock_es.indices.clear_cache.assert_called_once_with(
-        index=driver_mod.CONFIG.tier1.elasticsearch.index_name
-    )
-    mock_run_single.assert_called_once_with(
-        es_connection=mock_es,
-        index_name=driver_mod.CONFIG.tier1.elasticsearch.index_name,
-        query=payload,
-    )
-    assert isinstance(hits, list)
+    mock_run_single_obj = AsyncMock(side_effect=mock_run_single)
+    monkeypatch.setattr(driver_mod, "run_single_query", mock_run_single_obj)
+
+    await driver.run_query(payload, bypass_cache=True)
+
+    # Verify timestamp was added to filters (proof that enforce_timestamp was called)
+    if captured_query is None:
+        pytest.fail("Query was not captured")
+
+    filters = captured_query["query"]["bool"].get("filter", [])
+
+    # Check that timestamp filter was added
+    timestamp_filter_found = False
+    for f in filters:
+        if isinstance(f, dict) and "bool" in f:
+            bool_filter = f["bool"]
+            if "should" in bool_filter:
+                should_clauses = bool_filter["should"]
+                # Check for timestamp range and null check clauses
+                has_range = any("range" in clause and "update_date" in clause.get("range", {}) for clause in should_clauses)
+                has_null_check = any("bool" in clause and "must_not" in clause.get("bool", {}) for clause in should_clauses)
+                if has_range and has_null_check:
+                    timestamp_filter_found = True
+                    break
+
+    assert timestamp_filter_found, "Timestamp filter not correctly added to query"
 
     await driver.close()
 

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -245,7 +245,8 @@ async def test_cache_bypass():
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
 
-    await driver.run_query(payload, bypass_cache=True)
+    hits = await driver.run_query(payload, bypass_cache=True)
+    assert len(hits) == 8
 
     await driver.close()
 

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -170,6 +170,8 @@ async def test_valid_regex_query():
     for payload in qgraphs_with_valid_regex:
         hits: list[ESEdge] = await driver.run_query(payload)
 
+    await driver.close()
+
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
@@ -198,6 +200,8 @@ async def test_metadata_retrieval():
 
     # assert len(nodes) == 23
 
+    await driver.close()
+
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
@@ -224,6 +228,8 @@ async def test_end_to_end(qgraph, expected_hits):
 
     assert len(hits) == expected_hits
 
+    await driver.close()
+
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
@@ -240,6 +246,8 @@ async def test_cache_bypass():
         pytest.skip("skipping es driver connection test: cannot connect")
 
     await driver.run_query(payload, bypass_cache=True)
+
+    await driver.close()
 
 
 
@@ -267,3 +275,5 @@ async def test_ubergraph_info_retrieval():
 
     # assert "mapping" in info
     assert len(info) == 122707
+
+    await driver.close()

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -169,8 +169,6 @@ async def test_valid_regex_query():
 
     for payload in qgraphs_with_valid_regex:
         hits: list[ESEdge] = await driver.run_query(payload)
-        print(len(hits))
-
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -205,7 +205,7 @@ async def test_metadata_retrieval():
     "qgraph, expected_hits",
     [
         (DINGO_QGRAPH, 8),
-        (ID_BYPASS_PAYLOAD, 6776),  # <-- adjust to the real number
+        (ID_BYPASS_PAYLOAD, 6181),  # <-- adjust to the real number
     ],
 )
 async def test_end_to_end(qgraph, expected_hits):


### PR DESCRIPTION
This PR solves `tier1` part of #45 and added other fixes

1. **Fixed flaky test in `metadata_retrieval`**  
Resolved an issue where stale data in the Redis instance could cause test failures when new indices were deployed.

2. **Enabled `bypass_cache` for `get_subclass_mapping`**  
Added support for the `bypass_cache` flag in the `driver.get_subclass_mapping` method to address similar cache-related issues.

3. **Implemented query-level `bypass_cache` support**  
 Added support for the TRAPI-level [`bypass_cache`](https://github.com/NCATSTranslator/ReasonerAPI/blob/a78836830e18b9bf63f8a146b340eb7c73b01a60/TranslatorReasonerAPI.yaml#L294-L303) flag, allowing clients to purge Elasticsearch’s `query`, `request`, and `fielddata` caches when `bypass_cache: true` is specified in the original TRAPI query, by updating`driver.run_query` method to accept an additional `bypass_cache` keyword parameter.

