### PR TITLE
Pass through message parameters and turn off validation for dehydrated responses

### DIFF
--- a/src/retriever/data_tiers/tier_0/base_query.py
+++ b/src/retriever/data_tiers/tier_0/base_query.py
@@ -51,7 +51,9 @@ class Tier0Query(ABC):
             async with asyncio.timeout(timeout):
                 backend_results = await self.get_results(self.qgraph, self.response)
             
-            if not self.response["parameters"].get("dehydrated"):
+            parameters = self.response.get("parameters") or {}
+
+            if not parameters.get("dehydrated"):
                 with tracer.start_as_current_span("update_kg"):
                     normalize_kgraph(
                         backend_results["knowledge_graph"],
@@ -68,7 +70,7 @@ class Tier0Query(ABC):
                 f"Tier 0: Retrieved {len(backend_results['results'])} results / {len(self.kgraph['nodes'])} nodes / {len(self.kgraph['edges'])} edges in {duration_ms}ms."
             )
 
-            if not self.response["parameters"].get("dehydrated"):
+            if not parameters.get("dehydrated"):
                 # Add Retriever to the provenance chain
                 for edge_id, edge in backend_results["knowledge_graph"]["edges"].items():
                     try:

--- a/src/retriever/data_tiers/tier_0/base_query.py
+++ b/src/retriever/data_tiers/tier_0/base_query.py
@@ -50,7 +50,7 @@ class Tier0Query(ABC):
             )
             async with asyncio.timeout(timeout):
                 backend_results = await self.get_results(self.qgraph, self.response)
-            
+
             parameters = self.response.get("parameters") or {}
 
             if not parameters.get("dehydrated"):

--- a/src/retriever/data_tiers/tier_0/base_query.py
+++ b/src/retriever/data_tiers/tier_0/base_query.py
@@ -28,7 +28,9 @@ tracer = trace.get_tracer("lookup.execution.tracer")
 class Tier0Query(ABC):
     """Handler class for running a single Tier 0 query."""
 
-    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict) -> None:
+    def __init__(
+        self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict
+    ) -> None:
         """Initialize a Tier 0 Query instance."""
         self.ctx: QueryInfo = query_info
         self.qgraph: QueryGraphDict = qgraph
@@ -72,7 +74,9 @@ class Tier0Query(ABC):
 
             if not parameters.get("dehydrated"):
                 # Add Retriever to the provenance chain
-                for edge_id, edge in backend_results["knowledge_graph"]["edges"].items():
+                for edge_id, edge in backend_results["knowledge_graph"][
+                    "edges"
+                ].items():
                     try:
                         append_aggregator_source(edge, Infores("infores:retriever"))
                     except ValueError:
@@ -98,7 +102,9 @@ class Tier0Query(ABC):
             )
 
     @abstractmethod
-    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
+    async def get_results(
+        self, qgraph: QueryGraphDict, response: ResponseDict
+    ) -> BackendResult:
         """Interface with the Tier 0 backend and retrieve results, converting to ResultDict.
 
         Note that this method is responsible for calling the appropriate transpiler,

--- a/src/retriever/data_tiers/tier_0/base_query.py
+++ b/src/retriever/data_tiers/tier_0/base_query.py
@@ -12,6 +12,7 @@ from retriever.types.trapi import (
     Infores,
     KnowledgeGraphDict,
     QueryGraphDict,
+    ResponseDict,
 )
 from retriever.utils.logs import TRAPILogger
 from retriever.utils.trapi import (
@@ -27,13 +28,14 @@ tracer = trace.get_tracer("lookup.execution.tracer")
 class Tier0Query(ABC):
     """Handler class for running a single Tier 0 query."""
 
-    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo) -> None:
+    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict) -> None:
         """Initialize a Tier 0 Query instance."""
         self.ctx: QueryInfo = query_info
         self.qgraph: QueryGraphDict = qgraph
         self.job_log: TRAPILogger = TRAPILogger(self.ctx.job_id)
         self.kgraph: KnowledgeGraphDict = initialize_kgraph(self.qgraph)
         self.aux_graphs: dict[AuxGraphID, AuxiliaryGraphDict] = {}
+        self.response: ResponseDict = response
 
     @tracer.start_as_current_span("tier0_execute")
     async def execute(self) -> LookupArtifacts:
@@ -47,17 +49,18 @@ class Tier0Query(ABC):
                 f"Tier 0 timeout is {'disabled' if timeout is None else f'{timeout}s'}."
             )
             async with asyncio.timeout(timeout):
-                backend_results = await self.get_results(self.qgraph)
-
-            with tracer.start_as_current_span("update_kg"):
-                normalize_kgraph(
-                    backend_results["knowledge_graph"],
-                    backend_results["results"],
-                    backend_results["auxiliary_graphs"],
-                )
-                update_kgraph(self.kgraph, backend_results["knowledge_graph"])
-            with tracer.start_as_current_span("update_auxgraphs"):
-                self.aux_graphs.update(backend_results["auxiliary_graphs"])
+                backend_results = await self.get_results(self.qgraph, self.response)
+            
+            if not self.response["parameters"].get("dehydrated"):
+                with tracer.start_as_current_span("update_kg"):
+                    normalize_kgraph(
+                        backend_results["knowledge_graph"],
+                        backend_results["results"],
+                        backend_results["auxiliary_graphs"],
+                    )
+                    update_kgraph(self.kgraph, backend_results["knowledge_graph"])
+                with tracer.start_as_current_span("update_auxgraphs"):
+                    self.aux_graphs.update(backend_results["auxiliary_graphs"])
 
             end_time = time.time()
             duration_ms = math.ceil((end_time - start_time) * 1000)
@@ -65,14 +68,15 @@ class Tier0Query(ABC):
                 f"Tier 0: Retrieved {len(backend_results['results'])} results / {len(self.kgraph['nodes'])} nodes / {len(self.kgraph['edges'])} edges in {duration_ms}ms."
             )
 
-            # Add Retriever to the provenance chain
-            for edge_id, edge in backend_results["knowledge_graph"]["edges"].items():
-                try:
-                    append_aggregator_source(edge, Infores("infores:retriever"))
-                except ValueError:
-                    self.job_log.warning(
-                        f"Edge f{edge_id} has an invalid provenance chain."
-                    )
+            if not self.response["parameters"].get("dehydrated"):
+                # Add Retriever to the provenance chain
+                for edge_id, edge in backend_results["knowledge_graph"]["edges"].items():
+                    try:
+                        append_aggregator_source(edge, Infores("infores:retriever"))
+                    except ValueError:
+                        self.job_log.warning(
+                            f"Edge f{edge_id} has an invalid provenance chain."
+                        )
 
             return LookupArtifacts(
                 backend_results["results"],
@@ -92,7 +96,7 @@ class Tier0Query(ABC):
             )
 
     @abstractmethod
-    async def get_results(self, qgraph: QueryGraphDict) -> BackendResult:
+    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
         """Interface with the Tier 0 backend and retrieve results, converting to ResultDict.
 
         Note that this method is responsible for calling the appropriate transpiler,

