### PR TITLE
Add qualifier expansion for `tier1`

### DIFF
--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -850,9 +850,7 @@ class DgraphTranspiler(Tier0Transpiler):
                 field = self._v(qtype)
 
                 # Expand qualifier values to include descendants
-                expanded_values = biolink.get_descendant_values(
-                    qtype, qval
-                )
+                expanded_values = biolink.get_descendant_values(qtype, qval)
                 if len(expanded_values) > 1:
                     and_filters.append(
                         self._create_in_filter(field, sorted(expanded_values))

--- a/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/transpiler.py
@@ -843,12 +843,23 @@ class DgraphTranspiler(Tier0Transpiler):
                 qval = (
                     biolink.rmprefix(q["qualifier_value"])
                     if "qualified_predicate" in qtype
-                    else q["qualifier_value"]
+                    else biolink.rmprefix(q["qualifier_value"])
                 )
                 if not qtype or qval == "":
                     continue
                 field = self._v(qtype)
-                and_filters.append(self._get_operator_filter(field, "==", qval))
+
+                # Expand qualifier values to include descendants
+                expanded_values = biolink.get_descendant_values(
+                    qtype, qval
+                )
+                if len(expanded_values) > 1:
+                    and_filters.append(
+                        self._create_in_filter(field, sorted(expanded_values))
+                    )
+                else:
+                    and_filters.append(self._get_operator_filter(field, "==", qval))
+
             if and_filters:
                 # AND items within the set; wrap in parentheses if more than one
                 set_filters.append(

--- a/src/retriever/data_tiers/tier_1/elasticsearch/constraints/qualifiers/qualifier.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/constraints/qualifiers/qualifier.py
@@ -1,10 +1,12 @@
 from retriever.data_tiers.tier_1.elasticsearch.constraints.types.qualifier_types import (
+    ESBoolQueryForExpandedQualifiers,
     ESConstraintsChainedQuery,
-    ESQueryForSingleQualifierConstraint,
+    ESEquivalentQualifierPairCollection,
     ESTermClause,
 )
 from retriever.types.trapi import QualifierConstraintDict
 from retriever.utils import biolink
+from retriever.utils.biolink import get_descendant_values, get_descendants
 
 ES_QUAL_FIELD = "qualifiers"
 ES_QUAL_NAME = "type_id"
@@ -12,38 +14,73 @@ ES_QUAL_VAL = "value"
 
 
 def process_single_entry_result(
-    results: list[ESTermClause],
-) -> ESTermClause | ESQueryForSingleQualifierConstraint:
+    results: list[ESEquivalentQualifierPairCollection],
+) -> ESEquivalentQualifierPairCollection | ESBoolQueryForExpandedQualifiers:
     """Wrap chained processed qualifier query."""
     if len(results) == 1:
         return results[0]
 
-    wrapped: ESQueryForSingleQualifierConstraint = {"bool": {"must": results}}
+    wrapped: ESBoolQueryForExpandedQualifiers = {"bool": {"must": results}}
 
     return wrapped
 
 
+def expand_qualifier_pairs(
+    pairs: set[tuple[str, str]],
+) -> list[ESEquivalentQualifierPairCollection]:
+    """Expand qualifier pairs to all possible descendant pairs."""
+    must: list[ESEquivalentQualifierPairCollection] = []
+
+    for q_type, q_value in pairs:
+        # unique pairs of valid qualifier types and values
+        equivalent_pairs: set[tuple[str, str]] = set()
+
+        # get qualifier type descendants
+        all_q_type_desc: list[str] = get_descendants(q_type)
+
+        for q_type_desc in all_q_type_desc:
+            # for each qualifier type descendant, get value descendants
+            all_q_value_desc: set[str] = get_descendant_values(q_type_desc, q_value)
+            for q_value_desc in all_q_value_desc:
+                equivalent_pairs.add(
+                    (biolink.rmprefix(q_type_desc), biolink.rmprefix(q_value_desc))
+                )
+
+        should_terms: list[ESTermClause] = [
+            {"term": {_type: _value}} for _type, _value in equivalent_pairs
+        ]
+
+        must.append(
+            {
+                "bool": {
+                    "should": should_terms,
+                    "minimum_should_match": 1,
+                }
+            }
+        )
+
+    return must
+
+
 def handle_single_constraint(
     constraint: QualifierConstraintDict,
-) -> list[ESTermClause] | None:
-    """Generate query terms based on single constraint. One constraint could contain multiple qualifiers set."""
+) -> list[ESEquivalentQualifierPairCollection] | None:
+    """Generate query terms based on single constraint. One constraint could contain multiple entries in its qualifiers set."""
     qualifiers = constraint["qualifier_set"]
 
     # empty qualifier set
     if not qualifiers:
         return None
 
-    must: list[ESTermClause] = []
-
-    # todo uniqueness check for specified type-value pair
+    pairs: set[tuple[str, str]] = set()
 
     for qualifier in qualifiers:
-        qual_type = biolink.rmprefix(qualifier["qualifier_type_id"])
-        qual_value = biolink.rmprefix(qualifier["qualifier_value"])
+        qual_type = qualifier["qualifier_type_id"]
+        qual_value = qualifier["qualifier_value"]
+        pairs.add((qual_type, qual_value))
 
-        must.append(
-            {"term": {qual_type: qual_value}},
-        )
+    # within a qualifier set, it's AND relationship.
+    must = expand_qualifier_pairs(pairs)
 
     return must
 
@@ -52,8 +89,8 @@ def process_qualifier_constraints(
     constraints: list[QualifierConstraintDict] | None,
 ) -> (
     ESConstraintsChainedQuery
-    | ESQueryForSingleQualifierConstraint
-    | ESTermClause
+    | ESEquivalentQualifierPairCollection
+    | ESBoolQueryForExpandedQualifiers
     | None
 ):
     """Generate terms for a list of qualifier constraints.
@@ -88,14 +125,17 @@ def process_qualifier_constraints(
     # if not isinstance(constraints, list):
     #     raise TypeError("qualifier constraints must be a list")
 
-    constraint_queries: list[list[ESTermClause]] = list(
+    constraint_queries: list[list[ESEquivalentQualifierPairCollection]] = list(
         filter(None, map(handle_single_constraint, constraints))
     )
 
     if not constraint_queries:
         return None
 
-    should_array = list(map(process_single_entry_result, constraint_queries))
+    # within qualifier_constraints, it's OR relationship. We will wrap each entry as a separate query and put them in `should`.
+    should_array: list[
+        ESEquivalentQualifierPairCollection | ESBoolQueryForExpandedQualifiers
+    ] = list(map(process_single_entry_result, constraint_queries))
 
     if len(should_array) == 1:
         # no need to use `should`

--- a/src/retriever/data_tiers/tier_1/elasticsearch/constraints/types/qualifier_types.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/constraints/types/qualifier_types.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 
 class ESTermClause(TypedDict):
@@ -22,7 +22,32 @@ class ESQueryForSingleQualifierConstraint(TypedDict):
 ESQualifierConstraintQuery = ESQueryForSingleQualifierConstraint | ESTermClause
 
 
+class ESEquivalentQualifierPair(TypedDict):
+    """Wrapper for equivalent qualifier constraint pairs."""
+
+    should: list[ESTermClause]
+    minimum_should_match: NotRequired[int]
+
+
+class ESEquivalentQualifierPairCollection(TypedDict):
+    """Wrapper for equivalent qualifier constraint pairs."""
+
+    bool: ESEquivalentQualifierPair
+
+
+class ESMustQueryForExpandedQualifiers(TypedDict):
+    """Must query combining nested queries for qualifiers for one constraint with proper expansion."""
+
+    must: list[ESEquivalentQualifierPairCollection]
+
+
+class ESBoolQueryForExpandedQualifiers(TypedDict):
+    """Bool wrapper for ESMustQueryForExpandedQualifiers."""
+
+    bool: ESMustQueryForExpandedQualifiers
+
+
 class ESConstraintsChainedQuery(TypedDict):
     """Query entry specifying an OR relationship between constraints."""
 
-    should: list[ESQualifierConstraintQuery]
+    should: list[ESEquivalentQualifierPairCollection | ESBoolQueryForExpandedQualifiers]

--- a/src/retriever/data_tiers/tier_1/elasticsearch/transpiler.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/transpiler.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, override
+from typing import Any, Literal, cast, override
 
 import orjson
 
@@ -13,6 +13,9 @@ from retriever.data_tiers.tier_1.elasticsearch.constraints.qualifiers.qualifier 
 from retriever.data_tiers.tier_1.elasticsearch.constraints.types.attribute_types import (
     AttributeFilterQuery,
     AttributeOrigin,
+)
+from retriever.data_tiers.tier_1.elasticsearch.constraints.types.qualifier_types import (
+    ESEquivalentQualifierPairCollection,
 )
 from retriever.data_tiers.tier_1.elasticsearch.types import (
     ESBooleanQuery,
@@ -220,14 +223,15 @@ class ElasticsearchTranspiler(Tier1Transpiler):
                 )
 
             # otherwise we have either
-            # 0) `ESQueryForSingleQualifierConstraint`, a single constraint with multiple qualifiers, or
-            # 1) `ESTermClause`, a single qualifier in a single constraint
-            # in both cases, inner payload of one or more qualifier terms can be added
-            # as a single or a list of `ESQueryForOneQualifierEntry` to `filter` field
-            elif "bool" in qualifier_terms:
+            # 0) `ESEquivalentQualifierPairCollection`, a single constraint of a should array, or
+            # 1) `ESBoolQueryForExpandedQualifiers`, a single constraint of a must array
+            # in both cases, there's a bool field that can be parsed/added to existing filter query
+            elif "must" in qualifier_terms["bool"]:
                 query_kwargs["filter"].extend(qualifier_terms["bool"]["must"])
-            elif "term" in qualifier_terms:
-                query_kwargs["filter"].append(qualifier_terms)
+            elif "should" in qualifier_terms["bool"]:
+                query_kwargs["filter"].append(
+                    cast(ESEquivalentQualifierPairCollection, qualifier_terms)
+                )
 
         # generate constraint terms for edges and associated nodes
         # currently, this is DISABLED by default to favor post-processing

--- a/src/retriever/data_tiers/tier_1/elasticsearch/types.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/types.py
@@ -7,7 +7,8 @@ from retriever.data_tiers.tier_1.elasticsearch.constraints.types.attribute_types
     AttributeFilterQuery,
 )
 from retriever.data_tiers.tier_1.elasticsearch.constraints.types.qualifier_types import (
-    ESQueryForSingleQualifierConstraint,
+    ESBoolQueryForExpandedQualifiers,
+    ESEquivalentQualifierPairCollection,
     ESTermClause,
 )
 from retriever.data_tiers.utils import (
@@ -29,8 +30,10 @@ class ESFilterClause(TypedDict):
 class ESBooleanQuery(TypedDict):
     """An Elasticsearch boolean query."""
 
-    filter: list[ESFilterClause | ESTermClause]
-    should: NotRequired[list[ESQueryForSingleQualifierConstraint | ESTermClause]]
+    filter: list[ESFilterClause | ESTermClause | ESEquivalentQualifierPairCollection]
+    should: NotRequired[
+        list[ESEquivalentQualifierPairCollection | ESBoolQueryForExpandedQualifiers]
+    ]
     minimum_should_match: NotRequired[int]
     must: NotRequired[list[AttributeFilterQuery]]
     must_not: NotRequired[list[AttributeFilterQuery]]

--- a/src/retriever/utils/biolink.py
+++ b/src/retriever/utils/biolink.py
@@ -79,7 +79,7 @@ def get_descendant_values(qualifier_type: BiolinkQualifier, value: str) -> set[s
 
     permissible_values: set[str] = {value}
     for enum_name, enum_def in biolink.view.all_enums().items():
-        if value in (enum_def.permissible_values or {}):
+        if value in cast(dict[str, object], enum_def.permissible_values or {}):
             permissible_values.update(
                 biolink.get_permissible_value_descendants(value, enum_name)
             )

--- a/src/retriever/utils/biolink.py
+++ b/src/retriever/utils/biolink.py
@@ -74,17 +74,14 @@ def get_descendants[T: str](value: T) -> list[T]:
 
 def get_descendant_values(qualifier_type: BiolinkQualifier, value: str) -> set[str]:
     """Given a biolink qualifier and an associated value, return applicable descendant values."""
-    ranges = biolink.get_slot_range(qualifier_type)  # pyright:ignore[reportUnknownMemberType]
-
-    # Handle qualified_predicate
     if "predicate" in qualifier_type:
         return {rmprefix(predicate) for predicate in expand(value)}
 
     permissible_values: set[str] = {value}
-    for value_type in ranges:
-        if biolink.is_enum(value_type):
+    for enum_name, enum_def in biolink.view.all_enums().items():
+        if value in (enum_def.permissible_values or {}):
             permissible_values.update(
-                biolink.get_permissible_value_descendants(value, value_type)
+                biolink.get_permissible_value_descendants(value, enum_name)
             )
 
     return permissible_values

--- a/src/retriever/utils/trapi.py
+++ b/src/retriever/utils/trapi.py
@@ -144,7 +144,7 @@ def append_aggregator_source(
     upstreams = set(
         itertools.chain(
             *[
-                source.get(Infores("upstream_resource_ids"), [])
+                (source.get("upstream_resource_ids", []) or [])
                 for source in edge["sources"]
             ]
         )

--- a/tests/data_tiers/tier_0/dgraph/test_driver.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver.py
@@ -1031,6 +1031,127 @@ async def test_simple_one_query_live_grpc() -> None:
 @pytest.mark.live
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("mock_dgraph_config")
+async def test_qualifier_constraints_with_descendant_expansion_live_grpc() -> None:
+    """
+    Integration test: Verify qualifier constraints expand to include descendant values.
+    """
+
+    qgraph_query: QueryGraphDict = qg(
+        {
+            "nodes": {
+                "ON": {
+                    "ids": ["HGNC:3870"],
+                    "categories": ["biolink:Gene"],
+                },
+                "SN": {
+                    "ids": ["CHEBI:59173"],
+                    "categories": ["biolink:ChemicalEntity"],
+                },
+            },
+            "edges": {
+                "e0": {
+                    "subject": "SN",
+                    "object": "ON",
+                    "predicates": ["biolink:affects"],
+                    "qualifier_constraints": [
+                        {
+                            "qualifier_set": [
+                                {
+                                    "qualifier_type_id": "biolink:qualified_predicate",
+                                    "qualifier_value": "biolink:causes",
+                                },
+                                {
+                                    "qualifier_type_id": "biolink:object_aspect_qualifier",
+                                    "qualifier_value": "biolink:activity",
+                                },
+                                {
+                                    "qualifier_type_id": "biolink:object_direction_qualifier",
+                                    "qualifier_value": "biolink:decreased",
+                                },
+                            ]
+                        }
+                    ],
+                }
+            },
+        }
+    )
+
+    # object_direction_qualifier "decreased" expands to ["decreased", "downregulated"]
+    dgraph_query_match: str = dedent("""
+    {
+        q0_node_n0(func: eq(vN_id, "HGNC:3870")) @cascade(vN_id, ~vN_object) {
+            expand(vN_Node)
+            in_edges_e0: ~vN_object @filter(eq(vN_predicate_ancestors, "affects") AND (eq(vN_qualified_predicate, "causes") AND eq(vN_object_aspect_qualifier, "activity") AND eq(vN_object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(vN_predicate, vN_subject) {
+                expand(vN_Edge) { vN_sources expand(vN_Source) }
+                node_n1: vN_subject @filter(eq(vN_id, "CHEBI:59173")) @cascade(vN_id) {
+                    expand(vN_Node)
+                }
+            }
+        }
+    }
+    """).strip()
+
+    driver = new_grpc_driver()
+    await driver.connect()
+
+    # Get the active Dgraph schema version
+    dgraph_schema_version = await driver.get_active_version()
+
+    # Initialize the transpiler with the detected version
+    transpiler: _TestDgraphTranspiler = _TestDgraphTranspiler(
+        version=dgraph_schema_version,
+        enable_symmetric_edges=False,
+        enable_subclass_edges=False,
+    )
+    assert transpiler.version == "vN"
+    assert transpiler.prefix == "vN_"
+
+    # Use the transpiler to generate the Dgraph query
+    dgraph_query: str = transpiler.convert_multihop_public(qgraph_query)
+    assert_query_equals(dgraph_query, dgraph_query_match)
+
+    # Run the query against the live Dgraph instance
+    result: dg_models.DgraphResponse = await driver.run_query(
+        dgraph_query, transpiler=transpiler
+    )
+    assert isinstance(result, dg_models.DgraphResponse)
+
+    # Verify data is returned
+    assert result.data, "No data returned from Dgraph for qualifier constraints query"
+    assert "q0" in result.data
+    assert len(result.data["q0"]) >= 1
+
+    # Root node should be the object (HGNC:3870)
+    root_node = result.data["q0"][0]
+    assert root_node.binding == "ON"
+    assert root_node.id == "HGNC:3870"
+    assert len(root_node.edges) >= 1
+
+    # Validate edge qualifiers
+    for edge in root_node.edges:
+        assert edge.binding == "e0"
+        assert edge.direction == "in"
+        assert edge.predicate == "affects"
+
+        # Qualifier values should include descendants
+        qualifiers = edge.qualifiers
+        assert qualifiers.get("qualified_predicate") == "causes"
+        assert qualifiers.get("object_direction_qualifier") in (
+            "decreased",
+            "downregulated",
+        )
+
+    # Validate connected node
+    connected_node = root_node.edges[0].node
+    assert connected_node.binding == "SN"
+    assert connected_node.id == "CHEBI:59173"
+
+    await driver.close()
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("mock_dgraph_config")
 async def test_simple_reverse_query_live_grpc() -> None:
     """
     Integration test: Run the 'simple-one' query against a live Dgraph HTTP instance.

--- a/tests/data_tiers/tier_0/dgraph/test_driver.py
+++ b/tests/data_tiers/tier_0/dgraph/test_driver.py
@@ -1062,7 +1062,7 @@ async def test_qualifier_constraints_with_descendant_expansion_live_grpc() -> No
                                 },
                                 {
                                     "qualifier_type_id": "biolink:object_aspect_qualifier",
-                                    "qualifier_value": "biolink:activity",
+                                    "qualifier_value": "biolink:activity_or_abundance",
                                 },
                                 {
                                     "qualifier_type_id": "biolink:object_direction_qualifier",
@@ -1081,7 +1081,7 @@ async def test_qualifier_constraints_with_descendant_expansion_live_grpc() -> No
     {
         q0_node_n0(func: eq(vN_id, "HGNC:3870")) @cascade(vN_id, ~vN_object) {
             expand(vN_Node)
-            in_edges_e0: ~vN_object @filter(eq(vN_predicate_ancestors, "affects") AND (eq(vN_qualified_predicate, "causes") AND eq(vN_object_aspect_qualifier, "activity") AND eq(vN_object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(vN_predicate, vN_subject) {
+            in_edges_e0: ~vN_object @filter(eq(vN_predicate_ancestors, "affects") AND (eq(vN_qualified_predicate, "causes") AND eq(vN_object_aspect_qualifier, ["abundance", "activity", "activity_or_abundance", "expression", "synthesis"]) AND eq(vN_object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(vN_predicate, vN_subject) {
                 expand(vN_Edge) { vN_sources expand(vN_Source) }
                 node_n1: vN_subject @filter(eq(vN_id, "CHEBI:59173")) @cascade(vN_id) {
                     expand(vN_Node)
@@ -1136,6 +1136,7 @@ async def test_qualifier_constraints_with_descendant_expansion_live_grpc() -> No
         # Qualifier values should include descendants
         qualifiers = edge.qualifiers
         assert qualifiers.get("qualified_predicate") == "causes"
+        assert qualifiers.get("object_aspect_qualifier") == "activity"
         assert qualifiers.get("object_direction_qualifier") in (
             "decreased",
             "downregulated",

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -764,6 +764,46 @@ QUALIFIER_SETS_AND_QGRAPH: QueryGraphDict = qg(
     }
 )
 
+QUALIFIER_DESCENDANT_EXPANSION_QGRAPH: QueryGraphDict = qg(
+    {
+        "nodes": {
+            "ON": {
+                "ids": ["HGNC:3870"],
+                "categories": ["biolink:Gene"],
+            },
+            "SN": {
+                "ids": ["CHEBI:59173"],
+                "categories": ["biolink:ChemicalEntity"],
+            },
+        },
+        "edges": {
+            "e0": {
+                "subject": "SN",
+                "object": "ON",
+                "predicates": ["biolink:affects"],
+                "qualifier_constraints": [
+                    {
+                        "qualifier_set": [
+                            {
+                                "qualifier_type_id": "biolink:qualified_predicate",
+                                "qualifier_value": "biolink:causes",
+                            },
+                            {
+                                "qualifier_type_id": "biolink:object_aspect_qualifier",
+                                "qualifier_value": "activity",
+                            },
+                            {
+                                "qualifier_type_id": "biolink:object_direction_qualifier",
+                                "qualifier_value": "decreased",
+                            },
+                        ]
+                    }
+                ],
+            }
+        },
+    }
+)
+
 
 # -----------------------
 # Expected queries
@@ -1342,6 +1382,21 @@ EXP_QUALIFIER_SETS_AND = dedent("""
 }
 """).strip()
 
+EXP_QUALIFIER_DESCENDANT_EXPANSION = dedent("""
+{
+  q0_node_n0(func: eq(id, "HGNC:3870")) @cascade(id, ~object) {
+    expand(Node)
+    in_edges_e0: ~object @filter(eq(predicate_ancestors, "affects") AND
+      (eq(qualified_predicate, "causes") AND eq(object_aspect_qualifier, "activity") AND eq(object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(predicate, subject) {
+      expand(Edge) { sources expand(Source) }
+      node_n1: subject @filter(eq(id, "CHEBI:59173")) @cascade(id) {
+        expand(Node)
+      }
+    }
+  }
+}
+""").strip()
+
 
 # -----------------------
 # Case pairs
@@ -1384,6 +1439,10 @@ CASES: list[QueryCase] = [
     ),
     QueryCase("qualifier-set", QUALIFIER_SET_QGRAPH, EXP_QUALIFIER_SET),
     QueryCase("qualifier-sets-and", QUALIFIER_SETS_AND_QGRAPH, EXP_QUALIFIER_SETS_AND),
+    QueryCase(
+        "qualifier-descendant-expansion",
+        QUALIFIER_DESCENDANT_EXPANSION_QGRAPH, EXP_QUALIFIER_DESCENDANT_EXPANSION,
+    ),
     # NOTE: The following cases test transpiler-level attribute constraint filtering, which is
     # intentionally disabled. Attribute constraints are enforced via Python-level post-filtering
     # in `_build_results` using `attributes_meet_contraints`. See transpiler.py `_build_edge_filter`.

--- a/tests/data_tiers/tier_0/dgraph/test_transpiler.py
+++ b/tests/data_tiers/tier_0/dgraph/test_transpiler.py
@@ -790,7 +790,7 @@ QUALIFIER_DESCENDANT_EXPANSION_QGRAPH: QueryGraphDict = qg(
                             },
                             {
                                 "qualifier_type_id": "biolink:object_aspect_qualifier",
-                                "qualifier_value": "activity",
+                                "qualifier_value": "activity_or_abundance",
                             },
                             {
                                 "qualifier_type_id": "biolink:object_direction_qualifier",
@@ -1387,7 +1387,7 @@ EXP_QUALIFIER_DESCENDANT_EXPANSION = dedent("""
   q0_node_n0(func: eq(id, "HGNC:3870")) @cascade(id, ~object) {
     expand(Node)
     in_edges_e0: ~object @filter(eq(predicate_ancestors, "affects") AND
-      (eq(qualified_predicate, "causes") AND eq(object_aspect_qualifier, "activity") AND eq(object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(predicate, subject) {
+      (eq(qualified_predicate, "causes") AND eq(object_aspect_qualifier, ["abundance", "activity", "activity_or_abundance", "expression", "synthesis"]) AND eq(object_direction_qualifier, ["decreased", "downregulated"]))) @cascade(predicate, subject) {
       expand(Edge) { sources expand(Source) }
       node_n1: subject @filter(eq(id, "CHEBI:59173")) @cascade(id) {
         expand(Node)

--- a/tests/data_tiers/tier_1/elasticsearch_tests/payload/trapi_qgraphs.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/payload/trapi_qgraphs.py
@@ -1,13 +1,29 @@
 import copy
-from typing import cast, Any
+from typing import Any, cast
 
-from retriever.types.trapi import QueryGraphDict, QEdgeID, QualifierConstraintDict, AttributeConstraintDict, QNodeID, \
-    OperatorEnum
-from .trapi_attributes import ATTRIBUTE_CONSTRAINTS, base_constraint, \
-    base_negation_constraint, VALID_REGEX_CONSTRAINTS, INVALID_REGEX_CONSTRAINTS, NODE_CONSTRAINTS
-from .trapi_qualifiers import multiple_qualifier_constraints, \
-    single_qualifier_constraint, single_qualifier_constraint_with_single_qualifier_entry, sex_qualifier_constraint, \
-    frequency_qualifier_constraint
+from retriever.types.trapi import (
+    AttributeConstraintDict,
+    QEdgeID,
+    QNodeID,
+    QualifierConstraintDict,
+    QueryGraphDict,
+)
+
+from .trapi_attributes import (
+    ATTRIBUTE_CONSTRAINTS,
+    INVALID_REGEX_CONSTRAINTS,
+    NODE_CONSTRAINTS,
+    VALID_REGEX_CONSTRAINTS,
+    base_constraint,
+    base_negation_constraint,
+)
+from .trapi_qualifiers import (
+    frequency_qualifier_constraint,
+    multiple_qualifier_constraints,
+    sex_qualifier_constraint,
+    single_qualifier_constraint,
+    single_qualifier_constraint_with_single_qualifier_entry,
+)
 
 
 def qg(d: dict[str, Any]) -> QueryGraphDict:
@@ -169,6 +185,76 @@ ID_BYPASS_PAYLOAD = qg({
         }
     }
 })
+
+SINGLE_EXPANDED_QUALIFIER_QGRAPH = qg({
+    "nodes": {
+        "ON": {
+            "ids": ["HGNC:3870"],
+            "categories": ["biolink:Gene"],
+        },
+        "SN": {
+            "ids": ["CHEBI:59173"],
+            "categories": ["biolink:ChemicalEntity"],
+        },
+    },
+    "edges": {
+        "e0": {
+            "subject": "SN",
+            "object": "ON",
+            "predicates": ["biolink:affects"],
+            "qualifier_constraints": [
+                {
+                    "qualifier_set": [
+                        {
+                            "qualifier_type_id": "biolink:qualified_predicate",
+                            "qualifier_value": "biolink:causes",
+                        },
+                    ]
+                }
+            ],
+        },
+    },
+})
+
+
+EXPANDED_QUALIFIER_QGRAPH = qg({
+    "nodes": {
+        "ON": {
+            "ids": ["HGNC:3870"],
+            "categories": ["biolink:Gene"],
+        },
+        "SN": {
+            "ids": ["CHEBI:59173"],
+            "categories": ["biolink:ChemicalEntity"],
+        },
+    },
+    "edges": {
+        "e0": {
+            "subject": "SN",
+            "object": "ON",
+            "predicates": ["biolink:affects"],
+            "qualifier_constraints": [
+                {
+                    "qualifier_set": [
+                        {
+                            "qualifier_type_id": "biolink:qualified_predicate",
+                            "qualifier_value": "biolink:causes",
+                        },
+                        {
+                            "qualifier_type_id": "biolink:object_aspect_qualifier",
+                            "qualifier_value": "activity_or_abundance",
+                        },
+                        {
+                            "qualifier_type_id": "biolink:object_direction_qualifier",
+                            "qualifier_value": "decreased",
+                        },
+                    ]
+                }
+            ],
+        },
+    },
+})
+
 
 HYDRATION_QGRAPH = qg({
     "nodes": {

--- a/tests/data_tiers/tier_1/elasticsearch_tests/payload/trapi_qualifiers.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/payload/trapi_qualifiers.py
@@ -1,6 +1,10 @@
 from typing import cast
 
-from retriever.types.trapi import QualifierDict, QualifierConstraintDict, QualifierTypeID
+from retriever.types.trapi import (
+    QualifierConstraintDict,
+    QualifierDict,
+    QualifierTypeID,
+)
 
 
 def create_qualifier_constraint(name: str, value) -> QualifierConstraintDict:
@@ -25,7 +29,7 @@ qualifier_specifications = cast(list[QualifierDict],
                                     },
 
                                     {
-                                        "qualifier_type_id": "biolink:object_modifier_qualifier",
+                                        "qualifier_type_id": "biolink:object_direction_qualifier",
                                         "qualifier_value": "increased"
                                     },
 

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -3,14 +3,24 @@ from collections.abc import Iterator
 from typing import Any, cast
 
 import pytest
+from payload.trapi_qgraphs import (
+    DINGO_QGRAPH,
+    EXPANDED_QUALIFIER_QGRAPH,
+    ID_BYPASS_PAYLOAD,
+    INVALID_REGEX_QGRAPHS,
+    VALID_REGEX_QGRAPHS,
+)
+from test_tier1_transpiler import _convert_batch_triple, _convert_triple
+
 import retriever.config.general as general_mod
 import retriever.data_tiers.tier_1.elasticsearch.driver as driver_mod
-from retriever.data_tiers.tier_1.elasticsearch.meta import extract_metadata_entries_from_blob, get_t1_indices
+from retriever.data_tiers.tier_1.elasticsearch.meta import (
+    extract_metadata_entries_from_blob,
+    get_t1_indices,
+)
 from retriever.data_tiers.tier_1.elasticsearch.transpiler import ElasticsearchTranspiler
-from retriever.data_tiers.tier_1.elasticsearch.types import ESPayload, ESEdge, ESNode
-from payload.trapi_qgraphs import DINGO_QGRAPH, VALID_REGEX_QGRAPHS, INVALID_REGEX_QGRAPHS, ID_BYPASS_PAYLOAD
+from retriever.data_tiers.tier_1.elasticsearch.types import ESEdge, ESNode, ESPayload
 from retriever.utils.redis import RedisClient
-from test_tier1_transpiler import _convert_triple, _convert_batch_triple
 
 
 def esp(d: dict[str, Any]) -> ESPayload:
@@ -233,6 +243,7 @@ async def test_fetch_single_node():
     [
         (DINGO_QGRAPH, 8),
         (ID_BYPASS_PAYLOAD, 4176),  # <-- adjust to the real number
+        (EXPANDED_QUALIFIER_QGRAPH, 1),
     ],
 )
 async def test_end_to_end(qgraph, expected_hits):

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_transpiler.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_transpiler.py
@@ -9,11 +9,13 @@ from payload.es_hits import (  # pyright:ignore[reportImplicitRelativeImport]
     SIMPLE_ES_HITS,
 )
 from payload.trapi_qgraphs import (  # pyright:ignore[reportImplicitRelativeImport]
-    BASE_QGRAPH, ID_BYPASS_PAYLOAD,
+    BASE_QGRAPH, EXPANDED_QUALIFIER_QGRAPH, ID_BYPASS_PAYLOAD,
+    SINGLE_EXPANDED_QUALIFIER_QGRAPH,
 )
 
 from retriever.data_tiers.tier_1.elasticsearch.constraints.types.qualifier_types import (
-    ESQueryForSingleQualifierConstraint,
+    ESBoolQueryForExpandedQualifiers,
+    ESEquivalentQualifierPairCollection,
     ESTermClause,
 )
 from retriever.data_tiers.tier_1.elasticsearch.transpiler import (
@@ -65,26 +67,62 @@ def remove_biolink_prefixes(input: list):
     return list(map(biolink.rmprefix, input))
 
 
-def verify_es_term_clause(qualifier: QualifierDict, generated_query: ESTermClause):
-    assert "term" in generated_query
-    term = generated_query["term"]
-    qualifier_name = qualifier["qualifier_type_id"]
-    qualifier_value = qualifier["qualifier_value"]
-    assert term[biolink.rmprefix(qualifier_name)] == biolink.rmprefix(qualifier_value)
-
-
-def verify_chained_es_term_clauses(
-    qualifiers: list[QualifierDict],
-    generated_query: ESQueryForSingleQualifierConstraint,
+def verify_expanded_qualifier(
+    qualifier: QualifierDict,
+    generated_query: ESEquivalentQualifierPairCollection,
 ):
+    """Verify a single qualifier's `bool.should` expansion.
+
+    The original (type, value) pair must appear among the should terms (along
+    with any biolink descendants).
+    """
+    assert "bool" in generated_query
+    inner = generated_query["bool"]
+    assert "should" in inner
+    assert inner.get("minimum_should_match") == 1
+
+    should_terms: list[ESTermClause] = inner["should"]
+    assert len(should_terms) >= 1
+
+    qtype = biolink.rmprefix(qualifier["qualifier_type_id"])
+    qvalue = biolink.rmprefix(qualifier["qualifier_value"])
+    pairs = {(k, v) for term in should_terms for k, v in term["term"].items()}
+    # every term in this should-array must be for the same qualifier type
+    assert {t for t, _ in pairs} == {qtype}
+    # and the original value must be retained alongside any descendants
+    assert qvalue in {v for _, v in pairs}
+
+
+def verify_expanded_multi_qualifiers(
+    qualifiers: list[QualifierDict],
+    generated_query: ESBoolQueryForExpandedQualifiers,
+):
+    """Verify a multi-qualifier constraint's `bool.must` expansion.
+
+    Each qualifier in the input set becomes one `bool.should` entry within the
+    must array; ordering is non-deterministic because the source code iterates
+    over a set, so we match by qualifier type.
+    """
     assert "bool" in generated_query
     assert "must" in generated_query["bool"]
-    query_terms: list[ESTermClause] = generated_query["bool"]["must"]
+    must_entries: list[ESEquivalentQualifierPairCollection] = generated_query[
+        "bool"
+    ]["must"]
 
-    assert len(query_terms) == len(qualifiers)
+    assert len(must_entries) == len(qualifiers)
 
-    for qualifier, terms in zip(qualifiers, query_terms):
-        verify_es_term_clause(qualifier, terms)
+    entries_by_type: dict[str, ESEquivalentQualifierPairCollection] = {}
+    for entry in must_entries:
+        types_in_entry = {
+            k for term in entry["bool"]["should"] for k in term["term"].keys()
+        }
+        assert len(types_in_entry) == 1
+        entries_by_type[types_in_entry.pop()] = entry
+
+    for qualifier in qualifiers:
+        qtype = biolink.rmprefix(qualifier["qualifier_type_id"])
+        assert qtype in entries_by_type
+        verify_expanded_qualifier(qualifier, entries_by_type[qtype])
 
 
 def check_single_query_payload(q_graph: QueryGraphDict, generated_payload: ESPayload):
@@ -99,18 +137,19 @@ def check_single_query_payload(q_graph: QueryGraphDict, generated_payload: ESPay
     side_type = Literal["object", "subject"]
     sides: list[side_type] = ["subject", "object"]
 
-    # qualifier checker
-    # 0. check should, if > 1 constraints; make sure minimum_should_match
-    # 1. otherwise, check filter; should have one or more filters with `term`
+    # qualifier checker (post-expansion format)
+    # 0. > 1 constraints       -> top-level `should` + `minimum_should_match: 1`
+    # 1. 1 constraint, >1 qual -> `ESBoolQueryForExpandedQualifiers` flattened into `filter`
+    # 2. 1 constraint, 1 qual  -> single `ESEquivalentQualifierPairCollection` appended to `filter`
 
-    if "qualifier_constraints" in q_edge:
+    if q_edge.get("qualifier_constraints"):
         qualifier_entries: list[QualifierConstraintDict] = q_edge[
             "qualifier_constraints"
         ]
 
         if len(qualifier_entries) > 1:
             assert "should" in query_content
-            assert "minimum_should_match" in query_content
+            assert query_content.get("minimum_should_match") == 1
 
             should_array = query_content["should"]
             assert len(should_array) == len(qualifier_entries)
@@ -120,44 +159,29 @@ def check_single_query_payload(q_graph: QueryGraphDict, generated_payload: ESPay
             ):
                 qualifiers = qualifier_entry["qualifier_set"]
                 if len(qualifiers) == 1:
-                    # assert 'bool' in generated_query and 'query' in generated_query['bool']
-                    qualifier = qualifiers[0]
-                    verify_es_term_clause(qualifier, generated_query)
+                    verify_expanded_qualifier(qualifiers[0], generated_query)
                 elif len(qualifiers) > 1:
-                    verify_chained_es_term_clauses(qualifiers, generated_query)
-        elif len(qualifier_entries) == 1:
-            # in this case qualifier query is merged with `filter`
+                    verify_expanded_multi_qualifiers(qualifiers, generated_query)
+        else:
+            # single constraint: qualifier expansion entries are in `filter`
             qualifiers = qualifier_entries[0]["qualifier_set"]
-            check_set = set(
-                [
-                    f"{
-                        '%'.join(
-                            remove_biolink_prefixes(
-                                [
-                                    qualifier['qualifier_type_id'],
-                                    qualifier['qualifier_value'],
-                                ]
-                            )
-                        )
-                    }"
-                    for qualifier in qualifiers
-                ]
-            )
+            bool_entries = [clause for clause in filter_content if "bool" in clause]
+            assert len(bool_entries) == len(qualifiers)
 
-            for term in filter_content:
-                # `terms` is usually query filter, while `term` is usually qualifier
-                if "term" in term:
-                    qualifier_query = term["term"]
-                    assert isinstance(qualifier_query, dict)
-                    assert len(qualifier_query) == 1
+            entries_by_type: dict[str, dict] = {}
+            for entry in bool_entries:
+                types_in_entry = {
+                    k
+                    for term in entry["bool"]["should"]
+                    for k in term["term"].keys()
+                }
+                assert len(types_in_entry) == 1
+                entries_by_type[types_in_entry.pop()] = entry
 
-                    for key in qualifier_query.keys():
-                        assembled_value = "%".join([key, qualifier_query[key]])
-                        if assembled_value in check_set:
-                            check_set.remove(assembled_value)
-
-            # all qualifiers should have been represented in the query
-            assert len(check_set) == 0
+            for qualifier in qualifiers:
+                qtype = biolink.rmprefix(qualifier["qualifier_type_id"])
+                assert qtype in entries_by_type
+                verify_expanded_qualifier(qualifier, entries_by_type[qtype])
 
     # hacky attribute checking for now
     if q_edge.get("attribute_constraints"):
@@ -242,6 +266,78 @@ def test_bypass_payload(
         "subject.category" in clause.get("terms", {})
         for clause in must_clauses
     )
+
+@pytest.mark.parametrize(
+    "q_graph",
+    [SINGLE_EXPANDED_QUALIFIER_QGRAPH, EXPANDED_QUALIFIER_QGRAPH],
+    ids=["single_qualifier", "multi_qualifier"],
+)
+def test_expanded_qualifier_constraints(
+    q_graph: QueryGraphDict,
+    es_transpiler: ElasticsearchTranspiler,
+) -> None:
+    """Each (type, value) pair in a qualifier_set should expand into a
+    `bool.should` clause containing the original pair plus all biolink
+    descendants. The single-qualifier case exercises the
+    `"should" in qualifier_terms["bool"]` branch in `generate_queries`
+    (bare `ESEquivalentQualifierPairCollection` appended to filter); the
+    multi-qualifier case exercises the `"must" in qualifier_terms["bool"]`
+    branch (entries extended from `ESBoolQueryForExpandedQualifiers`).
+    """
+    generated_payload = _convert_triple(es_transpiler, q_graph)
+
+    assert generated_payload is not None
+    query_content = generated_payload["query"]["bool"]
+    filter_content = query_content["filter"]
+
+    # Only a single qualifier_constraints entry -> no top-level should/minimum_should_match
+    assert "should" not in query_content
+    assert "minimum_should_match" not in query_content
+
+    q_edge = q_graph["edges"]["e0"]
+    qualifiers = q_edge["qualifier_constraints"][0]["qualifier_set"]
+
+    # Collect the bool-wrapped expansion entries (each qualifier becomes one)
+    expansion_entries = [clause for clause in filter_content if "bool" in clause]
+    assert len(expansion_entries) == len(qualifiers)
+
+    # Index expansions by the qualifier type embedded in the should-terms
+    expansions_by_type: dict[str, list[ESTermClause]] = {}
+    for entry in expansion_entries:
+        inner = entry["bool"]
+        assert "should" in inner
+        assert inner.get("minimum_should_match") == 1
+
+        should_terms = inner["should"]
+        assert len(should_terms) >= 1
+
+        types_in_should = {next(iter(term["term"].keys())) for term in should_terms}
+        # All terms in a single expansion are for the same qualifier type
+        assert len(types_in_should) == 1
+        expansions_by_type[types_in_should.pop()] = should_terms
+
+    # Every input qualifier must have a matching expansion containing the original value
+    for qualifier in qualifiers:
+        qtype = biolink.rmprefix(qualifier["qualifier_type_id"])
+        qvalue = biolink.rmprefix(qualifier["qualifier_value"])
+        assert qtype in expansions_by_type, (
+            f"Expected expansion for qualifier type {qtype}"
+        )
+
+        values = {next(iter(term["term"].values())) for term in expansions_by_type[qtype]}
+        assert qvalue in values, (
+            f"Expected original value {qvalue} to be retained among the "
+            f"descendants for {qtype}, got {values}"
+        )
+
+    # Standard term filters for the subject/object ids and predicate should still be present
+    term_fields = {
+        next(iter(clause["terms"].keys()))
+        for clause in filter_content
+        if "terms" in clause
+    }
+    assert {"subject.id", "object.id", "predicate_ancestors"}.issubset(term_fields)
+
 
 @pytest.mark.parametrize(*Q_GRAPH_CASES, ids=Q_GRAPH_CASES_IDS)
 def test_convert_triple(


### PR DESCRIPTION
Fix #163 by expanding qualifier constraints when generating ES queries.

Since there isn't currently a utility in `biolink` to validate `qualifier_type` and `qualifier_value` pairs after expansion, all possible combinations are queried within a `should` array. This can be refined once such a feature becomes available in `biolink` utils.