--- a/src/retriever/data_tiers/tier_0/dgraph/query.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/query.py
@@ -6,7 +6,7 @@ from retriever.data_tiers.tier_0.base_query import Tier0Query
 from retriever.data_tiers.tier_0.dgraph.driver import DgraphGrpcDriver
 from retriever.data_tiers.tier_0.dgraph.transpiler import DgraphTranspiler
 from retriever.types.general import BackendResult
-from retriever.types.trapi import QueryGraphDict
+from retriever.types.trapi import QueryGraphDict, ResponseDict
 
 tracer = trace.get_tracer("lookup.execution.tracer")
 
@@ -15,7 +15,7 @@ class DgraphQuery(Tier0Query):
     """Adapter to querying Dgraph as a Tier 0 backend."""
 
     @override
-    async def get_results(self, qgraph: QueryGraphDict) -> BackendResult:
+    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
         backend_driver = DgraphGrpcDriver()
         dgraph_schema_version = await backend_driver.get_active_version()
         graph_uses_subclass = any(

--- a/src/retriever/data_tiers/tier_0/dgraph/query.py
+++ b/src/retriever/data_tiers/tier_0/dgraph/query.py
@@ -15,7 +15,9 @@ class DgraphQuery(Tier0Query):
     """Adapter to querying Dgraph as a Tier 0 backend."""
 
     @override
-    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
+    async def get_results(
+        self, qgraph: QueryGraphDict, response: ResponseDict
+    ) -> BackendResult:
         backend_driver = DgraphGrpcDriver()
         dgraph_schema_version = await backend_driver.get_active_version()
         graph_uses_subclass = any(

--- a/src/retriever/data_tiers/tier_0/gandalf/query.py
+++ b/src/retriever/data_tiers/tier_0/gandalf/query.py
@@ -10,6 +10,7 @@ from retriever.types.trapi import (
     MessageDict,
     QueryDict,
     QueryGraphDict,
+    ResponseDict,
 )
 
 tracer = trace.get_tracer("lookup.execution.tracer")
@@ -19,12 +20,13 @@ class GandalfQuery(Tier0Query):
     """Adapter to querying Dgraph as a Tier 0 backend."""
 
     @override
-    async def get_results(self, qgraph: QueryGraphDict) -> BackendResult:
+    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
         backend_driver = GandalfDriver()
         query_payload = QueryDict(
             message=MessageDict(
                 query_graph=qgraph,
-            )
+            ),
+            parameters=response["parameters"],
         )
 
         result = await backend_driver.run_query(query_payload)

--- a/src/retriever/data_tiers/tier_0/gandalf/query.py
+++ b/src/retriever/data_tiers/tier_0/gandalf/query.py
@@ -26,7 +26,7 @@ class GandalfQuery(Tier0Query):
             message=MessageDict(
                 query_graph=qgraph,
             ),
-            parameters=response["parameters"],
+            parameters=response.get("parameters") or {},
         )
 
         result = await backend_driver.run_query(query_payload)

--- a/src/retriever/data_tiers/tier_0/gandalf/query.py
+++ b/src/retriever/data_tiers/tier_0/gandalf/query.py
@@ -20,7 +20,9 @@ class GandalfQuery(Tier0Query):
     """Adapter to querying Dgraph as a Tier 0 backend."""
 
     @override
-    async def get_results(self, qgraph: QueryGraphDict, response: ResponseDict) -> BackendResult:
+    async def get_results(
+        self, qgraph: QueryGraphDict, response: ResponseDict
+    ) -> BackendResult:
         backend_driver = GandalfDriver()
         query_payload = QueryDict(
             message=MessageDict(

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -126,7 +126,9 @@ async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
             return tracked_response(200, query, response, job_log)
 
         results, kgraph, aux_graphs, logs, _ = await run_tiered_lookups(
-            query, expanded_qgraph, response,
+            query,
+            expanded_qgraph,
+            response,
         )
         job_log.log_deque.extend(logs)
 
@@ -308,7 +310,9 @@ async def qgraph_supported(
 
 @tracer.start_as_current_span("execute_lookup")
 async def run_tiered_lookups(
-    query: QueryInfo, expanded_qgraph: QueryGraphDict, response: ResponseDict,
+    query: QueryInfo,
+    expanded_qgraph: QueryGraphDict,
+    response: ResponseDict,
 ) -> LookupArtifacts:
     """Run lookups against requested tier(s) and combine results."""
     results = dict[int, ResultDict]()

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -126,7 +126,7 @@ async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
             return tracked_response(200, query, response, job_log)
 
         results, kgraph, aux_graphs, logs, _ = await run_tiered_lookups(
-            query, expanded_qgraph
+            query, expanded_qgraph, response,
         )
         job_log.log_deque.extend(logs)
 
@@ -308,7 +308,7 @@ async def qgraph_supported(
 
 @tracer.start_as_current_span("execute_lookup")
 async def run_tiered_lookups(
-    query: QueryInfo, expanded_qgraph: QueryGraphDict
+    query: QueryInfo, expanded_qgraph: QueryGraphDict, response: ResponseDict,
 ) -> LookupArtifacts:
     """Run lookups against requested tier(s) and combine results."""
     results = dict[int, ResultDict]()
@@ -328,7 +328,7 @@ async def run_tiered_lookups(
         if tier_manager.get_driver(i).is_failed:
             job_log.error(f"Tier {i} backend connection failed, tier must be skipped.")
             continue
-        query_handler = handlers[i](expanded_qgraph, query)
+        query_handler = handlers[i](expanded_qgraph, query, response)
         query_tasks.append(asyncio.create_task(query_handler.execute()))
 
     async for task in asyncio.as_completed(query_tasks):

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -42,6 +42,7 @@ from retriever.types.trapi import (
     QEdgeID,
     QNodeID,
     QueryGraphDict,
+    ResponseDict,
     ResultDict,
 )
 from retriever.utils import biolink
@@ -91,7 +92,7 @@ class QueryGraphExecutor:
     start_time: float
     timeout: float
 
-    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo) -> None:
+    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict) -> None:
         """Initialize a QueryGraphExecutor, setting up information shared by methods."""
         self.ctx = query_info
         self.qgraph = qgraph

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -92,7 +92,9 @@ class QueryGraphExecutor:
     start_time: float
     timeout: float
 
-    def __init__(self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict) -> None:
+    def __init__(
+        self, qgraph: QueryGraphDict, query_info: QueryInfo, response: ResponseDict
+    ) -> None:
         """Initialize a QueryGraphExecutor, setting up information shared by methods."""
         self.ctx = query_info
         self.qgraph = qgraph

--- a/src/retriever/types/trapi.py
+++ b/src/retriever/types/trapi.py
@@ -87,7 +87,7 @@ class ResponseDict(TypedDict):
     description: NotRequired[str | None]
     logs: NotRequired[list[LogEntryDict]]
     workflow: NotRequired[list[dict[str, JsonSerializable]] | None]
-    parameters: NotRequired[ParametersDict | dict]
+    parameters: NotRequired[ParametersDict | None]
     schema_version: NotRequired[str | None]
     biolink_version: NotRequired[str | None]
 

--- a/src/retriever/types/trapi.py
+++ b/src/retriever/types/trapi.py
@@ -87,7 +87,7 @@ class ResponseDict(TypedDict):
     description: NotRequired[str | None]
     logs: NotRequired[list[LogEntryDict]]
     workflow: NotRequired[list[dict[str, JsonSerializable]] | None]
-    parameters: NotRequired[ParametersDict | None]
+    parameters: NotRequired[ParametersDict | dict]
     schema_version: NotRequired[str | None]
     biolink_version: NotRequired[str | None]
 


### PR DESCRIPTION
Gandalf and Aragorn Pathfinder have a special dehydrated feature that allows a really slimmed down TRAPI message. This is to allow Retriever to pass these types of messages through without throwing up hopefully.