### PR TITLE
Dependency overhaul

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,9 @@ repos:
   - repo: local
     hooks:
       - id: static-typing
+        files: 'src/.*/*.py'
         name: static typing
         language: node
-        files: src
         entry: uv
         require_serial: true
         args: [run, basedpyright, src]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.13-alpine
 # Ensure requirements
 RUN apk add --no-cache git
 # Build requirements
-RUN apk add --no-cache rust cargo g++ file make
+RUN apk add --no-cache rust cargo g++ gcc file make python3-dev musl-dev linux-headers
 RUN pip install --upgrade pip
 
 RUN adduser -D python
@@ -14,6 +14,15 @@ USER python
 WORKDIR /usr/src/app
 
 COPY --chown=python:python . .
+
+# Bake the running build's git commit + branch into small files
+RUN sh -ec '\
+        git -C /usr/src/app rev-parse HEAD \
+            > /usr/src/app/src/retriever/_version_commit.txt 2>/dev/null || :; \
+        git -C /usr/src/app rev-parse --abbrev-ref HEAD \
+            > /usr/src/app/src/retriever/_version_branch.txt 2>/dev/null || :; \
+        touch /usr/src/app/src/retriever/_version_commit.txt \
+              /usr/src/app/src/retriever/_version_branch.txt'
 
 RUN pip install --user uv
 ENV PATH="/home/python/.local/bin:${PATH}"

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -1,9 +1,8 @@
----
 # Default configuration values.
 # Managed by Retriever.
 # Don't edit this file, it will be overwritten.
 # Edit the appropriate config file instead.
-debug: false # Run server with increased compatibility for breakpoint debugging.
+debug: false  # Run server with increased compatibility for breakpoint debugging.
 instance_env: dev # Instance environment. Used in Sentry, userAgent of subqueries, instance-appropriate behavior, etc.
 instance_idx: 0 # Instance index. Use when multiple Retriever instances are run, so a leader can be determined.
 log_level: DEBUG # Level of application logs to print/keep.
@@ -11,74 +10,77 @@ host: 0.0.0.0 # Uvicorn listen host.
 port: 8080 # Uvicorn listen port.
 trust_proxy: true # Use proxy IP headers (such as in nginx cases)
 cors:
-  allow_origins: # Origins allowed to make cross-origin requests.
-    - '*'
+  allow_origins:  # Origins allowed to make cross-origin requests.
+  - '*'
   allow_credentials: true # Support cookies in cross-origin requests.
   allow_methods: # Methods allowed in cross-origin requests.
-    - '*'
+  - '*'
   allow_headers: # Headers allowed in cross-origin requests.
-    - '*'
+  - '*'
 workers: # Number of workers, defaults to n_cpus * worker_cpu_ratio if unset.
 worker_cpu_ratio: 1 # Ratio of workers to n_cpus if worker count is unset (rounds to ceiling after multiplication).
 allow_profiler: true # Allow all queries to enable profiling with a query parameter.
 job:
   callback:
-    retries: 3 # Number of times to retry the callback.
+    retries: 3  # Number of times to retry the callback.
     timeout: 60 # Time in seconds before a callback attempt should time out.
   lookup:
-    tier0_timeout: 180 # Time in seconds before a tier 0 query should time out, set to -1 to disable.
+    tier0_timeout: 180  # Time in seconds before a tier 0 query should time out, set to -1 to disable.
     tier1_timeout: 10 # Time in seconds before a tier 1 query should time out, set to -1 to disable.
     tier2_timeout: 300 # Time in seconds before a tier 2 query should time out, set to -1 to disable.
     implicit_subclassing: true # Whether or not to answer via subclasses.
     subclass_cutoff: 1000 # Maximum number of subclass descendants found for a given node before failing a query. Set to -1 to disable.
   metakg:
-    retries: 3 # Number of times to retry obtaining DINGO metadata.
+    retries: 3  # Number of times to retry obtaining DINGO metadata.
     acquire_timeout: 30 # Time in seconds until a metadata call should time out, set to -1 to disable.
     timeout: 10 # Time in seconds before a job should time out, set to -1 to disable.
     build_time: 3600 # Time in seconds before MetaKG should be rebuilt. Set to -1 to only build at start.
-  orphan_check_interval: 120 # Interval in seconds between orphan-job detection sweeps. Set to -1 to disable.
+  orphan_check_interval: 120  # Interval in seconds between orphan-job detection sweeps. Set to -1 to disable.
   ttl: 2592000 # Time in seconds for job state to remain after it was last touched
   ttl_max: 31536000 # Time in seconds after which job state is cleared, regardless of last touch
 log:
-  log_to_mongo: true # Persist logs in MongoDB.
+  log_to_mongo: true  # Persist logs in MongoDB.
   mongo_ttl: 1209600 # Time in seconds for a log to persist.
 redis:
   host: localhost
   port: 6379
   password:
   ssl_enabled: false
-  attempts: 3 # Number of attempts to accomplish operation before considering it failed.
+  attempts: 3  # Number of attempts to accomplish operation before considering it failed.
   timeout: 5 # Time before a redis operation is considered failed.
   shutdown_timeout: 3 # Time in seconds to wait for batched tasks to finish before force-quitting.
+  heartbeat_interval_seconds: 60 # Cadence at which workers / background / main re-register their process entry.
+  process_ttl_seconds: 300 # TTL on each registered process entry; set to several heartbeat intervals so a single missed refresh doesn't drop the entry.
 mongo:
   host: localhost
   port: 27017
   username:
   password:
   authsource:
-  attempts: 3 # Number of attempts to accomplish operation before considering it failed.
+  attempts: 3  # Number of attempts to accomplish operation before considering it failed.
   shutdown_timeout: 3 # Time in seconds to wait for serialize task to finish.
 tier0:
   backend: gandalf
   backend_infores: infores:dogpark-tier0
   gandalf:
-    host: localhost
+    host: http://localhost
     port: 443
-    query_timeout: 3600 # Time in seconds before a Gandalf query should time out.
+    query_timeout: 3600  # Time in seconds before a Gandalf query should time out.
     connect_retries: 5 # Number of retries before declaring a connection failure.
-  dump_queries: false # Write out TRAPI and translated queries to a file in jsonl format.
+  dump_queries: false  # Write out TRAPI and translated queries to a file in jsonl format.
 tier1:
   backend: elasticsearch
-  metadata_url: https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json
+  metadata_url:
+    https://stars.renci.org/var/translator/releases/translator_kg/latest/graph-metadata.json
   backend_infores: infores:dogpark-tier1
   elasticsearch:
-    query_timeout: 180 # Time in seconds before a Elasticsearch query should time out.
+    query_timeout: 180  # Time in seconds before a Elasticsearch query should time out.
     connect_retries: 5 # Number of retries before declaring a connection failure.
     host: ''
     port: 9200
     database_name: elasticsearch
     index_name: dingo
-  dump_queries: false # Write out TRAPI and translated queries to a file in jsonl format.
+  dump_queries: false  # Write out TRAPI and translated queries to a file in jsonl format.
 telemetry:
   otel_enabled: false
   otel_host: jaeger-otel-collector.sri
@@ -86,5 +88,5 @@ telemetry:
   otel_trace_endpoint: /v1/traces
   sentry_enabled: false
   sentry_dsn:
-  traces_sample_rate: 0.1 # Proportion of traces to send to Sentry.
+  traces_sample_rate: 0.1  # Proportion of traces to send to Sentry.
   profiles_sample_rate: 0.5 # Proportion of sampled traces to profile.

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -36,6 +36,7 @@ job:
     acquire_timeout: 30 # Time in seconds until a metadata call should time out, set to -1 to disable.
     timeout: 10 # Time in seconds before a job should time out, set to -1 to disable.
     build_time: 3600 # Time in seconds before MetaKG should be rebuilt. Set to -1 to only build at start.
+  orphan_check_interval: 120 # Interval in seconds between orphan-job detection sweeps. Set to -1 to disable.
   ttl: 2592000 # Time in seconds for job state to remain after it was last touched
   ttl_max: 31536000 # Time in seconds after which job state is cleared, regardless of last touch
 log:

--- a/config/openapi.default.yaml
+++ b/config/openapi.default.yaml
@@ -25,6 +25,8 @@ tags:
     description:
   - name: asyncquery_status
     description:
+  - name: status
+    description:
   - name: translator
     description:
   - name: trapi
@@ -77,6 +79,21 @@ response_descriptions:
     '404': Indicates this service is disabled by config.
   config:
     '200': The present config of the server, with secrets removed.
+  status:
+    root: Health snapshot — version, processes, dependencies, freshness.
+    jobs: Full per-job status (metadata + query/response geometry).
+    active: Currently in-flight jobs, newest first.
+    stuck: Active jobs running past the `min_age` threshold (default 1h).
+    counts: Status breakdown across three fixed windows (24h, week, all time).
+    timeline: Time-bucketed throughput counts for charting.
+    durations: Aggregate runtime stats (min/max/avg + percentiles).
+    submitters: Per-submitter activity leaderboard.
+    tiers: Per-tier activity and duration percentiles.
+    submitter_tier_stats: Per-(submitter, tier) cell stats; drives the heatmaps view.
+    failure_breakdown: Failure-status counts pivoted by submitter or by tier.
+    completed: Paged scan of successfully-terminated jobs.
+    failed: Paged scan of failed/errored terminal jobs.
+    server_logs: Logs not associated with any job.
 servers:
   - description: DOGSURF AWS Dev instance
     url: https://dev.retriever.biothings.io/

--- a/config/openapi.default.yaml
+++ b/config/openapi.default.yaml
@@ -1,4 +1,3 @@
----
 # Default configuration values.
 # Managed by Retriever.
 # Don't edit this file, it will be overwritten.
@@ -17,70 +16,87 @@ license:
   url: http://www.apache.org/licenses/LICENSE-2.0.html
 termsOfService: https://biothings.io/about
 tags:
-  - name: meta_knowledge_graph
-    description:
-  - name: query
-    description:
-  - name: asyncquery
-    description:
-  - name: asyncquery_status
-    description:
-  - name: status
-    description:
-  - name: translator
-    description:
-  - name: trapi
-    description:
-  - name: biothings
-    description:
-x_translator: # Note that fields usually named with - instead use _ (e.g. x-translator -> x_translator).
+- name: meta_knowledge_graph
+  description:
+- name: query
+  description:
+- name: asyncquery
+  description:
+- name: asyncquery_status
+  description:
+- name: status
+  description:
+- name: translator
+  description:
+- name: trapi
+  description:
+- name: biothings
+  description:
+x_translator:  # Note that fields usually named with - instead use _ (e.g. x-translator -> x_translator).
   component: KP
   team:
-    - DOGSURF
+  - DOGSURF
   biolink_version: 4.3.2
-  infores: infores:retriever # Unique identifier for this component, used in provenance.
+  infores: infores:retriever  # Unique identifier for this component, used in provenance.
   externalDocs:
-    description: The values for component and team are restricted according to this external JSON schema. See schema and examples at url.
-    url: https://github.com/NCATSTranslator/translator_extensions/blob/production/x-translator/
+    description: The values for component and team are restricted according to
+      this external JSON schema. See schema and examples at url.
+    url:
+      https://github.com/NCATSTranslator/translator_extensions/blob/production/x-translator/
 x_trapi:
   version: 1.6.0
-  multicuriesquery: false # Supports advanced set interpretation.
+  multicuriesquery: false  # Supports advanced set interpretation.
   pathfinderquery: false # Supports Pathfinder-type queries.
   asyncquery: true # Supports async query type.
   operations:
-    - lookup
-  batch_size_limit: 300 # Maximum IDs on any one node.
+  - lookup
+  batch_size_limit: 300  # Maximum IDs on any one node.
   test_data_location:
     default:
-      url: https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-bte-ara.json
+      url:
+        https://raw.githubusercontent.com/NCATS-Tangerine/translator-api-registry/master/biothings_explorer/sri-test-bte-ara.json
   externalDocs:
-    description: The values for version are restricted according to the regex in this external JSON schema. See schema and examples at url
-    url: https://github.com/NCATSTranslator/translator_extensions/blob/production/x-trapi/
+    description: The values for version are restricted according to the regex in
+      this external JSON schema. See schema and examples at url
+    url:
+      https://github.com/NCATSTranslator/translator_extensions/blob/production/x-trapi/
 response_descriptions:
   meta_knowledge_graph:
-    '200': Returns meta knowledge graph representation of this TRAPI web service.
+    '200': Returns meta knowledge graph representation of this TRAPI web
+      service.
   metadata:
     '200': Returns metadata for currently-served data in the backends.
   query:
-    '200': OK. There may or may not be results. Note that some of the provided identifiers may not have been recognized.
-    '400': Bad request. The request is invalid according to this OpenAPI schema OR a specific identifier is believed to be invalid somehow (not just unrecognized).
-    '413': Payload too large. Indicates that batch size was over the limit specified in x-trapi.
-    '429': Payload too large. Indicates that batch size was over the limit specified in x-trapi.
+    '200': OK. There may or may not be results. Note that some of the provided
+      identifiers may not have been recognized.
+    '400': Bad request. The request is invalid according to this OpenAPI schema
+      OR a specific identifier is believed to be invalid somehow (not just
+      unrecognized).
+    '413': Payload too large. Indicates that batch size was over the limit
+      specified in x-trapi.
+    '429': Payload too large. Indicates that batch size was over the limit
+      specified in x-trapi.
   asyncquery:
-    '200': The query is accepted for processing and the Response will be sent to the callback url when complete.
+    '200': The query is accepted for processing and the Response will be sent to
+      the callback url when complete.
   asyncquery_status:
-    '200': Returns the status and current logs of a previously submitted asyncquery.
+    '200': Returns the status and current logs of a previously submitted
+      asyncquery.
     '404': job_id not found
-    '501': Return code 501 indicates that this endpoint has not been implemented at this site. Sites that implement /asyncquery MUST implement /asyncquery_status/{job_id}, but those that do not implement /asyncquery SHOULD NOT implement /asyncquery_status.
+    '501': Return code 501 indicates that this endpoint has not been implemented
+      at this site. Sites that implement /asyncquery MUST implement
+      /asyncquery_status/{job_id}, but those that do not implement /asyncquery
+      SHOULD NOT implement /asyncquery_status.
   response:
-    '200': Returns either the status and logs, or if complete, the complete response  of a previously submitted asyncquery.
+    '200': Returns either the status and logs, or if complete, the complete
+      response  of a previously submitted asyncquery.
   logs:
     '200': Logs in either flat or structured JSON format.
     '404': Indicates this service is disabled by config.
   config:
     '200': The present config of the server, with secrets removed.
   status:
-    root: Health snapshot — version, processes, dependencies, freshness.
+    root: Health snapshot - version, processes, dependencies, freshness.
     jobs: Full per-job status (metadata + query/response geometry).
     active: Currently in-flight jobs, newest first.
     stuck: Active jobs running past the `min_age` threshold (default 1h).
@@ -89,15 +105,16 @@ response_descriptions:
     durations: Aggregate runtime stats (min/max/avg + percentiles).
     submitters: Per-submitter activity leaderboard.
     tiers: Per-tier activity and duration percentiles.
-    submitter_tier_stats: Per-(submitter, tier) cell stats; drives the heatmaps view.
+    submitter_tier_stats: Per-(submitter, tier) cell stats; drives the heatmaps
+      view.
     failure_breakdown: Failure-status counts pivoted by submitter or by tier.
     completed: Paged scan of successfully-terminated jobs.
     failed: Paged scan of failed/errored terminal jobs.
     server_logs: Logs not associated with any job.
 servers:
-  - description: DOGSURF AWS Dev instance
-    url: https://dev.retriever.biothings.io/
-    x_maturity: development
-  - description: Translator CI instance
-    url: https://retriever.ci.transltr.io/
-    x_maturity: staging
+- description: DOGSURF AWS Dev instance
+  url: https://dev.retriever.biothings.io/
+  x_maturity: development
+- description: Translator CI instance
+  url: https://retriever.ci.transltr.io/
+  x_maturity: staging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "msgpack>=1.1.1",
     "aiofiles>=25.1.0",
     "gitpython>=3.1.46",
+    "psutil>=6.1.1",
 ]
 
 [project.scripts]
@@ -173,7 +174,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.ruff]
-include = ["src/*"]
+# Limit to Python files; the dashboard static assets (HTML/JS/CSS) live
+# under src/ and shouldn't be linted by ruff.
+include = ["src/**/*.py", "src/**/*.pyi"]
 line-length = 88
 indent-width = 4
 
@@ -241,7 +244,6 @@ reportAny = false
 reportExplicitAny = false
 reportUnusedCallResult = false # Just makes code look worse; Usually unused results are deliberately ignored
 reportMissingTypeStubs = false # Sometimes type stubs aren't available and auto-gen is incorrect
-
 
 [tool.deptry]
 extend_exclude = ["locustfile.py", "tests"]

--- a/src/retriever/__main__.py
+++ b/src/retriever/__main__.py
@@ -1,6 +1,9 @@
+import asyncio
+import contextlib
 import math
 import multiprocessing
 import os
+from datetime import datetime
 
 import uvicorn
 import uvloop
@@ -13,6 +16,11 @@ from retriever.config.logger import configure_logging
 from retriever.config.write_configs import write_default_configs
 from retriever.utils.logs import add_mongo_sink, cleanup
 from retriever.utils.mongo import MongoClient, MongoQueue
+from retriever.utils.redis import (
+    PROCESS_TTL_SECONDS,
+    RedisClient,
+    heartbeat,
+)
 from retriever.utils.uvicorn_multiprocess import AsyncMultiprocess
 
 
@@ -25,10 +33,26 @@ async def _main_inner() -> None:
     logging_config = configure_logging()
 
     # For main process logging
+    main_heartbeat_task: asyncio.Task[None] | None = None
     if not CONFIG.debug:
         await MongoClient().initialize()
         await MongoQueue().initialize()
         add_mongo_sink()
+        await RedisClient().initialize()
+        main_pid = os.getpid()
+        main_started_at = datetime.now().astimezone()
+        await RedisClient().register_main(
+            main_pid, main_started_at, PROCESS_TTL_SECONDS
+        )
+        main_heartbeat_task = asyncio.create_task(
+            heartbeat(
+                lambda: RedisClient().register_main(
+                    main_pid, main_started_at, PROCESS_TTL_SECONDS
+                ),
+                role_label="Main",
+            ),
+            name="main-heartbeat",
+        )
 
     logger.debug(
         f"Starting with config: \n{yaml.dump(yaml.safe_load(CONFIG.model_dump_json()))}"
@@ -70,7 +94,12 @@ async def _main_inner() -> None:
     # /// POST-SERVER CLEANUP ///
 
     await background_manager.wrapup()
+    if main_heartbeat_task is not None:
+        main_heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await main_heartbeat_task
     if not CONFIG.debug:
+        await RedisClient().wrapup()
         await MongoQueue().wrapup()
         await MongoClient().close()
 

--- a/src/retriever/__main__.py
+++ b/src/retriever/__main__.py
@@ -1,5 +1,3 @@
-import asyncio
-import contextlib
 import math
 import multiprocessing
 import os
@@ -14,13 +12,10 @@ from retriever.background import BackgroundProcessManager
 from retriever.config.general import CONFIG
 from retriever.config.logger import configure_logging
 from retriever.config.write_configs import write_default_configs
+from retriever.utils.general import tolerate_init
 from retriever.utils.logs import add_mongo_sink, cleanup
 from retriever.utils.mongo import MongoClient, MongoQueue
-from retriever.utils.redis import (
-    PROCESS_TTL_SECONDS,
-    RedisClient,
-    heartbeat,
-)
+from retriever.utils.redis import RedisClient
 from retriever.utils.uvicorn_multiprocess import AsyncMultiprocess
 
 
@@ -33,7 +28,6 @@ async def _main_inner() -> None:
     logging_config = configure_logging()
 
     # For main process logging
-    main_heartbeat_task: asyncio.Task[None] | None = None
     if not CONFIG.debug:
         await MongoClient().initialize()
         await MongoQueue().initialize()
@@ -41,17 +35,17 @@ async def _main_inner() -> None:
         await RedisClient().initialize()
         main_pid = os.getpid()
         main_started_at = datetime.now().astimezone()
-        await RedisClient().register_main(
-            main_pid, main_started_at, PROCESS_TTL_SECONDS
-        )
-        main_heartbeat_task = asyncio.create_task(
-            heartbeat(
-                lambda: RedisClient().register_main(
-                    main_pid, main_started_at, PROCESS_TTL_SECONDS
-                ),
-                role_label="Main",
+        await tolerate_init(
+            "Main registration",
+            RedisClient().register_main(
+                main_pid, main_started_at, CONFIG.redis.process_ttl_seconds
             ),
-            name="main-heartbeat",
+        )
+        RedisClient().start_heartbeat(
+            lambda: RedisClient().register_main(
+                main_pid, main_started_at, CONFIG.redis.process_ttl_seconds
+            ),
+            role_label="Main",
         )
 
     logger.debug(
@@ -94,14 +88,11 @@ async def _main_inner() -> None:
     # /// POST-SERVER CLEANUP ///
 
     await background_manager.wrapup()
-    if main_heartbeat_task is not None:
-        main_heartbeat_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await main_heartbeat_task
+    # Main-heartbeat task lives in RedisClient().tasks; cancelled in its wrapup.
     if not CONFIG.debug:
         await RedisClient().wrapup()
         await MongoQueue().wrapup()
-        await MongoClient().close()
+        await MongoClient().wrapup()
 
     # Wait for loguru to complete
     await cleanup()

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -1,7 +1,9 @@
 import asyncio
+import contextlib
 import os
 import signal
 import sys
+from datetime import datetime
 from multiprocessing import Process
 
 import uvloop
@@ -14,7 +16,11 @@ from retriever.lookup.subclass import SubclassMapping
 from retriever.metadata.optable import OpTableManager
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MongoClient, MongoQueue
-from retriever.utils.redis import RedisClient
+from retriever.utils.redis import (
+    PROCESS_TTL_SECONDS,
+    RedisClient,
+    heartbeat,
+)
 from retriever.utils.telemetry import configure_telemetry
 
 
@@ -29,6 +35,22 @@ async def _background_async() -> None:
     await MongoQueue().initialize()
     add_mongo_sink()
     await RedisClient().initialize()
+
+    background_pid = os.getpid()
+    background_started_at = datetime.now().astimezone()
+    await RedisClient().register_background(
+        background_pid, background_started_at, PROCESS_TTL_SECONDS
+    )
+    heartbeat_task = asyncio.create_task(
+        heartbeat(
+            lambda: RedisClient().register_background(
+                background_pid, background_started_at, PROCESS_TTL_SECONDS
+            ),
+            role_label="Background",
+        ),
+        name="background-heartbeat",
+    )
+
     await tier_manager.connect_drivers()
     metakg_manager = OpTableManager(leader=True)
     await metakg_manager.initialize()
@@ -46,6 +68,9 @@ async def _background_async() -> None:
 
     # /// WRAPUP ///
 
+    heartbeat_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await heartbeat_task
     await SubclassMapping().wrapup()
     await metakg_manager.wrapup()
     await RedisClient().wrapup()

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -10,18 +10,16 @@ import uvloop
 from loguru import logger
 from uvicorn.supervisors.multiprocess import SIGNALS
 
+from retriever.config.general import CONFIG
 from retriever.config.logger import configure_logging
 from retriever.data_tiers import tier_manager
 from retriever.lookup.subclass import SubclassMapping
 from retriever.metadata.optable import OpTableManager
+from retriever.utils.general import tolerate_init
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MongoClient, MongoQueue
 from retriever.utils.orphan_detection import periodically_mark_orphans
-from retriever.utils.redis import (
-    PROCESS_TTL_SECONDS,
-    RedisClient,
-    heartbeat,
-)
+from retriever.utils.redis import RedisClient
 from retriever.utils.telemetry import configure_telemetry
 
 
@@ -39,23 +37,28 @@ async def _background_async() -> None:
 
     background_pid = os.getpid()
     background_started_at = datetime.now().astimezone()
-    await RedisClient().register_background(
-        background_pid, background_started_at, PROCESS_TTL_SECONDS
-    )
-    heartbeat_task = asyncio.create_task(
-        heartbeat(
-            lambda: RedisClient().register_background(
-                background_pid, background_started_at, PROCESS_TTL_SECONDS
-            ),
-            role_label="Background",
+    await tolerate_init(
+        "Background registration",
+        RedisClient().register_background(
+            background_pid, background_started_at, CONFIG.redis.process_ttl_seconds
         ),
-        name="background-heartbeat",
+    )
+    RedisClient().start_heartbeat(
+        lambda: RedisClient().register_background(
+            background_pid, background_started_at, CONFIG.redis.process_ttl_seconds
+        ),
+        role_label="Background",
     )
 
-    await tier_manager.connect_drivers()
-    metakg_manager = OpTableManager(leader=True)
-    await metakg_manager.initialize()
-    await SubclassMapping(leader=True).initialize()
+    # The leader doesn't see query traffic, so opt into periodic backend pings.
+    tier_manager.enable_periodic_healthchecks()
+    await tier_manager.initialize_drivers()
+    metakg_manager = OpTableManager()
+    metakg_manager.promote_to_leader()
+    await tolerate_init("OpTable build", metakg_manager.initialize())
+    subclass_manager = SubclassMapping()
+    subclass_manager.promote_to_leader()
+    await tolerate_init("Subclass map build", subclass_manager.initialize())
     orphan_task = asyncio.create_task(
         periodically_mark_orphans(), name="orphan-detection"
     )
@@ -75,14 +78,12 @@ async def _background_async() -> None:
     orphan_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await orphan_task
-    heartbeat_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await heartbeat_task
+    # Heartbeat task lives in RedisClient().tasks; cancelled in its wrapup.
     await SubclassMapping().wrapup()
     await metakg_manager.wrapup()
     await RedisClient().wrapup()
     await MongoQueue().wrapup()
-    await MongoClient().close()
+    await MongoClient().wrapup()
 
 
 def background_process() -> None:

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -16,6 +16,7 @@ from retriever.lookup.subclass import SubclassMapping
 from retriever.metadata.optable import OpTableManager
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MongoClient, MongoQueue
+from retriever.utils.orphan_detection import periodically_mark_orphans
 from retriever.utils.redis import (
     PROCESS_TTL_SECONDS,
     RedisClient,
@@ -55,6 +56,9 @@ async def _background_async() -> None:
     metakg_manager = OpTableManager(leader=True)
     await metakg_manager.initialize()
     await SubclassMapping(leader=True).initialize()
+    orphan_task = asyncio.create_task(
+        periodically_mark_orphans(), name="orphan-detection"
+    )
     logger.success("Background process setup complete!")
 
     # /// MAIN LOOP ///
@@ -68,6 +72,9 @@ async def _background_async() -> None:
 
     # /// WRAPUP ///
 
+    orphan_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await orphan_task
     heartbeat_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await heartbeat_task

--- a/src/retriever/config/general.py
+++ b/src/retriever/config/general.py
@@ -177,6 +177,12 @@ class JobSettings(BaseModel):
     callback: CallbackSettings = CallbackSettings()
     lookup: LookupSettings = LookupSettings()
     metakg: MetaKGSettings = MetaKGSettings()
+    orphan_check_interval: Annotated[
+        int,
+        Field(
+            description="Interval in seconds between orphan-job detection sweeps. Set to -1 to disable."
+        ),
+    ] = 120
     ttl: Annotated[
         int,
         Field(

--- a/src/retriever/config/general.py
+++ b/src/retriever/config/general.py
@@ -62,6 +62,18 @@ class RedisSettings(BaseModel):
             description="Time in seconds to wait for batched tasks to finish before force-quitting."
         ),
     ] = 3
+    heartbeat_interval_seconds: Annotated[
+        int,
+        Field(
+            description="Cadence at which workers / background / main re-register their process entry."
+        ),
+    ] = 60
+    process_ttl_seconds: Annotated[
+        int,
+        Field(
+            description="TTL on each registered process entry; set to several heartbeat intervals so a single missed refresh doesn't drop the entry."
+        ),
+    ] = 300
 
 
 class MongoSettings(BaseModel):
@@ -250,7 +262,7 @@ class Tier1Settings(BaseModel):
 class GandalfSettings(BaseModel):
     """Settings for the Tier 0 Gandalf interface."""
 
-    host: str = "localhost"
+    host: str = "http://localhost"
     port: int = 443
     query_timeout: Annotated[
         int,

--- a/src/retriever/config/openapi.py
+++ b/src/retriever/config/openapi.py
@@ -138,7 +138,7 @@ class ResponseDescriptions(BaseModel):
         "200": "The present config of the server, with secrets removed."
     }
     status: dict[str, str] = {
-        "root": "Health snapshot — version, processes, dependencies, freshness.",
+        "root": "Health snapshot - version, processes, dependencies, freshness.",
         "jobs": "Full per-job status (metadata + query/response geometry).",
         "active": "Currently in-flight jobs, newest first.",
         "stuck": "Active jobs running past the `min_age` threshold (default 1h).",

--- a/src/retriever/config/openapi.py
+++ b/src/retriever/config/openapi.py
@@ -137,6 +137,22 @@ class ResponseDescriptions(BaseModel):
     config: dict[str, str] = {
         "200": "The present config of the server, with secrets removed."
     }
+    status: dict[str, str] = {
+        "root": "Health snapshot — version, processes, dependencies, freshness.",
+        "jobs": "Full per-job status (metadata + query/response geometry).",
+        "active": "Currently in-flight jobs, newest first.",
+        "stuck": "Active jobs running past the `min_age` threshold (default 1h).",
+        "counts": "Status breakdown across three fixed windows (24h, week, all time).",
+        "timeline": "Time-bucketed throughput counts for charting.",
+        "durations": "Aggregate runtime stats (min/max/avg + percentiles).",
+        "submitters": "Per-submitter activity leaderboard.",
+        "tiers": "Per-tier activity and duration percentiles.",
+        "submitter_tier_stats": "Per-(submitter, tier) cell stats; drives the heatmaps view.",
+        "failure_breakdown": "Failure-status counts pivoted by submitter or by tier.",
+        "completed": "Paged scan of successfully-terminated jobs.",
+        "failed": "Paged scan of failed/errored terminal jobs.",
+        "server_logs": "Logs not associated with any job.",
+    }
 
 
 class ServerConfig(CommentedSettings):
@@ -167,6 +183,7 @@ class OpenAPIConfig(CommentedSettings):
             Tag(name="query"),
             Tag(name="asyncquery"),
             Tag(name="asyncquery_status"),
+            Tag(name="status"),
             Tag(name="translator"),
             Tag(name="trapi"),
             Tag(name="biothings"),

--- a/src/retriever/data_tiers/base_driver.py
+++ b/src/retriever/data_tiers/base_driver.py
@@ -4,51 +4,32 @@ from typing import Any
 from retriever.types.general import EntityToEntityMapping
 from retriever.types.metakg import Operation, OperationNode
 from retriever.types.trapi import BiolinkEntity
-from retriever.utils.general import Singleton
+from retriever.utils.backend_client import BackendClient
 
 
-class DatabaseDriver(ABC, metaclass=Singleton):
-    """A driver which handles interfacing with a given database backend.
+class DatabaseDriver(BackendClient, ABC):
+    """Driver interface to a database backend; queries are in the backend's own language."""
 
-    The driver is completely abstracted from TRAPI, receiving a query in its own language
-    and responding in whatever format.
-    """
-
-    _failed: bool = False
-
-    @property
-    def is_failed(self) -> bool:
-        """Returns True if the backend connection has failed unrecoverably."""
-        return self._failed
-
-    @abstractmethod
-    async def connect(self) -> None:
-        """Initialize a persistent connection to the database backend.
-
-        This method should be called in server.py lifespan.
-        """
+    healthcheck_interval: float | None = None
+    """Tier drivers ping on-demand; query callers nudge `request_health_check()` on failure."""
 
     @abstractmethod
     async def run_query(self, query: Any, *args: Any, **kwargs: Any) -> Any:
         """Run a query against the database backend and return the result."""
 
     @abstractmethod
-    async def close(self) -> None:
-        """Close the database connection so the server can wrap up.
-
-        This method should be called in server.py lifespan.
-        """
-
-    @abstractmethod
-    async def get_metadata(self) -> dict[str, Any] | None:
-        """Return metadata that can be used to obtain operations."""
+    async def get_metadata(self, bypass_cache: bool = False) -> dict[str, Any] | None:
+        """Backend metadata; `bypass_cache=True` forces a live fetch."""
 
     @abstractmethod
     async def get_operations(
         self,
+        bypass_cache: bool = False,
     ) -> tuple[list[Operation], dict[BiolinkEntity, OperationNode]]:
-        """Return Operations and Nodes exposed by this driver."""
+        """Operations and Nodes from this driver; `bypass_cache=True` forces a live fetch."""
 
     @abstractmethod
-    async def get_subclass_mapping(self) -> EntityToEntityMapping:
-        """Return a mapping of nodes to their ontological descendants."""
+    async def get_subclass_mapping(
+        self, bypass_cache: bool = False
+    ) -> EntityToEntityMapping:
+        """Nodes to ontological descendants; `bypass_cache=True` forces a live fetch."""

--- a/src/retriever/data_tiers/tier_0/base_query.py
+++ b/src/retriever/data_tiers/tier_0/base_query.py
@@ -76,7 +76,8 @@ class Tier0Query(ABC):
 
             return LookupArtifacts(results, kgraph, aux_graphs, self.job_log.get_logs())
         except Exception as e:
-            if isinstance(e, TimeoutError):
+            timed_out = isinstance(e, TimeoutError)
+            if timed_out:
                 self.job_log.error("Tier 0 operation timed out.")
             elif not isinstance(e, asyncio.exceptions.CancelledError):
                 self.job_log.exception(
@@ -87,7 +88,7 @@ class Tier0Query(ABC):
                 KnowledgeGraphDict(nodes={}, edges={}),
                 {},
                 self.job_log.get_logs(),
-                error=True,
+                status="TimedOut" if timed_out else "Failed",
             )
 
     @abstractmethod

--- a/src/retriever/data_tiers/tier_0/gandalf/driver.py
+++ b/src/retriever/data_tiers/tier_0/gandalf/driver.py
@@ -29,20 +29,72 @@ class GandalfDriver(DatabaseDriver):
     connect_retries: int
 
     _http_session: httpx.AsyncClient | None = None
-
-    _failed: bool = False
+    _session_lock: asyncio.Lock
 
     def __init__(
         self,
     ) -> None:
         """Initialize the Gandalf driver with connection settings."""
+        super().__init__()
         self.settings = CONFIG.tier0.gandalf
         self.query_timeout = self.settings.query_timeout
         self.connect_retries = self.settings.connect_retries
         self._http_session = None
+        self._session_lock = asyncio.Lock()
 
         self.endpoint = self.settings.http_endpoint
         self.metadata = None
+
+    async def _ensure_session(self) -> None:
+        """Rebuild the HTTP session via `_establish_connection` if it has been nulled.
+
+        Locks so concurrent run_query calls don't overlap in rebuilding client.
+        """
+        if self._http_session is not None:
+            return
+        async with self._session_lock:
+            if self._http_session is not None:
+                return
+            await self._establish_connection()
+
+    @override
+    async def ping(self) -> None:
+        """HEAD the base endpoint; 405 or 2xx means up."""
+        await self._ensure_session()
+        assert self._http_session is not None
+        response = await self._http_session.head(
+            self.endpoint,
+            timeout=self.query_timeout,
+        )
+        if response.status_code == HTTPStatus.METHOD_NOT_ALLOWED:
+            return
+        response.raise_for_status()
+
+    @override
+    def is_outage_error(self, exc: BaseException) -> bool:
+        """4xx HTTP responses are query problems, not outages - except 404 (endpoint missing)."""
+        if not super().is_outage_error(exc):
+            return False
+        if isinstance(exc, httpx.HTTPStatusError):
+            code = exc.response.status_code
+            if code == HTTPStatus.NOT_FOUND:
+                return True
+            if HTTPStatus.BAD_REQUEST <= code < HTTPStatus.INTERNAL_SERVER_ERROR:
+                return False
+        return True
+
+    @override
+    def _handle_ping_failure(self, exc: BaseException) -> None:
+        super()._handle_ping_failure(exc)
+        loop_closed = isinstance(exc, RuntimeError) and "Event loop is closed" in str(
+            exc
+        )
+        if loop_closed or isinstance(exc, httpx.PoolTimeout):
+            # Loop-closed: session is bound to a dead loop, can't await aclose.
+            # PoolTimeout: httpx client is effectively dead
+            # see https://github.com/encode/httpx/discussions/2556
+            # Either way, drop the reference and let `_ensure_session` rebuild.
+            self._http_session = None
 
     @override
     async def run_query(
@@ -70,15 +122,20 @@ class GandalfDriver(DatabaseDriver):
             otel_span = None
 
         try:
+            await self._ensure_session()
             result = await self._run_http_query(
                 query_json,
             )
         except TimeoutError as e:
             if otel_span is not None:
                 otel_span.add_event("gandalf_query_timeout")
+            self.request_health_check()
             raise TimeoutError(
                 f"Gandalf query exceeded {self.query_timeout}s timeout"
             ) from e
+        except Exception:
+            self.request_health_check()
+            raise
 
         if otel_span is not None:
             otel_span.add_event("gandalf_query_end")
@@ -97,7 +154,8 @@ class GandalfDriver(DatabaseDriver):
         Returns:
             Parsed response
         """
-        assert self._http_session is not None, "HTTP session not initialized"
+        if self._http_session is None:
+            raise RuntimeError("HTTP session not initialized")
 
         start = time.time()
         log.debug("Querying Gandalf...")
@@ -133,8 +191,17 @@ class GandalfDriver(DatabaseDriver):
             ) from error
 
     @override
-    async def connect(self, retries: int = 0) -> None:
-        """Connect to Gandalf using selected protocol."""
+    async def initialize(self) -> None:
+        """Establish the HTTP session, probe Gandalf, and start the health loop."""
+        self.on_recover(self._fetch_metadata)
+        try:
+            await self._establish_connection()
+        except Exception as exc:
+            self._handle_ping_failure(exc)
+        await super().initialize()
+
+    async def _establish_connection(self, retries: int = 0) -> None:
+        """Connect to Gandalf with retry/backoff. Raises if all retries fail."""
         log.info("Checking Gandalf connection...")
         try:
             await self._connect_http()
@@ -148,23 +215,27 @@ class GandalfDriver(DatabaseDriver):
                     Could not establish connection to Gandalf via http,
                     trying again... retry {retries + 1}
                 """)
-                await self.connect(retries + 1)
+                await self._establish_connection(retries + 1)
             else:
                 log.error(f"Could not establish connection to Gandalf, error: {e}")
-                self._failed = True
                 raise e
 
     async def _connect_http(self) -> None:
-        """Establish HTTP connection to Gandalf."""
+        """Establish HTTP connection to Gandalf and load fresh metadata."""
         self._http_session = httpx.AsyncClient()
-        # Test connection with a simple query
+        await self._fetch_metadata()
+
+    async def _fetch_metadata(self) -> None:
+        """Pull fresh metadata from Gandalf into the in-process cache."""
+        if self._http_session is None:
+            raise RuntimeError("HTTP session not initialized")
         response = await self._http_session.get(
             f"{self.endpoint}/metadata",
             timeout=self.query_timeout,
         )
         if response.status_code != HTTPStatus.OK:
             raise ConnectionError(
-                f"HTTP connection failed with status {response.status_code}: {response.text}"
+                f"HTTP metadata fetch failed with status {response.status_code}: {response.text}"
             )
         self.metadata = response.json()
 
@@ -177,30 +248,29 @@ class GandalfDriver(DatabaseDriver):
             self._http_session = None
 
     @override
-    async def close(self) -> None:
-        """Close the connection to Gandalf and clean up resources."""
+    async def wrapup(self) -> None:
+        """Cancel the health loop first, then tear down the HTTP session."""
+        await super().wrapup()
         await self._cleanup_connections()
 
     @override
-    async def get_metadata(self) -> dict[str, Any] | None:
-        """Queries Gandalf for the active schema's metadata mapping.
-
-        The mapping is stored as a msgpack-serialized JSON blob in the
-        schema_metadata_mapping field. This method retrieves and deserializes it
-        for the active schema version.
-
-        The result is cached per-version with a 5-minute TTL.
-
-        Returns:
-            Deserialized mapping dictionary, or None if not found or on error.
-        """
+    async def get_metadata(self, bypass_cache: bool = False) -> dict[str, Any] | None:
+        """Cached metadata; on `bypass_cache=True` refresh first, falling back to cache on failure."""
+        if bypass_cache and self._http_session is not None:
+            try:
+                await self._fetch_metadata()
+            except Exception as exc:
+                log.warning(
+                    f"Gandalf metadata refresh failed; using cached copy. Error: {exc}"
+                )
         return self.metadata
 
     @override
     async def get_operations(
         self,
+        bypass_cache: bool = False,
     ) -> tuple[list[Operation], dict[BiolinkEntity, OperationNode]]:
-        metadata = await self.get_metadata()
+        metadata = await self.get_metadata(bypass_cache=bypass_cache)
         if metadata is None:
             raise ValueError(
                 "Unable to obtain metadata from backend, cannot parse operations."
@@ -211,5 +281,7 @@ class GandalfDriver(DatabaseDriver):
         return operations, nodes
 
     @override
-    async def get_subclass_mapping(self) -> EntityToEntityMapping:
+    async def get_subclass_mapping(
+        self, bypass_cache: bool = False
+    ) -> EntityToEntityMapping:
         raise NotImplementedError("Tier 0 does not implement subclass mapping.")

--- a/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/driver.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from typing import Any, cast, override
 
 import orjson
@@ -46,7 +47,42 @@ class ElasticSearchDriver(DatabaseDriver):
     """An Elasticsearch driver."""
 
     es_connection: AsyncElasticsearch | None = None
-    _failed: bool = False
+
+    def __init__(self) -> None:
+        """Initialize state. Connection is built lazily by `connect()`."""
+        super().__init__()
+        self.es_connection = None
+
+    @override
+    async def ping(self) -> None:
+        """Probe Elasticsearch via the client `ping()`; raises on failure."""
+        if self.es_connection is None:
+            self.setup_es_connection()
+        if self.es_connection is None:
+            raise RuntimeError("ES connection not initialized")
+        if not await self.es_connection.ping():
+            raise ConnectionError("Elasticsearch ping returned False.")
+
+    @override
+    def is_outage_error(self, exc: BaseException) -> bool:
+        """ES 4xx ApiError responses are query problems, not outages - except 404."""
+        if not super().is_outage_error(exc):
+            return False
+        if isinstance(exc, es_exceptions.ApiError):
+            code = exc.status_code
+            if code == 404:  # noqa: PLR2004
+                return True
+            if 400 <= code < 500:  # noqa: PLR2004
+                return False
+        return True
+
+    @override
+    def _handle_ping_failure(self, exc: BaseException) -> None:
+        super()._handle_ping_failure(exc)
+        if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+            # Stale client is bound to the dead loop; can't await close on it.
+            # Drop the reference and let the next ping lazy-create a fresh client.
+            self.es_connection = None
 
     def setup_es_connection(self) -> None:
         """Setup connection to Elasticsearch instance."""
@@ -76,12 +112,12 @@ class ElasticSearchDriver(DatabaseDriver):
         """Retry connection to Elasticsearch and raise exception if retries exceeded."""
         # Keep trying to connect, if allowed
         if retries <= CONFIG.tier1.elasticsearch.connect_retries:
-            await self.close()
+            await self._close_connection()
             await asyncio.sleep(1)
             log.error(
                 f"Could not establish connection to elasticsearch_tests, trying again... retry {retries + 1}"
             )
-            return await self.connect(retries + 1)
+            return await self._establish_connection(retries + 1)
 
         # Retry limit reached
         try:
@@ -92,10 +128,9 @@ class ElasticSearchDriver(DatabaseDriver):
             log.error(
                 f"Could not establish connection to elasticsearch_tests, error: {e}"
             )
-            self._failed = True
             raise e
         finally:
-            await self.close()
+            await self._close_connection()
 
         # Theoretical corner case, when ping() failed but connection_info() succeeded
         log.error(
@@ -106,8 +141,29 @@ class ElasticSearchDriver(DatabaseDriver):
         )
 
     @override
-    async def connect(self, retries: int = 0) -> None:
-        """Initialize a persistent connection to Elasticsearch instance."""
+    async def initialize(self) -> None:
+        """Establish the ES connection, probe, and start the health loop."""
+        self.on_recover(self._refresh_metadata_cache)
+        try:
+            await self._establish_connection()
+        except Exception as exc:
+            self._handle_ping_failure(exc)
+        await super().initialize()
+
+    async def _refresh_metadata_cache(self) -> None:
+        """Repopulate the in-process metadata + ubergraph cache from live ES."""
+        if self.es_connection is None:
+            return
+        with contextlib.suppress(Exception):
+            _ = await get_t1_metadata(
+                self.es_connection,
+                CONFIG.tier1.elasticsearch.index_name,
+                bypass_cache=True,
+            )
+            _ = await get_ubergraph_info(self.es_connection, bypass_cache=True)
+
+    async def _establish_connection(self, retries: int = 0) -> None:
+        """Connect to Elasticsearch with retry/backoff. Raises if all retries fail."""
         log.info("Checking ElasticSearch connection...")
 
         if self.es_connection is None:
@@ -119,21 +175,29 @@ class ElasticSearchDriver(DatabaseDriver):
         if not is_connected:
             await self.retry_es_connection(retries)
 
-    @override
-    async def close(self) -> None:
-        """Close connection to Elasticsearch instance, if present."""
+    async def _close_connection(self) -> None:
+        """Close the ES client connection. Reusable from retry paths."""
         if self.es_connection is not None:
             await self.es_connection.close()
         self.es_connection = None
 
+    @override
+    async def wrapup(self) -> None:
+        """Cancel the health loop first, then close the ES connection."""
+        await super().wrapup()
+        await self._close_connection()
+
     async def run(
-        self, query: ESPayload | list[ESPayload], bypass_cache: bool = False
+        self,
+        query: ESPayload | list[ESPayload],
+        bypass_cache: bool = False,
+        retries: int = 0,
     ) -> list[ESEdge] | list[list[ESEdge]]:
-        """Execute query logic."""
+        """Execute query logic; one same-client retry on `ConnectionError`."""
         # Check ES connection instance
         if self.es_connection is None:
             raise RuntimeError(
-                "Must use ElasticSearchDriver.connect() before running queries."
+                "Must use ElasticSearchDriver.initialize() before running queries."
             )
 
         if bypass_cache:
@@ -157,8 +221,15 @@ class ElasticSearchDriver(DatabaseDriver):
             log.exception(f"query timed out: {e}")
             raise e
         except es_exceptions.ConnectionError:
-            await self.connect()
-            return await self.run(query, bypass_cache=bypass_cache)
+            # One same-client retry covers transient network blips without
+            # touching es_connection (which would race the health loop).
+            if retries < 1:
+                log.debug("ES ConnectionError; retrying once on same client.")
+                await asyncio.sleep(0.1)
+                return await self.run(
+                    query, bypass_cache=bypass_cache, retries=retries + 1
+                )
+            raise
         except es_exceptions.ApiError as e:
             log.exception("Elasticsearch query returned non-200 HTTP status")
             raise e
@@ -179,14 +250,18 @@ class ElasticSearchDriver(DatabaseDriver):
 
         if self.es_connection is None:
             raise RuntimeError(
-                "Must use ElasticSearchDriver.connect() before fetching node metadata."
+                "Must use ElasticSearchDriver.initialize() before fetching node metadata."
             )
 
-        response = await self.es_connection.search(
-            index=index_name,
-            size=1,
-            query={"term": {"id": _curie}},
-        )
+        try:
+            response = await self.es_connection.search(
+                index=index_name,
+                size=1,
+                query={"term": {"id": _curie}},
+            )
+        except Exception:
+            self.request_health_check()
+            raise
         hits = response["hits"]["hits"]
         if len(hits) == 0:
             return None
@@ -214,7 +289,11 @@ class ElasticSearchDriver(DatabaseDriver):
             )
 
         bypass_cache = kwargs.get("bypass_cache", False)
-        query_result = await self.run(query, bypass_cache)
+        try:
+            query_result = await self.run(query, bypass_cache)
+        except Exception:
+            self.request_health_check()
+            raise
         if otel_span is not None:
             otel_span.add_event("elasticsearch_query_end")
 
@@ -287,9 +366,10 @@ class ElasticSearchDriver(DatabaseDriver):
     @override
     async def get_operations(
         self,
+        bypass_cache: bool = False,
     ) -> tuple[list[Operation], dict[BiolinkEntity, OperationNode]]:
         # return await self.legacy_get_metadata()
-        return await self.get_t1_operations()
+        return await self.get_t1_operations(bypass_cache=bypass_cache)
 
     async def get_valid_metadata(
         self, bypass_cache: bool = False
@@ -322,9 +402,12 @@ class ElasticSearchDriver(DatabaseDriver):
 
     async def get_t1_operations(
         self,
+        bypass_cache: bool = False,
     ) -> tuple[list[Operation], dict[BiolinkEntity, OperationNode]]:
         """Get tier1 operations based on metadata."""
-        metadata_blob, indices = await self.get_valid_metadata()
+        metadata_blob, indices = await self.get_valid_metadata(
+            bypass_cache=bypass_cache
+        )
         metadata_list = extract_metadata_entries_from_blob(metadata_blob, indices)
         operations, nodes = await generate_operations(metadata_list)
 

--- a/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
+++ b/src/retriever/data_tiers/tier_1/elasticsearch/meta.py
@@ -3,6 +3,7 @@ import hashlib
 import zlib
 from collections import defaultdict
 from copy import deepcopy
+from types import MappingProxyType
 from typing import Any
 
 import msgpack
@@ -25,6 +26,10 @@ from retriever.utils.redis import RedisClient
 T1MetaData = dict[str, Any]
 
 CACHE_KEY = "TIER1_META"
+
+_LOCAL_CACHE: dict[str, T1MetaData] = {}
+"""Per-process metadata cache. Fronts Redis so the worker still serves
+hits during an outage; saves populate both layers."""
 
 
 async def get_t1_indices(
@@ -53,23 +58,38 @@ def get_stable_hash(key: str) -> str:
 
 
 async def save_metadata_cache(key: str, payload: T1MetaData) -> None:
-    """Wrapper for persist metadata in Redis."""
-    await RedisClient().set(
-        get_stable_hash(key),
-        ormsgpack.packb(payload),
-        compress=True,
-        ttl=CONFIG.job.metakg.build_time,
-    )
+    """Cache `payload` locally; best-effort Redis write skipped while Redis is down."""
+    _LOCAL_CACHE[key] = payload
+    if not RedisClient().up:
+        return
+    try:
+        await RedisClient().set(
+            get_stable_hash(key),
+            ormsgpack.packb(payload),
+            compress=True,
+        )
+    except Exception:
+        log.debug(f"Redis write for {key} failed; serving from local cache.")
 
 
 async def read_metadata_cache(key: str) -> T1MetaData | None:
-    """Wrapper for retrieving persisted metadata in Redis."""
-    redis_key = get_stable_hash(key)
-    metadata_pack = await RedisClient().get(redis_key, compressed=True)
-    if metadata_pack is not None:
-        return ormsgpack.unpackb(metadata_pack)
-
-    return None
+    """Cached metadata preferring local then Redis; `None` on miss or Redis down."""
+    cached = _LOCAL_CACHE.get(key)
+    if cached is not None:
+        return cached
+    if not RedisClient().up:
+        return None
+    try:
+        redis_key = get_stable_hash(key)
+        metadata_pack = await RedisClient().get(redis_key, compressed=True)
+    except Exception:
+        log.debug(f"Redis read for {key} failed; treating as cache miss.")
+        return None
+    if metadata_pack is None:
+        return None
+    payload: T1MetaData = ormsgpack.unpackb(metadata_pack)
+    _LOCAL_CACHE[key] = payload
+    return payload
 
 
 def extract_metadata_entries_from_blob(
@@ -120,28 +140,36 @@ async def get_t1_metadata(
     bypass_cache: bool,
     retries: int = 0,
 ) -> T1MetaData | None:
-    """Caller to orchestrate retrieving t1 metadata."""
+    """T1 metadata, preferring cache; `None` if neither cache nor backend can serve."""
     meta_blob = None if bypass_cache else await read_metadata_cache(CACHE_KEY)
     if not meta_blob:
+        if es_connection is None:
+            return await _cached_fallback(bypass_cache)
         try:
-            if es_connection is None:
-                raise ValueError(
-                    "Invalid Elasticsearch connection. Driver must be initialized and connected."
-                )
             meta_blob = await retrieve_metadata_from_es(es_connection, indices_alias)
             await save_metadata_cache(CACHE_KEY, meta_blob)
-        except ValueError as e:
-            # if exceeds retries or ES connection is invalid, return None
-            if retries == RETRY_LIMIT or str(e).startswith(
-                "Invalid Elasticsearch connection"
-            ):
-                return None
+        except Exception as exc:
+            if retries >= RETRY_LIMIT:
+                log.warning(
+                    f"Failed to retrieve T1 metadata after {RETRY_LIMIT} retries: {exc}"
+                )
+                return await _cached_fallback(bypass_cache)
             return await get_t1_metadata(
                 es_connection, indices_alias, bypass_cache=True, retries=retries + 1
             )
 
     log.success("DINGO Metadata retrieved!")
     return meta_blob
+
+
+async def _cached_fallback(bypass_cache: bool) -> T1MetaData | None:
+    """When `bypass_cache=True` exhausted live retries, fall back to the cached copy."""
+    if not bypass_cache:
+        return None
+    cached = await read_metadata_cache(CACHE_KEY)
+    if cached is not None:
+        log.warning("Live T1 metadata fetch failed; falling back to cached metadata.")
+    return cached
 
 
 def hash_meta_attribute(attr: MetaAttributeDict) -> int:
@@ -294,7 +322,7 @@ async def get_ubergraph_info(
         cached_info = await read_metadata_cache(ubergraph_info_cache_key)
 
         if cached_info is not None:
-            return to_ubergraph_info(cached_info)
+            return MappingProxyType(to_ubergraph_info(cached_info))
     else:
         log.info("cache bypassed for ubergraph info retrieval")
 
@@ -321,4 +349,4 @@ async def get_ubergraph_info(
         return await get_ubergraph_info(es_connection, retries + 1, bypass_cache)
 
     log.success("ubergraph info retrieved!")
-    return cached_info
+    return MappingProxyType(cached_info)

--- a/src/retriever/data_tiers/tier_manager.py
+++ b/src/retriever/data_tiers/tier_manager.py
@@ -27,6 +27,9 @@ QUERY_HANDLERS = dict[str, type[Tier0Query]](
     gandalf=GandalfQuery,
 )
 
+IMPLEMENTED_TIERS: frozenset[TierNumber] = frozenset((0, 1))
+"""Tiers `get_driver` / `get_transpiler` resolve without raising."""
+
 
 def get_driver(tier: TierNumber) -> DatabaseDriver:
     """Get the configured driver for the given tier."""
@@ -48,28 +51,28 @@ def get_transpiler(tier: TierNumber) -> Transpiler:
         raise NotImplementedError(f"Tier {tier} is not yet implemented.")
 
 
-async def connect_drivers() -> None:
-    """Connect all drivers simultaneously, logging failures."""
-    connect_tasks: set[asyncio.Task[None]] = {
+async def initialize_drivers() -> None:
+    """Initialize all drivers simultaneously, logging failures."""
+    init_tasks: set[asyncio.Task[None]] = {
         asyncio.create_task(
-            get_driver(i).connect(), name=f"Tier {i} backend connection"
+            get_driver(i).initialize(), name=f"Tier {i} backend initialize"
         )
         for i in range(2)
     }
 
     def _cancel_tasks() -> None:
-        for task in connect_tasks:
+        for task in init_tasks:
             with contextlib.suppress(asyncio.CancelledError):
                 task.cancel()
 
-    # In case connect tasks run long and user wants to close
+    # In case init tasks run long and user wants to close
     asyncio.get_event_loop().add_signal_handler(SIGTERM, _cancel_tasks)
 
     successes = 0
 
-    while connect_tasks:
+    while init_tasks:
         done, pending = await asyncio.wait(
-            connect_tasks, return_when=asyncio.FIRST_EXCEPTION
+            init_tasks, return_when=asyncio.FIRST_EXCEPTION
         )
 
         for task in done:
@@ -78,7 +81,7 @@ async def connect_drivers() -> None:
             else:
                 successes += 1
 
-        connect_tasks = pending
+        init_tasks = pending
 
     if successes == 0:
         logger.warning(
@@ -86,10 +89,16 @@ async def connect_drivers() -> None:
         )
 
 
-async def close_drivers() -> None:
-    """Close all drivers simultaneously, skipping failures."""
+def enable_periodic_healthchecks(interval: float = 60.0) -> None:
+    """Switch each tier driver to periodic-ping mode; call before `initialize_drivers`."""
+    for tier in range(2):
+        get_driver(tier).healthcheck_interval = interval
+
+
+async def wrapup_drivers() -> None:
+    """Wrap up all drivers simultaneously, skipping failures."""
     close_tasks: set[asyncio.Task[None]] = {
-        asyncio.create_task(get_driver(i).close(), name=f"Tier {i}") for i in range(2)
+        asyncio.create_task(get_driver(i).wrapup(), name=f"Tier {i}") for i in range(2)
     }
 
     while close_tasks:

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -103,6 +103,48 @@ async def async_lookup(
         context.detach(token)
 
 
+def _summarize_execution(
+    ctx: QueryInfo,
+    status: str,
+    results_count: int,
+    duration_ms: int,
+    job_log: TRAPILogger,
+) -> str:
+    """Build the post-execution description and emit a status-appropriate log line.
+
+    `TimedOut` is an internal-only status the query handlers can emit; the
+    caller is expected to collapse it to `Failed` before storing / responding.
+    """
+    match status:
+        case "Success":
+            finish_msg = (
+                f"Execution completed, obtained {results_count} results "
+                f"in {duration_ms}ms."
+            )
+            job_log.success(finish_msg)
+        case "QueryNotTraversable":
+            finish_msg = (
+                "Execution terminated: query graph was not traversable "
+                f"with the current MetaKG (took {duration_ms}ms)."
+            )
+            job_log.warning(finish_msg)
+        case "TimedOut":
+            finish_msg = f"Execution exceeded timeout ({duration_ms}ms > {ctx.timeout * 1000}ms)."
+            job_log.error(finish_msg)
+        case "Failed":
+            finish_msg = (
+                "Execution failed in query handling; see logs "
+                f"for details (took {duration_ms}ms)."
+            )
+            job_log.error(finish_msg)
+        case _:
+            finish_msg = (
+                f"Execution ended with status {status!r} (took {duration_ms}ms)."
+            )
+            job_log.warning(finish_msg)
+    return finish_msg
+
+
 async def lookup(query: QueryInfo) -> tuple[HTTPStatus, ResponseDict]:
     """Execute a lookup query.
 
@@ -152,17 +194,23 @@ async def lookup(query: QueryInfo) -> tuple[HTTPStatus, ResponseDict]:
             QueryGraphExecutor,
         )
         query_handler = handlers[query.tier or 0](expanded_qgraph, query)
-        results, kgraph, aux_graphs, logs, _error = await query_handler.execute()
+        results, kgraph, aux_graphs, logs, status = await query_handler.execute()
 
         job_log.log_deque.extend(logs)
 
         job_log.info(f"Collected {len(results)} results from query task.")
 
-        end_time = time.time()
-        finish_msg = f"Execution completed, obtained {len(results)} results in {math.ceil((end_time - start_time) * 1000):}ms."
-        job_log.success(finish_msg)
+        duration_ms = math.ceil((time.time() - start_time) * 1000)
+        finish_msg = _summarize_execution(
+            query, status, len(results), duration_ms, job_log
+        )
 
-        response["status"] = "Complete"
+        # `TimedOut` is an internal signal driving the description above;
+        # the wire/storage status collapses to `Failed` per spec.
+        if status == "TimedOut":
+            status = "Failed"
+
+        response["status"] = status
         response["description"] = finish_msg
         response["message"]["results"] = results
         response["message"]["knowledge_graph"] = kgraph
@@ -351,6 +399,7 @@ def tracked_response(
                 aux_graphs=len(response["message"].get("auxiliary_graphs") or {}),
                 results=len(response["message"].get("results") or []),
                 status=(response.get("status") or "Running"),
+                description=response.get("description"),
             ),
         )
     except MongoOutage:

--- a/src/retriever/lookup/lookup.py
+++ b/src/retriever/lookup/lookup.py
@@ -2,6 +2,7 @@ import math
 import time
 from collections import deque
 from copy import deepcopy
+from http import HTTPStatus
 
 import bmt
 import httpx
@@ -23,6 +24,7 @@ from retriever.metadata.optable import (
 from retriever.types.general import QueryInfo
 from retriever.types.trapi import (
     KnowledgeGraphDict,
+    LogEntryDict,
     LogLevel,
     MessageDict,
     ParametersDict,
@@ -32,9 +34,10 @@ from retriever.types.trapi import (
     ResultDict,
 )
 from retriever.types.trapi_pydantic import TierNumber
+from retriever.utils import service_health
 from retriever.utils.calls import get_callback_client
 from retriever.utils.logs import TRAPILogger, trapi_level_to_int
-from retriever.utils.mongo import MongoQueue, ResponseState
+from retriever.utils.mongo import MongoOutage, MongoQueue, ResponseState
 
 tracer = trace.get_tracer("lookup.execution.tracer")
 biolink = bmt.Toolkit()
@@ -43,8 +46,16 @@ OP_TABLE_MANAGER = OpTableManager()
 
 ZSTD_COMPRESSOR = zstandard.ZstdCompressor()
 
+CALLBACK_BODY_LOG_LIMIT = 500
+"""Truncate logged callback response bodies to this many chars."""
 
-async def async_lookup(query: QueryInfo, ctx: dict[str, str]) -> None:
+
+async def async_lookup(
+    query: QueryInfo,
+    ctx: dict[str, str],
+    *,
+    extra_warnings: list[LogEntryDict] | None = None,
+) -> None:
     """Handle running lookup as an async query where the client receives a callback."""
     token = context.attach(propagate.extract(ctx))  # Ensure context propagates
 
@@ -55,24 +66,32 @@ async def async_lookup(query: QueryInfo, ctx: dict[str, str]) -> None:
         job_id = query.job_id
         job_log = TRAPILogger(job_id)
         status, response = await lookup(query)
+        if extra_warnings:
+            response["logs"] = [*(response.get("logs") or []), *extra_warnings]
 
         job_log.debug(f"Sending callback to `{query.body['callback']}`...")
         try:
-            client = get_callback_client()
-            callback_response = await client.post(
-                url=str(query.body["callback"]), json=response
-            )
-            callback_response.raise_for_status()
-            job_log.debug("Callback sent successfully.")
+            async with get_callback_client() as client:
+                callback_response = await client.post(
+                    url=str(query.body["callback"]), json=response
+                )
+                callback_response.raise_for_status()
+                job_log.debug("Callback sent successfully.")
         except httpx.HTTPStatusError as error:
             job_log.exception(
                 f"Callback returned erroneous status {error.response.status_code}"
             )
-            job_log.error(f"Response body was {error.response.text}")
+            job_log.error(
+                f"Response body was {error.response.text[:CALLBACK_BODY_LOG_LIMIT]}"
+            )
         except httpx.HTTPError:
             job_log.exception(
-                "An unhandled exception occured while making response callback."
+                "An unhandled httpx error occurred while making response callback."
             )
+        except Exception:
+            # Anything not modeled by httpx (e.g. serialization issues)
+            # gets logged so the background task doesn't crash unnoticed.
+            job_log.exception("Unexpected error during callback delivery.")
 
         # Effectively tack the callback logs onto the end of the response
         response_logs = response.get("logs", []) or []
@@ -84,7 +103,7 @@ async def async_lookup(query: QueryInfo, ctx: dict[str, str]) -> None:
         context.detach(token)
 
 
-async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
+async def lookup(query: QueryInfo) -> tuple[HTTPStatus, ResponseDict]:
     """Execute a lookup query.
 
     Does job state updating regardless of asyncquery for easier debugging.
@@ -108,21 +127,25 @@ async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
 
         # Query graph validation that isn't handled by reasoner_pydantic
         if not passes_validation(query.body, response, job_log) or "paths" in qgraph:
-            return tracked_response(422, query, response, job_log)
+            return tracked_response(
+                HTTPStatus.UNPROCESSABLE_ENTITY, query, response, job_log
+            )
 
         expanded_qgraph = expand_qgraph(deepcopy(qgraph), job_log)
 
         if not await qgraph_supported(
             expanded_qgraph, response, job_log, query.tier or 0
         ):
-            return tracked_response(200, query, response, job_log)
+            return tracked_response(HTTPStatus.OK, query, response, job_log)
 
-        if tier_manager.get_driver(query.tier or 0).is_failed:
+        if not tier_manager.get_driver(query.tier or 0).up:
             msg = f"Tier {query.tier or 0} backend connection failed, query terminates."
             job_log.error(msg)
             response["status"] = "Failed"
             response["description"] = msg
-            return tracked_response(424, query, response, job_log)
+            return tracked_response(
+                HTTPStatus.FAILED_DEPENDENCY, query, response, job_log
+            )
 
         handlers = (
             tier_manager.QUERY_HANDLERS[CONFIG.tier0.backend],
@@ -144,7 +167,7 @@ async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
         response["message"]["results"] = results
         response["message"]["knowledge_graph"] = kgraph
         response["message"]["auxiliary_graphs"] = aux_graphs
-        return tracked_response(200, query, response, job_log)
+        return tracked_response(HTTPStatus.OK, query, response, job_log)
 
     except Exception:
         job_log.error(
@@ -155,7 +178,9 @@ async def lookup(query: QueryInfo) -> tuple[int, ResponseDict]:
         response["description"] = (
             "Execution failed due to an unhandled error. See the logs for more details."
         )
-        return tracked_response(500, query, response, job_log)
+        return tracked_response(
+            HTTPStatus.INTERNAL_SERVER_ERROR, query, response, job_log
+        )
 
 
 def initialize_lookup(query: QueryInfo) -> tuple[str, TRAPILogger, ResponseDict]:
@@ -294,8 +319,11 @@ async def qgraph_supported(
 
 
 def tracked_response(
-    status: int, query: QueryInfo, response: ResponseDict, job_log: TRAPILogger
-) -> tuple[int, ResponseDict]:
+    status: HTTPStatus,
+    query: QueryInfo,
+    response: ResponseDict,
+    job_log: TRAPILogger,
+) -> tuple[HTTPStatus, ResponseDict]:
     """Utility function for response handling."""
     # Filter for desired log_level
     desired_log_level = trapi_level_to_int(
@@ -312,16 +340,22 @@ def tracked_response(
 
     # Cast because TypedDict has some *really annoying* interactions with more general dicts
     kgraph = response["message"].get("knowledge_graph") or {}
-    MONGO_QUEUE.put(
-        "job_state",
-        ResponseState(
-            job_id=query.job_id,
-            response=ZSTD_COMPRESSOR.compress(ormsgpack.packb(response)),
-            knodes=len(kgraph.get("nodes") or {}),
-            kedges=len(kgraph.get("edges") or {}),
-            aux_graphs=len(response["message"].get("auxiliary_graphs") or {}),
-            results=len(response["message"].get("results") or []),
-            status=(response.get("status") or "Running"),
-        ),
-    )
+    try:
+        MONGO_QUEUE.put(
+            "job_state",
+            ResponseState(
+                job_id=query.job_id,
+                response=ZSTD_COMPRESSOR.compress(ormsgpack.packb(response)),
+                knodes=len(kgraph.get("nodes") or {}),
+                kedges=len(kgraph.get("edges") or {}),
+                aux_graphs=len(response["message"].get("auxiliary_graphs") or {}),
+                results=len(response["message"].get("results") or []),
+                status=(response.get("status") or "Running"),
+            ),
+        )
+    except MongoOutage:
+        response["logs"] = [
+            *(response.get("logs") or []),
+            service_health.mongo_outage_warning(),
+        ]
     return status, response

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -44,7 +44,7 @@ from retriever.types.trapi import (
     QueryGraphDict,
     ResultDict,
 )
-from retriever.utils import biolink, service_health
+from retriever.utils import service_health
 from retriever.utils.general import EmptyIteratorError, merge_iterators
 from retriever.utils.logs import TRAPILogger
 from retriever.utils.redis import RedisClient

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -4,7 +4,7 @@ import math
 import time
 from asyncio.tasks import Task
 from collections.abc import AsyncGenerator, Hashable, Iterable
-from typing import cast
+from typing import Literal, cast
 
 from opentelemetry import trace
 
@@ -63,6 +63,14 @@ DISPATCHER = SubqueryDispatcher()
 
 CompletePathName = str
 
+TerminateReason = Literal[
+    "timeout",
+    "subclass_cutoff",
+    "branch_empty_iterator",
+    "no_supporting_knowledge",
+]
+"""Why the QGX was terminated. Used for internal signaling choices."""
+
 
 class QueryGraphExecutor:
     """Handler class for running the QGX algorithm."""
@@ -90,6 +98,7 @@ class QueryGraphExecutor:
 
     locks: dict[Hashable, asyncio.Lock]
     terminate: bool
+    terminate_reason: TerminateReason | None
     start_time: float
     timeout: float
 
@@ -138,6 +147,7 @@ class QueryGraphExecutor:
         }
 
         self.terminate = False
+        self.terminate_reason = None
         self.start_time = 0  # replaced on execute start
 
         self.timeout = self.ctx.timeout
@@ -160,7 +170,11 @@ class QueryGraphExecutor:
                     f"Failed for find operations supporting query edge(s): {list(operation_plan.keys())}"
                 )
                 return LookupArtifacts(
-                    [], self.kgraph, self.aux_graphs, self.job_log.get_logs()
+                    [],
+                    self.kgraph,
+                    self.aux_graphs,
+                    self.job_log.get_logs(),
+                    status="QueryNotTraversable",
                 )
 
             await self.expand_initial_subclasses()
@@ -222,7 +236,17 @@ class QueryGraphExecutor:
             evaluate_set_interpretation(self.qgraph, results, self.job_log)
 
             return LookupArtifacts(
-                results, self.kgraph, self.aux_graphs, self.job_log.get_logs()
+                results,
+                self.kgraph,
+                self.aux_graphs,
+                self.job_log.get_logs(),
+                status=(
+                    "TimedOut"
+                    if self.terminate_reason == "timeout"
+                    else "Failed"
+                    if self.terminate_reason == "subclass_cutoff"
+                    else "Success"
+                ),
             )
         except Exception:
             self.job_log.exception(
@@ -230,7 +254,11 @@ class QueryGraphExecutor:
             )
             timeout_task.cancel()
             return LookupArtifacts(
-                [], self.kgraph, self.aux_graphs, self.job_log.get_logs(), error=True
+                [],
+                self.kgraph,
+                self.aux_graphs,
+                self.job_log.get_logs(),
+                status="Failed",
             )
 
     async def hydrate_missing_nodes(self) -> None:
@@ -338,6 +366,7 @@ class QueryGraphExecutor:
                     f"Qnode `{qnode_id}` curie {curie} found {len(descendants)} descendants, exceeding cutoff of {CONFIG.job.lookup.subclass_cutoff}. For stability, your query terminates."
                 )
                 self.terminate = True
+                self.terminate_reason = "subclass_cutoff"
                 return []
 
             if not descendants:
@@ -373,6 +402,7 @@ class QueryGraphExecutor:
                 f"Branch {Branch.branch_id_to_name(initial_id)} terminated in an unexpected manner."
             )
             self.terminate = True
+            self.terminate_reason = "branch_empty_iterator"
 
         return partials, reconciled
 
@@ -423,6 +453,7 @@ class QueryGraphExecutor:
                     f"QEdge {longest_branch[-2][1]} found no supporting knowledge. No results can be reconciled. Query terminates."
                 )
                 self.terminate = True
+                self.terminate_reason = "no_supporting_knowledge"
                 break
 
             # await asyncio.sleep(0)
@@ -824,5 +855,6 @@ class QueryGraphExecutor:
             await asyncio.sleep(self.timeout)
             self.job_log.error("QGX hit timeout, attempting wrapup...")
             self.terminate = True
+            self.terminate_reason = "timeout"
         except asyncio.CancelledError:
             return

--- a/src/retriever/lookup/qgx.py
+++ b/src/retriever/lookup/qgx.py
@@ -44,9 +44,10 @@ from retriever.types.trapi import (
     QueryGraphDict,
     ResultDict,
 )
-from retriever.utils import biolink
+from retriever.utils import biolink, service_health
 from retriever.utils.general import EmptyIteratorError, merge_iterators
 from retriever.utils.logs import TRAPILogger
+from retriever.utils.redis import RedisClient
 from retriever.utils.trapi import (
     evaluate_set_interpretation,
     initialize_kgraph,
@@ -59,7 +60,6 @@ OP_TABLE_MANAGER = OpTableManager()
 SUBCLASS_MAPPING = SubclassMapping()
 DISPATCHER = SubqueryDispatcher()
 
-# TODO: Set interpretation
 
 CompletePathName = str
 
@@ -86,6 +86,7 @@ class QueryGraphExecutor:
 
     skip_subclassing: bool
     subclass_backmap: dict[CURIE, CURIE]
+    subclass_warning_emitted: bool
 
     locks: dict[Hashable, asyncio.Lock]
     terminate: bool
@@ -126,6 +127,7 @@ class QueryGraphExecutor:
             for edge in self.qgraph["edges"].values()
         )
         self.subclass_backmap = {}
+        self.subclass_warning_emitted = False
 
         # Initialize locks for accessing some of the above
         self.locks = {
@@ -304,9 +306,29 @@ class QueryGraphExecutor:
         ):
             return list(curies)
 
+        # No subclass mapping when Redis is down. Warn once per query,
+        # then skip expansion.
+        if not RedisClient().up:
+            if not self.subclass_warning_emitted:
+                self.job_log.log_deque.append(
+                    service_health.subclass_unavailable_warning()
+                )
+                self.subclass_warning_emitted = True
+            return list(curies)
+
         new_curies = set[CURIE](curies)
         for curie in curies:
             descendants = await SUBCLASS_MAPPING.get(curie)
+
+            # `None` signals Redis went down mid-flight. Attach the warning once and
+            # continue without expansion.
+            if descendants is None:
+                if not self.subclass_warning_emitted:
+                    self.job_log.log_deque.append(
+                        service_health.subclass_unavailable_warning()
+                    )
+                    self.subclass_warning_emitted = True
+                continue
 
             if (
                 CONFIG.job.lookup.subclass_cutoff > 0

--- a/src/retriever/lookup/subclass.py
+++ b/src/retriever/lookup/subclass.py
@@ -11,7 +11,7 @@ from retriever.types.trapi import (
     CURIE,
 )
 from retriever.utils.general import BatchedAction
-from retriever.utils.redis import RedisClient
+from retriever.utils.redis import SUBCLASS_META_KEY, RedisClient
 
 REDIS_CLIENT = RedisClient()
 
@@ -87,6 +87,12 @@ class SubclassMapping(BatchedAction):
                 mapping=packed_mapping,
                 ttl=CONFIG.job.metakg.build_time,
             )
+
+        await REDIS_CLIENT.write_freshness(
+            SUBCLASS_META_KEY,
+            count=len(mapping),
+            ttl=CONFIG.job.metakg.build_time,
+        )
 
         del mapping
         del packed_mapping

--- a/src/retriever/lookup/subclass.py
+++ b/src/retriever/lookup/subclass.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from collections.abc import Callable
 from typing import cast, override
 
@@ -11,7 +12,7 @@ from retriever.types.trapi import (
     CURIE,
 )
 from retriever.utils.general import BatchedAction
-from retriever.utils.redis import SUBCLASS_META_KEY, RedisClient
+from retriever.utils.redis import SUBCLASS_META_KEY, TIER_RECOVERED_CHANNEL, RedisClient
 
 REDIS_CLIENT = RedisClient()
 
@@ -28,15 +29,22 @@ class SubclassMapping(BatchedAction):
     multibatch: bool = True
 
     is_leader: bool = False
-    subscriptions: dict[CURIE, list[Callable[[list[CURIE]], None]]]
+    subscriptions: dict[CURIE, list[Callable[[list[CURIE] | None], None]]]
+    _refresh_lock: asyncio.Lock
+    _pending_refresh: bool = False
 
     redis_setup_batch_size: int = 5000
 
-    def __init__(self, leader: bool = False) -> None:
-        """Initialize an instance."""
-        self.is_leader = leader
+    def __init__(self) -> None:
+        """Initialize without leader role; call `promote_to_leader()` to flip the flag."""
         self.subscriptions = {}
+        self._refresh_lock = asyncio.Lock()
+        self._pending_refresh = False
         super().__init__()
+
+    def promote_to_leader(self) -> None:
+        """Flip this instance to leader mode. Must be called before `initialize()`."""
+        self.is_leader = True
 
     @override
     async def initialize(self) -> None:
@@ -52,58 +60,84 @@ class SubclassMapping(BatchedAction):
             return  # rebuild loop already running
 
         try:
-            await self._reload_mapping()
+            await self.refresh()
             self.tasks.append(asyncio.create_task(self.rebuild()))
         except Exception:
             logger.exception(
                 "Unable to initialize subclass mapping due to below error, proceeding without implicit subclassing..."
             )
 
+        REDIS_CLIENT.on_recover(self.refresh)
+        tier_manager.get_driver(1).on_recover(self.refresh)
+        # Also listen for worker-detected tier 1 recovery via Redis so
+        # the rebuild fires faster than the leader's own periodic ping.
+        with contextlib.suppress(Exception):
+            await REDIS_CLIENT.subscribe(
+                TIER_RECOVERED_CHANNEL, self._on_remote_tier_recover
+            )
+
         return await super().initialize()
 
+    @override
+    async def wrapup(self) -> None:
+        """Unsubscribe the leader's tier-recovery listener, then cancel the rebuild loop."""
+        if self.is_leader:
+            with contextlib.suppress(Exception):
+                await REDIS_CLIENT.unsubscribe(
+                    TIER_RECOVERED_CHANNEL, self._on_remote_tier_recover
+                )
+        await super().wrapup()
+
+    async def _on_remote_tier_recover(self, message: str) -> None:
+        """Refresh when a worker signals tier 1 came back."""
+        # The channel is shared with OpTableManager - filter to tier 1.
+        if message == "1":
+            await self.refresh()
+
+    async def refresh(self) -> None:
+        """Rebuild and publish the subclass mapping; concurrent calls collapse to one trailing rebuild."""
+        self._pending_refresh = True
+        if self._refresh_lock.locked():
+            logger.debug(
+                "Subclass rebuild already in progress; trailing rebuild queued."
+            )
+            return
+        async with self._refresh_lock:
+            while self._pending_refresh:
+                self._pending_refresh = False
+                await self._reload_mapping()
+
     async def _reload_mapping(self) -> None:
-        """Pull the full subclass mapping from tier 1 and push it to Redis in batches."""
+        """Pull the subclass mapping live from tier 1 and write it to Redis in batches."""
         logger.info("Loading subclass mapping...")
-        mapping = await tier_manager.get_driver(1).get_subclass_mapping()
+        # bypass_cache: rebuild must reflect live upstream state, not the
+        # in-process cache (which `meta._LOCAL_CACHE` returns by reference).
+        mapping = await tier_manager.get_driver(1).get_subclass_mapping(
+            bypass_cache=True
+        )
         total = len(mapping)
 
-        # Send to redis in batches to avoid overwhelming it.
         packed_mapping = dict[str, bytes]()
-        while mapping:
-            curie, descendants = mapping.popitem()
+        for curie, descendants in mapping.items():
             packed_mapping[curie] = ormsgpack.packb(descendants)
-
             if len(packed_mapping) >= self.redis_setup_batch_size:
-                await REDIS_CLIENT.hset(
-                    MAPPING_ID,
-                    mapping=packed_mapping,
-                    ttl=CONFIG.job.metakg.build_time,
-                )
+                await REDIS_CLIENT.hset(MAPPING_ID, mapping=packed_mapping)
                 packed_mapping = {}
 
         if packed_mapping:
-            await REDIS_CLIENT.hset(
-                MAPPING_ID,
-                mapping=packed_mapping,
-                ttl=CONFIG.job.metakg.build_time,
-            )
+            await REDIS_CLIENT.hset(MAPPING_ID, mapping=packed_mapping)
 
-        await REDIS_CLIENT.write_freshness(
-            SUBCLASS_META_KEY,
-            count=len(mapping),
-            ttl=CONFIG.job.metakg.build_time,
-        )
+        await REDIS_CLIENT.write_freshness(SUBCLASS_META_KEY, count=total)
 
-        del mapping
         del packed_mapping
 
         logger.success(f"Subclass mapping refreshed with {total} ancestors.")
 
-    async def get(self, curie: CURIE) -> list[CURIE]:
-        """Get the descendants of a given CURIE."""
-        future = asyncio.Future[list[CURIE]]()
+    async def get(self, curie: CURIE) -> list[CURIE] | None:
+        """Descendants of `curie`; `None` when the mapping is unavailable, `[]` when none exist."""
+        future = asyncio.Future[list[CURIE] | None]()
 
-        def return_result(curies: list[CURIE]) -> None:
+        def return_result(curies: list[CURIE] | None) -> None:
             if not future.done():
                 future.set_result(curies)
 
@@ -113,21 +147,36 @@ class SubclassMapping(BatchedAction):
         return await future
 
     async def batch_expand(self, batch: list[CURIE]) -> None:
-        """Get a batch of expanded curies and propagate them to original callers."""
+        """Expand a batch of curies; signal `None` to callbacks when Redis is unavailable."""
         if len(batch) == 0:
             return
         logger.trace(f"Batch expand batch of {len(batch)}")
-        descendants_packed = await REDIS_CLIENT.hmget(MAPPING_ID, *batch)
+        if not REDIS_CLIENT.up:
+            self._broadcast(batch, None)
+            return
+        try:
+            descendants_packed = await REDIS_CLIENT.hmget(MAPPING_ID, *batch)
+        except Exception:
+            logger.debug(
+                "Subclass batch_expand failed against Redis; signaling unavailable."
+            )
+            self._broadcast(batch, None)
+            return
         for curie, desc_packed in zip(batch, descendants_packed, strict=True):
-            descs = []
+            descs: list[CURIE] = []
             if desc_packed is not None:
                 descs = cast(list[CURIE], ormsgpack.unpackb(desc_packed))
 
             # Pop atomically: callbacks can't be skipped by list mutation, and
             # the key doesn't linger forever.
-            callbacks = self.subscriptions.pop(curie, None) or []
-            for callback in callbacks:
+            for callback in self.subscriptions.pop(curie, None) or []:
                 callback(descs)
+
+    def _broadcast(self, batch: list[CURIE], value: list[CURIE] | None) -> None:
+        """Resolve every pending future for `batch` with the same `value`."""
+        for curie in batch:
+            for callback in self.subscriptions.pop(curie, None) or []:
+                callback(value)
 
     async def rebuild(self) -> None:
         """Periodically rebuild the mapping."""
@@ -138,10 +187,10 @@ class SubclassMapping(BatchedAction):
             while True:
                 await asyncio.sleep(interval)
                 try:
-                    await self._reload_mapping()
+                    await self.refresh()
                 except Exception:
                     logger.exception(
-                        f"Subclass mapping rebuild failed, rety in {interval}s."
+                        f"Subclass mapping rebuild failed, retry in {interval}s."
                     )
         except asyncio.CancelledError:
             return

--- a/src/retriever/lookup/utils.py
+++ b/src/retriever/lookup/utils.py
@@ -99,8 +99,10 @@ def get_submitter(query: QueryInfo) -> str:
     """Extract the submitter from a query, if it's provided."""
     body = query.body
 
-    if submitter := body is not None and body.get("submitter"):
-        return str(submitter)
+    submitter = body is not None and body.get("submitter")
+
+    if submitter:
+        return submitter
     else:
         return "not_provided"
 

--- a/src/retriever/metadata/metadata.py
+++ b/src/retriever/metadata/metadata.py
@@ -1,24 +1,33 @@
 import asyncio
+from http import HTTPStatus
 
 from retriever.data_tiers.tier_manager import get_driver
 from retriever.types.dingo import DINGOMetadata
 from retriever.types.general import ErrorDetail, QueryInfo
+from retriever.utils import service_health
 
 
 async def get_metadata(
     query: QueryInfo,
-) -> tuple[int, DINGOMetadata | ErrorDetail]:
+) -> tuple[HTTPStatus, DINGOMetadata | ErrorDetail]:
     """Obtain tier-specific metadata.
 
     Returns:
-        A tuple of HTTP status code, response body.
+        A tuple of HTTP status code, response body. None from the
+        driver indicates the tier backend is unreachable and no cache
+        layer can serve - surface as 424.
     """
+    driver = get_driver(query.tier or 0)
     try:
         async with asyncio.timeout(query.timeout if query.timeout != -1 else None):
-            driver = get_driver(query.tier or 0)
             metadata = await driver.get_metadata()
             if metadata is None:
-                return 500, ErrorDetail(detail="Metadata could not be retrieved.")
-            return 200, DINGOMetadata(**metadata)
+                return HTTPStatus.FAILED_DEPENDENCY, service_health.outage_detail(
+                    f"Tier {query.tier or 0} is unavailable; metadata cannot be retrieved.",
+                    driver,
+                )
+            return HTTPStatus.OK, DINGOMetadata(**metadata)
     except TimeoutError:
-        return 500, ErrorDetail(detail="Retrieving backend metadata timed out.")
+        return HTTPStatus.INTERNAL_SERVER_ERROR, ErrorDetail(
+            detail="Retrieving backend metadata timed out."
+        )

--- a/src/retriever/metadata/optable.py
+++ b/src/retriever/metadata/optable.py
@@ -36,7 +36,12 @@ from retriever.types.trapi_pydantic import TierNumber
 from retriever.utils import biolink
 from retriever.utils.biolink import expand
 from retriever.utils.general import AsyncDaemon
-from retriever.utils.redis import OP_TABLE_KEY, OP_TABLE_UPDATE_CHANNEL, RedisClient
+from retriever.utils.redis import (
+    OP_TABLE_KEY,
+    OP_TABLE_META_KEY,
+    OP_TABLE_UPDATE_CHANNEL,
+    RedisClient,
+)
 from retriever.utils.trapi import (
     hash_meta_attribute,
     meta_qualifier_meets_constraints,
@@ -139,6 +144,11 @@ class OpTableManager(AsyncDaemon):
 
         await REDIS_CLIENT.set(
             OP_TABLE_KEY, op_table_json, compress=True, ttl=CONFIG.job.metakg.build_time
+        )
+        await REDIS_CLIENT.write_freshness(
+            OP_TABLE_META_KEY,
+            count=len(op_table.operations_flat),
+            ttl=CONFIG.job.metakg.build_time,
         )
         await REDIS_CLIENT.publish(OP_TABLE_UPDATE_CHANNEL, 1)
 

--- a/src/retriever/metadata/optable.py
+++ b/src/retriever/metadata/optable.py
@@ -1,7 +1,8 @@
 import asyncio
+import contextlib
 import itertools
 from collections import defaultdict
-from collections.abc import Callable, Coroutine, Iterable
+from collections.abc import Awaitable, Callable, Coroutine, Iterable
 from typing import NamedTuple, override
 
 import ormsgpack
@@ -40,6 +41,7 @@ from retriever.utils.redis import (
     OP_TABLE_KEY,
     OP_TABLE_META_KEY,
     OP_TABLE_UPDATE_CHANNEL,
+    TIER_RECOVERED_CHANNEL,
     RedisClient,
 )
 from retriever.utils.trapi import (
@@ -92,13 +94,21 @@ class OpTableManager(AsyncDaemon):
     """Utility class that keeps an up-to-date OperationTable."""
 
     _operation_table: OperationTable | None = None
-    update_lock: asyncio.Lock = asyncio.Lock()
-    is_leader: bool
+    update_lock: asyncio.Lock
+    _refresh_lock: asyncio.Lock
+    _pending_refresh: bool = False
+    is_leader: bool = False
 
-    def __init__(self, leader: bool = False) -> None:
-        """Initialize with leader setting."""
-        self.is_leader = leader
+    def __init__(self) -> None:
+        """Initialize without leader role; call `promote_to_leader()` to flip the flag."""
+        self.update_lock = asyncio.Lock()
+        self._refresh_lock = asyncio.Lock()
+        self._pending_refresh = False
         super().__init__()
+
+    def promote_to_leader(self) -> None:
+        """Flip this instance to leader mode. Must be called before `initialize()`."""
+        self.is_leader = True
 
     @override
     def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:
@@ -111,19 +121,112 @@ class OpTableManager(AsyncDaemon):
     async def initialize(self) -> None:
         """Start the appropriate tasks for a given process."""
         if self.is_leader:
-            await self.build_operation_table()
+            # Register hooks before the initial refresh so a startup
+            # against a down dependency still recovers later.
+            REDIS_CLIENT.on_recover(self.refresh)
+            for tier in range(0, 2):
+                tier_manager.get_driver(tier).on_recover(self.refresh)
+            with contextlib.suppress(Exception):
+                await REDIS_CLIENT.subscribe(
+                    TIER_RECOVERED_CHANNEL, self._on_remote_tier_recover
+                )
+            try:
+                await self.refresh()
+            except Exception:
+                logger.exception(
+                    "Initial OpTable refresh failed; on_recover will retry once dependencies are back."
+                )
         else:
-            await self.pull_op_table("")
-            await REDIS_CLIENT.subscribe(OP_TABLE_UPDATE_CHANNEL, self.pull_op_table)
+            with contextlib.suppress(Exception):
+                await self.pull_op_table("")
+            with contextlib.suppress(Exception):
+                await REDIS_CLIENT.subscribe(
+                    OP_TABLE_UPDATE_CHANNEL, self.pull_op_table
+                )
+            REDIS_CLIENT.on_recover(self._on_redis_recover)
+            for tier_idx in range(0, 2):
+                driver = tier_manager.get_driver(tier_idx)
+                driver.on_recover(self._on_tier_recover)
+                # Tell the leader so it rebuilds without waiting on its periodic ping.
+                driver.on_recover(self._make_remote_publisher(tier_idx))
         return await super().initialize()
+
+    def _make_remote_publisher(self, tier: int) -> Callable[[], Awaitable[None]]:
+        """Build a tier-specific on_recover hook that broadcasts to Redis."""
+
+        async def _publish() -> None:
+            if not REDIS_CLIENT.up:
+                return
+            try:
+                await REDIS_CLIENT.publish(TIER_RECOVERED_CHANNEL, str(tier))
+            except Exception:
+                logger.debug(f"Failed to publish tier {tier} recovery notice to Redis.")
+
+        return _publish
+
+    async def _on_remote_tier_recover(self, _message: str) -> None:
+        """Leader-side subscriber callback for cross-process tier recovery."""
+        await self.refresh()
+
+    async def refresh(self) -> None:
+        """Rebuild and publish the OpTable; concurrent calls collapse to one trailing rebuild."""
+        self._pending_refresh = True
+        if self._refresh_lock.locked():
+            logger.debug(
+                "OpTable rebuild already in progress; trailing rebuild queued."
+            )
+            return
+        async with self._refresh_lock:
+            while self._pending_refresh:
+                self._pending_refresh = False
+                await self.build_operation_table()
+
+    async def _on_redis_recover(self) -> None:
+        """Worker hook: re-pull the published OpTable on Redis recovery."""
+        try:
+            await self.pull_op_table("")
+        except Exception:
+            logger.exception("Failed to re-pull OpTable on Redis recovery.")
+
+    async def _on_tier_recover(self) -> None:
+        """Worker hook: locally rebuild on tier recovery, but only while Redis is down."""
+        if REDIS_CLIENT.up:
+            return
+        try:
+            await self.degraded_local_build()
+        except Exception:
+            logger.exception("Local OpTable rebuild on tier recovery failed.")
+
+    async def degraded_local_build(self) -> None:
+        """Worker-side local OpTable build when Redis is unavailable; not published."""
+        logger.info(
+            "Building local OpTable from available tiers (Redis unavailable)..."
+        )
+        op_table = await self._collect_tier_ops(bypass_cache=True)
+        async with self.update_lock:
+            if REDIS_CLIENT.up:
+                logger.debug(
+                    "Redis recovered mid-local-build; discarding local OpTable."
+                )
+                return
+            self._operation_table = op_table
+        logger.success(
+            f"Local OpTable built with {len(op_table.operations_flat)} operations / {len(op_table.nodes)} nodes."
+        )
 
     @override
     async def wrapup(self) -> None:
         """Cancel running tasks so connections can close."""
-        try:
-            await REDIS_CLIENT.unsubscribe(OP_TABLE_UPDATE_CHANNEL, self.pull_op_table)
-        except Exception:
-            logger.exception("Exception occurred stopping OpTable task.")
+        if self.is_leader:
+            with contextlib.suppress(Exception):
+                await REDIS_CLIENT.unsubscribe(
+                    TIER_RECOVERED_CHANNEL, self._on_remote_tier_recover
+                )
+        else:
+            with contextlib.suppress(Exception):
+                await REDIS_CLIENT.unsubscribe(
+                    OP_TABLE_UPDATE_CHANNEL, self.pull_op_table
+                )
         return await super().wrapup()
 
     async def store_operation_table(self, op_table: OperationTable) -> None:
@@ -142,13 +245,10 @@ class OpTableManager(AsyncDaemon):
             }
         )
 
-        await REDIS_CLIENT.set(
-            OP_TABLE_KEY, op_table_json, compress=True, ttl=CONFIG.job.metakg.build_time
-        )
+        await REDIS_CLIENT.set(OP_TABLE_KEY, op_table_json, compress=True)
         await REDIS_CLIENT.write_freshness(
             OP_TABLE_META_KEY,
             count=len(op_table.operations_flat),
-            ttl=CONFIG.job.metakg.build_time,
         )
         await REDIS_CLIENT.publish(OP_TABLE_UPDATE_CHANNEL, 1)
 
@@ -233,48 +333,82 @@ class OpTableManager(AsyncDaemon):
                         attr["attribute_type_id"]
                     )
 
+    async def _collect_tier_ops(self, *, bypass_cache: bool = False) -> OperationTable:
+        """Collect operations from all implemented tiers concurrently.
+
+        Per-tier failures are logged and skipped so a single tier outage
+        doesn't waste the work of the others. Raises `ValueError` only
+        when no tier contributed - callers should treat that as "preserve
+        the previous OpTable" rather than overwrite with an empty one.
+
+        `bypass_cache=True` propagates to each driver so periodic rebuilds
+        pull fresh upstream metadata; drivers fall back to their own
+        cache when the live fetch fails.
+        """
+        results = await asyncio.gather(
+            *(
+                tier_manager.get_driver(tier).get_operations(bypass_cache=bypass_cache)
+                for tier in range(0, 2)
+            ),
+            return_exceptions=True,
+        )
+
+        operations_flat = FlatOperations()
+        operations_sorted = SortedOperations()
+        nodes = dict[BiolinkEntity, dict[TierNumber, OperationNode]]()
+        succeeded = 0
+        for tier, result in enumerate(results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    f"OpTable build: Tier {tier} get_operations failed; skipping. Error: {result!r}"
+                )
+                continue
+            new_operations, new_nodes = result
+            self.merge_operations(operations_flat, operations_sorted, new_operations)
+            self.merge_nodes(nodes, new_nodes, tier)
+            succeeded += 1
+
+        if succeeded == 0:
+            raise ValueError("No tier drivers succeeded; preserving previous OpTable.")
+        return OperationTable(operations_sorted, operations_flat, nodes)
+
     async def build_operation_table(self) -> None:
         """Build Retriever's internal OperationTable and store it to Redis."""
         if CONFIG.instance_idx != 0:
             return
 
         logger.info("Building Operation Table...")
-
-        operations_flat = FlatOperations()
-        operations_sorted = SortedOperations()
-        nodes = dict[BiolinkEntity, dict[TierNumber, OperationNode]]()
-
-        driver_ops = [
-            await tier_manager.get_driver(tier).get_operations() for tier in range(0, 2)
-        ]
-
-        for tier, (new_operations, new_nodes) in enumerate(driver_ops):
-            self.merge_operations(operations_flat, operations_sorted, new_operations)
-            self.merge_nodes(nodes, new_nodes, tier)
-
+        op_table = await self._collect_tier_ops(bypass_cache=True)
         async with self.update_lock:
-            self._operation_table = OperationTable(
-                operations_sorted, operations_flat, nodes
-            )
+            self._operation_table = op_table
 
         await self.store_operation_table(self._operation_table)
         logger.success(
-            f"Built Operation Table containing {len(operations_flat)} operations / {len(nodes)} nodes."
+            f"Built Operation Table containing {len(op_table.operations_flat)} operations / {len(op_table.nodes)} nodes."
         )
-        # The leader never reads _operation_table back — it only exists to push to
+        # The leader never reads _operation_table back - it only exists to push to
         # Redis. Drop the reference so the snapshot doesn't sit in process memory.
         if self.is_leader:
             async with self.update_lock:
                 self._operation_table = None
 
     async def periodic_build_op_table(self) -> None:
-        """Periodically rebuild the operation table."""
-        while True:
-            try:
-                await self.build_operation_table()
+        """Periodically rebuild the operation table; build failures log and retry next interval."""
+        try:
+            while True:
+                try:
+                    await self.build_operation_table()
+                except ValueError:
+                    logger.warning(
+                        "OpTable rebuild had no successful tiers; will retry next interval."
+                    )
+                except Exception:
+                    logger.exception(
+                        "OpTable rebuild failed; will retry next interval."
+                    )
                 await asyncio.sleep(CONFIG.job.metakg.build_time)
-            except (ValueError, asyncio.CancelledError):
-                break
+        except asyncio.CancelledError:
+            return
 
     async def pull_op_table(self, _message: str) -> None:
         """Start a subscriber that updates the local operation table."""
@@ -283,19 +417,26 @@ class OpTableManager(AsyncDaemon):
             self._operation_table = await self.retrieve_stored_operation_table()
         logger.success("In-memory OpTable updated.")
 
-    async def get_op_table(self, retries: int = 0) -> OperationTable:
-        """Return the currently-stored Operation Table."""
-        async with self.update_lock:
-            op_table = self._operation_table
-        if op_table is None:
-            if retries >= 6:  # noqa: PLR2004
-                raise ValueError("Failed to retrieve or build a valid OpTable!")
-            if retries == 3:  # noqa: PLR2004
-                # Assume OpTable is not stored and rebuild it
-                await self.build_operation_table()
-            await self.pull_op_table("")
-            return await self.get_op_table(retries + 1)
-        return op_table
+    async def get_op_table(self) -> OperationTable:
+        """Return the currently-stored Operation Table; worker-builds locally if Redis is down."""
+        # Phase 1: try pulling from Redis up to 3 times.
+        # Phase 2: build then pull up to 3 more times.
+        # Worker fallback (Redis down): build locally and re-check.
+        for phase in range(2):
+            for _ in range(3):
+                async with self.update_lock:
+                    op_table = self._operation_table
+                if op_table is not None:
+                    return op_table
+                if not REDIS_CLIENT.up and not self.is_leader:
+                    # Worker can't pull the published copy; build from
+                    # available tiers and re-check.
+                    await self.degraded_local_build()
+                    continue
+                if phase == 1:
+                    await self.build_operation_table()
+                await self.pull_op_table("")
+        raise ValueError("Failed to retrieve or build a valid OpTable!")
 
     async def find_operations(
         self, edge: QEdgeDict, qgraph: QueryGraphDict, tier: TierNumber

--- a/src/retriever/metadata/trapi_metakg.py
+++ b/src/retriever/metadata/trapi_metakg.py
@@ -1,4 +1,5 @@
 import asyncio
+from http import HTTPStatus
 
 from retriever.metadata.optable import OpTableManager
 from retriever.types.general import ErrorDetail, QueryInfo
@@ -11,7 +12,7 @@ OP_TABLE_MANAGER = OpTableManager()
 
 async def trapi_metakg(
     query: QueryInfo,
-) -> tuple[int, MetaKnowledgeGraphDict | ErrorDetail]:
+) -> tuple[HTTPStatus, MetaKnowledgeGraphDict | ErrorDetail]:
     """Obtain a TRAPI-formatted meta-kg.
 
     Returns:
@@ -20,6 +21,8 @@ async def trapi_metakg(
     try:
         async with asyncio.timeout(query.timeout if query.timeout is not -1 else None):
             metakg = await OP_TABLE_MANAGER.get_trapi_metakg(query.tier)
-            return 200, metakg
+            return HTTPStatus.OK, metakg
     except TimeoutError:
-        return 500, ErrorDetail(detail="Building TRAPI MetaKG timed out.")
+        return HTTPStatus.INTERNAL_SERVER_ERROR, ErrorDetail(
+            detail="Building TRAPI MetaKG timed out."
+        )

--- a/src/retriever/monitor/__init__.py
+++ b/src/retriever/monitor/__init__.py
@@ -2,5 +2,5 @@
 
 Plain HTML / JS / CSS under `static/`, mounted via FastAPI's StaticFiles
 from `server.py`. The browser polls the existing `/status/*` JSON API
-directly — no server-side session state for the dashboard.
+directly - no server-side session state for the dashboard.
 """

--- a/src/retriever/monitor/__init__.py
+++ b/src/retriever/monitor/__init__.py
@@ -1,0 +1,6 @@
+"""Static-file dashboard served at /monitor.
+
+Plain HTML / JS / CSS under `static/`, mounted via FastAPI's StaticFiles
+from `server.py`. The browser polls the existing `/status/*` JSON API
+directly — no server-side session state for the dashboard.
+"""

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -1,0 +1,1366 @@
+// Retriever dashboard.
+// Single Alpine component holds the whole page state; per-panel polling
+// timers keep it fresh. No server-side session state — every refresh is
+// an HTTP GET against the existing /status/* JSON API.
+
+const TERMINAL_FAILURE = new Set([
+  "Failed",
+  "QueryNotTraversable",
+  "UnsupportedConstraint",
+]);
+
+const REALTIME_INTERVAL_MS = 10_000;
+const AGGREGATE_INTERVAL_MS = 60_000;
+const TIMELINE_LOOKBACK_HOURS = 24;
+const RECENT_FAILURES_LIMIT = 25;
+const ACTIVITY_PAGE_SIZE = 25;
+const ACTIVITY_MODES = ["Active", "Stuck", "Completed", "Failed"];
+const ACTIVITY_LIVE_MODES = new Set(["Active", "Stuck"]);
+const LOOKBACK_OPTIONS = ["Last 24h", "Last 3 days", "Last week", "All time"];
+const LOOKBACK_HOURS = {
+  "Last 24h": 24,
+  "Last 3 days": 72,
+  "Last week": 168,
+  "All time": null,
+};
+const VIEWS = ["home", "activity", "performance", "heatmaps"];
+
+// Sorted alphabetically so the row dimension in the failure-breakdown
+// heatmaps is deterministic regardless of which statuses showed up.
+const FAILURE_STATUSES = ["Failed", "QueryNotTraversable", "UnsupportedConstraint"];
+
+// Performance view filters. Lookback is shared with the activity LOOKBACK_*
+// vocabulary (so URL state survives a tab switch); the status filter is
+// either "Complete" or "any-failure" (matches `/status/durations`).
+const PERFORMANCE_STATUS_OPTIONS = [
+  { value: "Complete", label: "Completed" },
+  { value: "failed", label: "Failed" },
+];
+const PERFORMANCE_STATUS_VALUES = new Set(
+  PERFORMANCE_STATUS_OPTIONS.map((o) => o.value),
+);
+
+// Sort fields for the activity table. For terminal modes these map
+// directly to the /status/completed and /status/failed `sort` query
+// param (server-side, cross-page). For live modes the same labels drive
+// a client-side reorder of the in-memory list.
+const SORT_FIELDS = [
+  { value: "created", label: "Started" },
+  { value: "completed", label: "Completed" },
+  { value: "duration", label: "Duration" },
+  { value: "submitter", label: "Submitter" },
+  { value: "status", label: "Status" },
+  { value: "results", label: "Results" },
+];
+const SORT_FIELD_VALUES = new Set(SORT_FIELDS.map((o) => o.value));
+
+// Backend only ever defines tiers 0, 1, 2. Centralized so URL parsing,
+// the filter dropdown, and the heatmap matrix all stay in lockstep.
+const TIERS = [0, 1, 2];
+const TIER_VALUES = new Set(TIERS);
+// Cap how many log lines we hand the modal — large dumps (5k+ lines)
+// stall the page during render. Tail-keeping the most recent N matches
+// how a developer typically reads them.
+const MODAL_LOG_MAX_LINES = 500;
+
+// ============== Helpers ==============
+
+async function fetchJson(path, { signal } = {}) {
+  const resp = await fetch(path, { signal, headers: { accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`${resp.status} ${resp.statusText}`);
+  }
+  return resp.json();
+}
+
+async function fetchText(path, { signal } = {}) {
+  const resp = await fetch(path, { signal, headers: { accept: "text/plain" } });
+  if (!resp.ok) {
+    throw new Error(`${resp.status} ${resp.statusText}`);
+  }
+  return resp.text();
+}
+
+/** Build `path?key=value&...`, skipping entries whose value is null/undefined.
+ * Lets callers pass `{ lookback: null }` for "All time" and have the param
+ * drop out cleanly without string-replace gymnastics. */
+function buildUrl(path, params) {
+  const sp = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v != null) sp.set(k, String(v));
+  }
+  const qs = sp.toString();
+  return qs ? `${path}?${qs}` : path;
+}
+
+function relTime(iso) {
+  if (!iso) return "";
+  const when = new Date(iso);
+  if (Number.isNaN(when.valueOf())) return iso;
+  const delta = (Date.now() - when.getTime()) / 1000;
+  if (delta < 0) return "just now";
+  if (delta < 60) return `${Math.floor(delta)}s ago`;
+  const m = delta / 60;
+  if (m < 60) return `${Math.floor(m)}m ago`;
+  const h = m / 60;
+  if (h < 24) return `${Math.floor(h)}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function formatUptime(seconds) {
+  const s = Math.floor(seconds || 0);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}
+
+function formatMb(mb) {
+  if (mb == null) return "—";
+  return `${mb.toFixed(1)}`;
+}
+
+function bucketLabel(iso) {
+  const d = new Date(iso);
+  if (Number.isNaN(d.valueOf())) return iso;
+  return `${String(d.getHours()).padStart(2, "0")}:00`;
+}
+
+function formatLocal(iso) {
+  if (!iso) return "—";
+  const when = new Date(iso);
+  if (Number.isNaN(when.valueOf())) return iso;
+  // Browser-local timezone, medium date + time.
+  return when.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function formatDurationSeconds(seconds) {
+  if (seconds == null) return "—";
+  if (seconds < 1) return `${(seconds * 1000).toFixed(0)}ms`;
+  if (seconds < 60) return `${seconds.toFixed(2)}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds - m * 60;
+  if (m < 60) return `${m}m ${s.toFixed(0)}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+/**
+ * Linear interpolation across two HSL endpoints, normalized within a
+ * heatmap (vmin/vmax come from the surrounding helper, not a global
+ * scale). Returns `transparent` for nulls so empty cells fall back to
+ * the `.heatmap-cell` default background.
+ *
+ * Scales:
+ *   `fail`     — green (good) → red (bad), hue 120 → 0.
+ *   `duration` — blue (fast)  → orange (slow), hue 210 → 30.
+ *   `count`    — same hue, lightness 80% → 35% (pale to saturated).
+ */
+const HEATMAP_SCALES = {
+  fail: { h0: 120, h1: 0, s: 60, l: 50 },
+  duration: { h0: 210, h1: 30, s: 65, l: 50 },
+  count: { h0: 210, h1: 210, s: 70, l0: 80, l1: 35 },
+};
+function heatmapColor(value, vmin, vmax, scale) {
+  if (value == null) return "transparent";
+  if (vmax === vmin) {
+    // Single non-null value with no range — pick the midpoint colour
+    // so it's still visually distinct from the empty-cell background.
+    const c = HEATMAP_SCALES[scale];
+    if (c.l0 != null) return `hsl(${c.h0}, ${c.s}%, ${(c.l0 + c.l1) / 2}%)`;
+    return `hsl(${(c.h0 + c.h1) / 2}, ${c.s}%, ${c.l}%)`;
+  }
+  const t = Math.max(0, Math.min(1, (value - vmin) / (vmax - vmin)));
+  const c = HEATMAP_SCALES[scale];
+  if (c.l0 != null) {
+    const l = c.l0 + (c.l1 - c.l0) * t;
+    return `hsl(${c.h0}, ${c.s}%, ${l}%)`;
+  }
+  const h = c.h0 + (c.h1 - c.h0) * t;
+  return `hsl(${h}, ${c.s}%, ${c.l}%)`;
+}
+
+function truncateLogLines(text) {
+  if (!text) return "(no logs)";
+  const lines = text.split("\n");
+  if (lines.length <= MODAL_LOG_MAX_LINES) return text;
+  const kept = lines.slice(lines.length - MODAL_LOG_MAX_LINES);
+  const dropped = lines.length - MODAL_LOG_MAX_LINES;
+  return (
+    `(showing last ${MODAL_LOG_MAX_LINES} of ${lines.length} lines; ` +
+    `${dropped} earlier lines hidden — use the "Open full logs" link above)\n\n` +
+    kept.join("\n")
+  );
+}
+
+// ============== uPlot helpers ==============
+
+/** Run `attempt` until it returns truthy, polling every 80ms.
+ *
+ * Used by every ensure*Plot — both Alpine `x-cloak` (which holds the
+ * body at display:none until init() finishes) and the lazy `defer`
+ * load of uPlot mean that a plot built during init() can be built
+ * into a zero-width container, and uPlot doesn't recover cleanly
+ * from that. Polling lets each ensure*Plot wait out both conditions
+ * (uPlot loaded AND container measured) before constructing. */
+function retryUntilBuilt(attempt) {
+  const tick = () => {
+    if (attempt()) return;
+    window.setTimeout(tick, 80);
+  };
+  tick();
+}
+
+let throughputPlot = null;
+let performancePlot = null;
+
+/** Force a redraw of every live timeline plot. Called from the theme
+ * toggle so axis/grid/series colors are re-read from the CSS palette. */
+function redrawAllPlots() {
+  for (const plot of [throughputPlot, performancePlot]) {
+    if (plot) plot.redraw(false, true);
+  }
+  for (const plot of tierPlots.values()) {
+    plot.redraw(false, true);
+  }
+}
+// Per-tier perf chart plots, keyed by tier number. Containers are
+// rendered by an `x-for` so they appear/disappear as the tier list
+// changes; we lazy-init in response to each container's x-init hook.
+const tierPlots = new Map();
+
+/**
+ * Compute the shared x-axis range for a timeline chart family. The
+ * returned object is also threaded through `applyTimelineData` to pin
+ * the y-axis: `yMax` is taken from the supplied buckets so a per-tier
+ * chart fed this same range will use the overall chart's y scale, not
+ * its own (otherwise each chart auto-scales independently and the
+ * visual heights become incomparable).
+ *
+ * - `hours` finite → x-window is `[now - hours*3600, now]`.
+ * - `hours` null ("All time") → derive x-window from the supplied
+ *   buckets so tier charts still align with the main chart.
+ */
+function computeTimelineRange(hours, buckets = []) {
+  const now = Math.floor(Date.now() / 1000);
+  const yMax = buckets.length
+    ? Math.max(1, ...buckets.map((b) => b.count))
+    : 1;
+  if (hours != null) {
+    return { xMin: now - hours * 3600, xMax: now, yMax };
+  }
+  if (!buckets.length) {
+    return { xMin: now - 24 * 3600, xMax: now, yMax };
+  }
+  const xs = buckets.map((b) =>
+    Math.floor(new Date(b.bucket_start).getTime() / 1000),
+  );
+  return { xMin: Math.min(...xs), xMax: Math.max(now, ...xs), yMax };
+}
+
+function emptyTimelineRange(hours = 24) {
+  // Two-point dataset spanning the lookback window with zero counts.
+  // uPlot needs at least two distinct x values to compute a sensible
+  // time scale — [[0], [0]] makes it draw an axis around the epoch.
+  const now = Math.floor(Date.now() / 1000);
+  return [
+    [now - hours * 3600, now],
+    [0, 0],
+  ];
+}
+
+function makeTimelinePlot(container, { hours = 24 } = {}) {
+  // Pane may still be `display:none` when init runs — fall back to a
+  // sensible width and let the ResizeObserver below correct it once the
+  // browser has laid the container out.
+  const initWidth = container.clientWidth || 600;
+  const initHeight = container.clientHeight || 180;
+  // Each color is read from the CSS palette on every redraw rather
+  // than once at construction. That lets a theme toggle re-tint the
+  // axes/grid without rebuilding the plot.
+  const cssVar = (name) =>
+    getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  const opts = {
+    width: initWidth,
+    height: initHeight,
+    cursor: { drag: { setScale: false }, points: { show: false } },
+    legend: { show: false },
+    axes: [
+      {
+        // `stroke` colors the axis tick LABELS (the text); `ticks` is
+        // the short perpendicular tick-mark segments; `grid` is the
+        // background grid lines.
+        stroke: () => cssVar("--axis-label"),
+        ticks: { stroke: () => cssVar("--axis-tick") },
+        grid: { stroke: () => cssVar("--border") },
+      },
+      {
+        stroke: () => cssVar("--axis-label"),
+        ticks: { stroke: () => cssVar("--axis-tick") },
+        grid: { stroke: () => cssVar("--border") },
+      },
+    ],
+    series: [
+      {},
+      {
+        label: "jobs",
+        stroke: () => cssVar("--accent"),
+        width: 1,
+        fill: "rgba(59, 130, 246, 0.55)",
+        // Render each bucket as a discrete bar instead of a connected
+        // line — for hourly aggregates a line was misleading (implied
+        // continuous data) and a single populated bucket disappeared
+        // into a hairline spike at 1/24th of the pinned x-axis.
+        paths: uPlot.paths.bars({ size: [0.85, 18] }),
+        points: { show: false },
+      },
+    ],
+    scales: { x: { time: true } },
+  };
+  const plot = new uPlot(opts, emptyTimelineRange(hours), container);
+  // Track container size so the chart resizes when the pane is unhidden
+  // (x-show flip), when the window resizes, or when the column widens.
+  // Covers the "rendered at half width" race where init ran before
+  // layout had a real width.
+  if (typeof ResizeObserver !== "undefined") {
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = Math.floor(entry.contentRect.width);
+        if (width <= 0) continue;
+        const height = container.clientHeight || initHeight;
+        if (plot.width === width && plot.height === height) continue;
+        plot.setSize({ width, height });
+      }
+    });
+    ro.observe(container);
+  }
+  return plot;
+}
+
+function applyTimelineData(plot, buckets, range) {
+  if (!plot) return;
+  const xs = buckets.map((b) =>
+    Math.floor(new Date(b.bucket_start).getTime() / 1000),
+  );
+  const ys = buckets.map((b) => b.count);
+  // uPlot needs at least 2 points; pad with current time if only one.
+  if (xs.length === 0) {
+    if (range && range.xMin != null && range.xMax != null) {
+      plot.setData([[range.xMin, range.xMax], [0, 0]]);
+      return;
+    }
+    plot.setData(emptyTimelineRange());
+    return;
+  }
+  if (xs.length === 1) {
+    xs.push(xs[0] + 3600);
+    ys.push(0);
+  }
+  plot.setData([xs, ys]);
+  // Pinning the x scale here is what keeps every chart on the perf
+  // page aligned to the same window, even when individual tiers cover
+  // sparser ranges than the overall timeline.
+  if (range && range.xMin != null && range.xMax != null) {
+    plot.setScale("x", { min: range.xMin, max: range.xMax });
+  }
+  // Pin the y-axis too so per-tier charts share the overall chart's
+  // y scale. Without this each chart auto-scales independently and a
+  // tier with count=8 ends up the same visual height as one with 80.
+  if (range && range.yMax != null) {
+    plot.setScale("y", { min: 0, max: range.yMax });
+  }
+}
+
+// ============== Alpine root component ==============
+
+function dashboard() {
+  return {
+    view: "home",
+    theme: localStorage.getItem("retriever-theme") || "dark",
+    data: {
+      status: null,
+      active: [],
+      stuck: [],
+      counts: null,
+      timeline: [],
+      failures: [],
+    },
+    activity: {
+      mode: "Completed",
+      lookback: "Last 24h",
+      submitter: null,
+      tier: null,
+      sortField: "completed",
+      sortDir: "desc",
+      items: [],
+      cursor: null,
+      nextCursor: null,
+      history: [],
+      submitterOptions: [],
+    },
+    performance: {
+      lookback: "Last 24h",
+      status: "Complete",
+      durations: null,
+      tiers: [],
+      timeline: [],
+      // tier number -> list of bucket objects {bucket_start, count}.
+      // Populated by fetchTierTimelines after the tier list arrives.
+      tierTimelines: {},
+      // Shared x-axis range applied to the main + every per-tier chart.
+      // Computed once per fetchPerformance() and reused when individual
+      // tier plots spin up lazily.
+      xRange: null,
+    },
+    heatmaps: {
+      lookback: "Last week",
+      submitterTable: [], // /status/submitters
+      tierTable: [], // /status/tiers
+      submitterTier: [], // /status/submitter_tier_stats
+      failuresBySubmitter: [], // /status/failure_breakdown?by=submitter
+      failuresByTier: [], // /status/failure_breakdown?by=tier
+    },
+    modalStack: [],
+    pollers: {},
+
+    // Constants exposed for template iteration.
+    ACTIVITY_MODES,
+    LOOKBACK_OPTIONS,
+    SORT_FIELDS,
+    PERFORMANCE_STATUS_OPTIONS,
+    FAILURE_STATUSES,
+    TIERS,
+
+    init() {
+      // Apply persisted theme.
+      document.documentElement.dataset.theme = this.theme;
+
+      // URL hash → initial view + activity filter state.
+      this.applyHashState();
+      window.addEventListener("popstate", () => {
+        this.applyHashState();
+        this.lazyInitForView();
+      });
+
+      // Fire the same per-view lazy init that setView() would on click.
+      // Without this, a hard refresh to #performance or #submitters
+      // leaves the view empty until the user tab-switches and back.
+      // For home this constructs the throughput plot lazily so it
+      // sees a real container width (a hidden pane has clientWidth=0
+      // and uPlot doesn't recover from being built into one).
+      this.lazyInitForView();
+
+      // First fetches (immediate) + recurring timers.
+      this.startPolling();
+
+      // Pause polls when the tab is hidden.
+      document.addEventListener("visibilitychange", () => {
+        if (document.hidden) {
+          this.stopPolling();
+        } else {
+          this.startPolling();
+        }
+      });
+    },
+
+    /** Idempotent: tears down any existing timers, fires immediate
+     * refreshes, then sets up the recurring intervals. Safe to call
+     * whenever we want "fresh data + active polling" — `init()` startup
+     * and visibility-resume both use it. */
+    startPolling() {
+      this.stopPolling();
+      this.refreshRealtime();
+      this.refreshAggregates();
+      this.pollers.realtime = window.setInterval(
+        () => this.refreshRealtime(),
+        REALTIME_INTERVAL_MS,
+      );
+      this.pollers.aggregate = window.setInterval(
+        () => this.refreshAggregates(),
+        AGGREGATE_INTERVAL_MS,
+      );
+    },
+
+    stopPolling() {
+      for (const k of Object.keys(this.pollers)) {
+        window.clearInterval(this.pollers[k]);
+        delete this.pollers[k];
+      }
+    },
+
+    setView(name) {
+      this.view = name;
+      this.writeHashState();
+      this.lazyInitForView();
+    },
+
+    /** Trigger the per-view first-fetch + chart init for the currently
+     * active view. Idempotent — fetchers run on every call (the user
+     * gets fresh data on tab switch), but plot init is gated by
+     * `ensurePerformancePlot`'s null check. Called from both setView()
+     * (tab click) and init() (hard refresh) so refresh-to-perf works. */
+    lazyInitForView() {
+      if (this.view === "home") this.ensureThroughputPlot();
+      if (this.view === "activity") this.fetchActivity();
+      if (this.view === "performance") {
+        this.ensurePerformancePlot();
+        this.fetchPerformance();
+      }
+      if (this.view === "heatmaps") this.fetchHeatmaps();
+    },
+
+    /** Lazy-construct the Home throughput chart once both uPlot is
+     * loaded and its container has real layout dimensions. uPlot
+     * built into a zero-width container renders a degenerate canvas
+     * that doesn't redraw cleanly on later resize — and the
+     * [x-cloak] CSS rule means EVERY container has clientWidth=0
+     * during init(), so we have to wait it out. */
+    ensureThroughputPlot() {
+      if (throughputPlot) {
+        // Already built — push current data through so a tab-back also
+        // refreshes the chart with whatever the latest poll fetched.
+        this.applyHomeTimeline();
+        return;
+      }
+      retryUntilBuilt(() => {
+        if (throughputPlot) return true;
+        if (typeof uPlot === "undefined") return false;
+        const container = document.getElementById("throughput-chart");
+        if (!container || container.clientWidth === 0) return false;
+        throughputPlot = makeTimelinePlot(container, {
+          hours: TIMELINE_LOOKBACK_HOURS,
+        });
+        this.applyHomeTimeline();
+        return true;
+      });
+    },
+
+    applyHomeTimeline() {
+      if (!throughputPlot) return;
+      const buckets = this.data.timeline || [];
+      applyTimelineData(
+        throughputPlot,
+        buckets,
+        computeTimelineRange(TIMELINE_LOOKBACK_HOURS, buckets),
+      );
+    },
+
+    toggleTheme() {
+      this.theme = this.theme === "dark" ? "light" : "dark";
+      localStorage.setItem("retriever-theme", this.theme);
+      document.documentElement.dataset.theme = this.theme;
+      // Axis/grid/series colors are read from CSS vars on every uPlot
+      // redraw, so a forced redraw is enough to pick up the new theme.
+      redrawAllPlots();
+    },
+
+    jumpToActivity({ mode, lookback, submitter, tier } = {}) {
+      if (mode && ACTIVITY_MODES.includes(mode)) this.activity.mode = mode;
+      if (lookback && LOOKBACK_HOURS[lookback] !== undefined)
+        this.activity.lookback = lookback;
+      this.activity.submitter = submitter || null;
+      this.activity.tier = tier === 0 || tier === 1 ? tier : null;
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.view = "activity";
+      this.writeHashState();
+      this.fetchActivity();
+    },
+
+    // ============== URL hash <-> state ==============
+
+    applyHashState() {
+      const hash = (location.hash || "#home").replace(/^#/, "");
+      const [viewPart, qs = ""] = hash.split("?");
+      this.view = VIEWS.includes(viewPart) ? viewPart : "home";
+      const params = new URLSearchParams(qs);
+
+      if (this.view === "activity") {
+        const mode = params.get("mode");
+        if (mode && ACTIVITY_MODES.includes(mode)) this.activity.mode = mode;
+        const lb = params.get("window");
+        if (lb && LOOKBACK_HOURS[lb] !== undefined)
+          this.activity.lookback = lb;
+        this.activity.submitter = params.get("submitter") || null;
+        const tierRaw = params.get("tier");
+        const tier = tierRaw == null || tierRaw === "" ? NaN : Number(tierRaw);
+        this.activity.tier = TIER_VALUES.has(tier) ? tier : null;
+        const sortField = params.get("sort");
+        if (sortField && SORT_FIELD_VALUES.has(sortField))
+          this.activity.sortField = sortField;
+        const dir = params.get("dir");
+        if (dir === "asc" || dir === "desc") this.activity.sortDir = dir;
+        this.activity.cursor = null;
+        this.activity.history = [];
+      } else if (this.view === "performance") {
+        const lb = params.get("window");
+        if (lb && LOOKBACK_HOURS[lb] !== undefined)
+          this.performance.lookback = lb;
+        const status = params.get("status");
+        if (status && PERFORMANCE_STATUS_VALUES.has(status))
+          this.performance.status = status;
+      } else if (this.view === "heatmaps") {
+        const lb = params.get("window");
+        if (lb && LOOKBACK_HOURS[lb] !== undefined)
+          this.heatmaps.lookback = lb;
+      }
+    },
+
+    writeHashState() {
+      let hash = `#${this.view}`;
+      const p = new URLSearchParams();
+      if (this.view === "activity") {
+        if (this.activity.mode !== "Completed") p.set("mode", this.activity.mode);
+        if (this.activity.lookback !== "Last 24h")
+          p.set("window", this.activity.lookback);
+        if (this.activity.submitter) p.set("submitter", this.activity.submitter);
+        if (this.activity.tier !== null) p.set("tier", String(this.activity.tier));
+        if (this.activity.sortField !== "completed")
+          p.set("sort", this.activity.sortField);
+        if (this.activity.sortDir !== "desc")
+          p.set("dir", this.activity.sortDir);
+      } else if (this.view === "performance") {
+        if (this.performance.lookback !== "Last 24h")
+          p.set("window", this.performance.lookback);
+        if (this.performance.status !== "Complete")
+          p.set("status", this.performance.status);
+      } else if (this.view === "heatmaps") {
+        if (this.heatmaps.lookback !== "Last week")
+          p.set("window", this.heatmaps.lookback);
+      }
+      const qs = p.toString();
+      if (qs) hash += `?${qs}`;
+      const target = `${location.pathname}${location.search}${hash}`;
+      if (location.hash !== hash) history.replaceState(null, "", target);
+    },
+
+    // ============== Activity view ==============
+
+    isLiveMode() {
+      return ACTIVITY_LIVE_MODES.has(this.activity.mode);
+    },
+
+    setActivityMode(mode) {
+      if (this.activity.mode === mode) return;
+      this.activity.mode = mode;
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      this.fetchActivity();
+    },
+
+    setActivityLookback(value) {
+      this.activity.lookback = value;
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      this.fetchActivity();
+    },
+
+    setActivitySubmitter(value) {
+      this.activity.submitter = value || null;
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      this.fetchActivity();
+    },
+
+    setActivityTier(value) {
+      this.activity.tier = value === "" ? null : Number(value);
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      this.fetchActivity();
+    },
+
+    setActivitySortField(value) {
+      if (!SORT_FIELD_VALUES.has(value)) return;
+      this.activity.sortField = value;
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      // Live modes sort client-side over the in-memory list; sortedItems()
+      // re-reads sortField on every render, so no refetch needed.
+      if (!this.isLiveMode()) this.fetchActivity();
+    },
+
+    toggleActivitySortDir() {
+      this.activity.sortDir =
+        this.activity.sortDir === "asc" ? "desc" : "asc";
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      if (!this.isLiveMode()) this.fetchActivity();
+    },
+
+    /**
+     * Click a column header to sort by that field. Same field → flip
+     * direction; new field → switch + default to desc.
+     */
+    headerSortClick(field) {
+      if (!SORT_FIELD_VALUES.has(field)) return;
+      if (this.activity.sortField === field) {
+        this.toggleActivitySortDir();
+        return;
+      }
+      this.activity.sortField = field;
+      this.activity.sortDir = "desc";
+      this.activity.cursor = null;
+      this.activity.history = [];
+      this.writeHashState();
+      if (!this.isLiveMode()) this.fetchActivity();
+    },
+
+    /** Sort-arrow indicator for a column header ("", "↑", or "↓"). */
+    headerArrow(field) {
+      if (this.activity.sortField !== field) return "";
+      return this.activity.sortDir === "asc" ? "↑" : "↓";
+    },
+
+    /**
+     * Which sort field a given column-header click should map to. The
+     * "When" column is the contextual one — `created` for live modes,
+     * `completed` for terminal ones.
+     */
+    whenSortField() {
+      return this.isLiveMode() ? "created" : "completed";
+    },
+
+    /**
+     * Outcome column maps to `status` in Failed mode, `results` elsewhere.
+     */
+    outcomeSortField() {
+      return this.activity.mode === "Failed" ? "status" : "results";
+    },
+
+    async activityNext() {
+      if (!this.activity.nextCursor) return;
+      this.activity.history.push(this.activity.cursor);
+      this.activity.cursor = this.activity.nextCursor;
+      await this.fetchActivity();
+    },
+
+    async activityPrev() {
+      if (this.activity.history.length === 0) return;
+      this.activity.cursor = this.activity.history.pop();
+      await this.fetchActivity();
+    },
+
+    async fetchActivity() {
+      const mode = this.activity.mode;
+      try {
+        if (ACTIVITY_LIVE_MODES.has(mode)) {
+          // Active/Stuck — flat list, no cursor, no server-side filters.
+          // Sort is applied client-side over the in-memory list.
+          const path = mode === "Active" ? "/status/active" : "/status/stuck";
+          const rows = await fetchJson(path);
+          this.activity.items = rows;
+          this.activity.nextCursor = null;
+          return;
+        }
+        const endpoint =
+          mode === "Failed" ? "/status/failed" : "/status/completed";
+        const p = new URLSearchParams({
+          limit: String(ACTIVITY_PAGE_SIZE),
+          sort: this.activity.sortField,
+          direction: this.activity.sortDir,
+        });
+        if (this.activity.cursor) p.set("cursor", this.activity.cursor);
+        const lookback = LOOKBACK_HOURS[this.activity.lookback];
+        if (lookback !== null) p.set("lookback", String(lookback));
+        if (this.activity.submitter) p.set("submitter", this.activity.submitter);
+        if (this.activity.tier !== null)
+          p.set("data_tier", String(this.activity.tier));
+        const page = await fetchJson(`${endpoint}?${p}`);
+        this.activity.items = page.items || [];
+        this.activity.nextCursor = page.next_cursor || null;
+      } catch (err) {
+        console.warn("activity fetch failed:", err);
+        this.activity.items = [];
+        this.activity.nextCursor = null;
+      }
+    },
+
+    async populateSubmitterOptions() {
+      try {
+        const rows = await fetchJson("/status/submitters?top=200");
+        this.activity.submitterOptions = rows
+          .map((r) => r.submitter)
+          .filter((s) => typeof s === "string" && s.length > 0);
+      } catch (err) {
+        console.warn("submitter list fetch failed:", err);
+      }
+    },
+
+    sortedItems() {
+      // Terminal modes are pre-sorted server-side; just hand back the
+      // current page. Live modes (Active/Stuck) need a client-side sort
+      // over the in-memory list.
+      if (!this.isLiveMode()) return this.activity.items;
+      const items = [...this.activity.items];
+      const field = this.activity.sortField;
+      const sign = this.activity.sortDir === "asc" ? 1 : -1;
+      items.sort((a, b) => {
+        const av = this.sortKey(a, field);
+        const bv = this.sortKey(b, field);
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (av < bv) return -sign;
+        if (av > bv) return sign;
+        return 0;
+      });
+      return items;
+    },
+
+    sortKey(row, field) {
+      if (field === "created" || field === "completed") {
+        const iso = row[field];
+        return iso ? new Date(iso).getTime() : null;
+      }
+      if (field === "duration") {
+        return this.isLiveMode()
+          ? row.age_seconds ?? null
+          : row.duration_seconds ?? null;
+      }
+      if (field === "submitter") return (row.submitter || "").toLowerCase();
+      if (field === "status") return (row.status || "").toLowerCase();
+      if (field === "results") return row.results ?? null;
+      return null;
+    },
+
+    activityWhen(row) {
+      if (ACTIVITY_LIVE_MODES.has(this.activity.mode)) {
+        return relTime(row.created);
+      }
+      return relTime(row.completed);
+    },
+
+    activityDuration(row) {
+      if (ACTIVITY_LIVE_MODES.has(this.activity.mode)) {
+        return formatDurationSeconds(row.age_seconds ?? null);
+      }
+      return formatDurationSeconds(row.duration_seconds ?? null);
+    },
+
+    activityOutcome(row) {
+      const m = this.activity.mode;
+      if (m === "Active") return "running";
+      if (m === "Stuck") return "stuck";
+      if (m === "Failed") return row.status || "";
+      const r = row.results;
+      return r != null ? `${r} results` : "—";
+    },
+
+    activityStatusText() {
+      const n = this.activity.items.length;
+      const noun = n === 1 ? "job" : "jobs";
+      if (this.isLiveMode()) return `Showing ${n} ${noun}`;
+      if (this.activity.nextCursor)
+        return `Showing ${n} ${noun} · more available`;
+      return `Showing ${n} ${noun} · end of results`;
+    },
+
+    async refreshRealtime() {
+      try {
+        const [status, active, stuck] = await Promise.all([
+          fetchJson("/status"),
+          fetchJson("/status/active"),
+          fetchJson("/status/stuck"),
+        ]);
+        this.data.status = status;
+        this.data.active = active;
+        this.data.stuck = stuck;
+      } catch (err) {
+        console.warn("realtime refresh failed:", err);
+      }
+    },
+
+    async refreshAggregates() {
+      try {
+        const [counts, timeline, failures] = await Promise.all([
+          fetchJson("/status/counts"),
+          fetchJson(
+            `/status/timeline?field=completed&granularity=hour&lookback=${TIMELINE_LOOKBACK_HOURS}`,
+          ),
+          fetchJson(`/status/failed?limit=${RECENT_FAILURES_LIMIT}`),
+        ]);
+        this.data.counts = counts;
+        this.data.timeline = timeline;
+        this.data.failures = failures.items || [];
+        applyTimelineData(
+          throughputPlot,
+          timeline,
+          computeTimelineRange(TIMELINE_LOOKBACK_HOURS, timeline),
+        );
+      } catch (err) {
+        console.warn("aggregate refresh failed:", err);
+      }
+      // Refresh the submitter dropdown on the same cadence so a
+      // long-lived session picks up new submitters without a reload.
+      // Failure here doesn't drag down the whole aggregate refresh.
+      this.populateSubmitterOptions();
+    },
+
+    // ============== Performance view ==============
+
+    /** Build the perf throughput uPlot lazily — its container only
+     * exists after the user has switched to the perf tab at least once
+     * (Alpine x-show keeps the element mounted after that). Safe to
+     * call repeatedly; init is a no-op once `performancePlot` is set. */
+    ensurePerformancePlot() {
+      if (performancePlot) return;
+      retryUntilBuilt(() => {
+        if (performancePlot) return true;
+        if (typeof uPlot === "undefined") return false;
+        const container = document.getElementById("performance-chart");
+        if (!container || container.clientWidth === 0) return false;
+        performancePlot = makeTimelinePlot(container, {
+          hours: this.performanceLookbackHours() ?? 24,
+        });
+        // fetchPerformance() may have resolved before the plot was
+        // built; feed the cached timeline in immediately.
+        if (this.performance.timeline.length > 0) {
+          applyTimelineData(
+            performancePlot,
+            this.performance.timeline,
+            this.performance.xRange,
+          );
+        }
+        return true;
+      });
+    },
+
+    performanceLookbackHours() {
+      return LOOKBACK_HOURS[this.performance.lookback];
+    },
+
+    async fetchPerformance() {
+      const lookback = this.performanceLookbackHours();
+      const status = this.performance.status;
+      try {
+        const [durations, tiers, timeline] = await Promise.all([
+          fetchJson(buildUrl("/status/durations", { status, lookback })),
+          fetchJson(buildUrl("/status/tiers", { lookback })),
+          fetchJson(
+            buildUrl("/status/timeline", {
+              field: "completed",
+              granularity: "hour",
+              lookback,
+            }),
+          ),
+        ]);
+        this.performance.durations = durations;
+        this.performance.tiers = tiers;
+        this.performance.timeline = timeline;
+        // Compute the shared x-range for every chart on the page.
+        // Lookback gives an exact window; "All time" derives it from
+        // the union timeline so tier charts still line up.
+        const range = computeTimelineRange(lookback, timeline);
+        this.performance.xRange = range;
+        applyTimelineData(performancePlot, timeline, range);
+        // Per-tier timelines fan out in parallel after we know which
+        // tiers showed activity.
+        await this.fetchTierTimelines(tiers, range);
+      } catch (err) {
+        console.warn("performance fetch failed:", err);
+      }
+    },
+
+    async fetchTierTimelines(tiers, range) {
+      const lookback = this.performanceLookbackHours();
+      const fetches = tiers.map(async (row) => {
+        try {
+          const buckets = await fetchJson(
+            buildUrl("/status/timeline", {
+              field: "completed",
+              granularity: "hour",
+              data_tier: row.tier,
+              lookback,
+            }),
+          );
+          this.performance.tierTimelines[row.tier] = buckets;
+          // Plot may not be initialized yet if the container only just
+          // entered the DOM; ensureTierPlot will pull data from
+          // tierTimelines once it spins up.
+          const plot = tierPlots.get(row.tier);
+          if (plot) applyTimelineData(plot, buckets, range);
+        } catch (err) {
+          console.warn(`tier ${row.tier} timeline fetch failed:`, err);
+        }
+      });
+      await Promise.all(fetches);
+    },
+
+    /** Lazy-init the chart for a tier pane. Called via x-init on each
+     * tier pane's chart container, which fires both on first render and
+     * any time Alpine re-renders the pane. */
+    ensureTierPlot(tier) {
+      if (tierPlots.has(tier)) return;
+      retryUntilBuilt(() => {
+        if (tierPlots.has(tier)) return true;
+        if (typeof uPlot === "undefined") return false;
+        const container = document.getElementById(
+          `performance-chart-tier-${tier}`,
+        );
+        if (!container || container.clientWidth === 0) return false;
+        const hours = this.performanceLookbackHours() ?? 24;
+        const plot = makeTimelinePlot(container, { hours });
+        tierPlots.set(tier, plot);
+        // Buckets may already be in state if the fetch finished
+        // before x-init fired — feed them in immediately, with the
+        // same shared range the main + sibling tier plots use.
+        const buckets = this.performance.tierTimelines[tier];
+        if (buckets) applyTimelineData(plot, buckets, this.performance.xRange);
+        return true;
+      });
+    },
+
+    setPerformanceLookback(value) {
+      if (!LOOKBACK_OPTIONS.includes(value)) return;
+      this.performance.lookback = value;
+      this.writeHashState();
+      this.fetchPerformance();
+    },
+
+    setPerformanceStatus(value) {
+      if (!PERFORMANCE_STATUS_VALUES.has(value)) return;
+      this.performance.status = value;
+      this.writeHashState();
+      this.fetchPerformance();
+    },
+
+    // ============== Heatmaps view ==============
+
+    async fetchHeatmaps() {
+      const lookback = LOOKBACK_HOURS[this.heatmaps.lookback];
+      try {
+        const [submitters, tiers, st, failsSub, failsTier] = await Promise.all([
+          fetchJson(buildUrl("/status/submitters", { top: 100, lookback })),
+          fetchJson(buildUrl("/status/tiers", { lookback })),
+          fetchJson(buildUrl("/status/submitter_tier_stats", { lookback })),
+          fetchJson(
+            buildUrl("/status/failure_breakdown", { by: "submitter", lookback }),
+          ),
+          fetchJson(
+            buildUrl("/status/failure_breakdown", { by: "tier", lookback }),
+          ),
+        ]);
+        this.heatmaps.submitterTable = submitters;
+        this.heatmaps.tierTable = tiers;
+        this.heatmaps.submitterTier = st;
+        this.heatmaps.failuresBySubmitter = failsSub.rows || [];
+        this.heatmaps.failuresByTier = failsTier.rows || [];
+      } catch (err) {
+        console.warn("heatmaps fetch failed:", err);
+      }
+    },
+
+    setHeatmapsLookback(value) {
+      if (!LOOKBACK_OPTIONS.includes(value)) return;
+      this.heatmaps.lookback = value;
+      this.writeHashState();
+      this.fetchHeatmaps();
+    },
+
+    /**
+     * Build the (submitter × tier) heatmap matrix for one of two
+     * metrics: `failed_pct` (failed/count) or `p95_seconds`. Returns a
+     * single flat array of grid items so the HTML template can render
+     * it with one x-for and the CSS grid auto-flows the layout.
+     */
+    submitterTierMatrix(metric) {
+      const subRows = this.heatmaps.submitterTable.map((r) => r.submitter);
+      const cols = TIERS;
+      const byCell = new Map();
+      for (const r of this.heatmaps.submitterTier) {
+        byCell.set(`${r.submitter}|${r.tier}`, r);
+      }
+      const values = [];
+      const cellGrid = subRows.map((sub) =>
+        cols.map((tier) => {
+          const r = byCell.get(`${sub}|${tier}`);
+          if (!r) return { value: null, display: "—" };
+          if (metric === "failed_pct") {
+            if (r.count === 0) return { value: null, display: "—" };
+            const v = (r.failed / r.count) * 100;
+            values.push(v);
+            return { value: v, display: `${v.toFixed(0)}%`, count: r.count };
+          }
+          if (r.p95_seconds == null) return { value: null, display: "—" };
+          values.push(r.p95_seconds);
+          return {
+            value: r.p95_seconds,
+            display: formatDurationSeconds(r.p95_seconds),
+            count: r.count,
+          };
+        }),
+      );
+      const vmin = values.length ? Math.min(...values) : 0;
+      const vmax = values.length ? Math.max(...values) : 0;
+      const scale = metric === "failed_pct" ? "fail" : "duration";
+      const flat = [];
+      // Top-left corner.
+      flat.push({ kind: "corner" });
+      // Column headers.
+      for (const t of cols) {
+        flat.push({ kind: "colHeader", text: `tier ${t}` });
+      }
+      // Each data row: row label then its cells.
+      subRows.forEach((sub, i) => {
+        flat.push({ kind: "rowHeader", text: sub });
+        cellGrid[i].forEach((c) => {
+          flat.push({
+            kind: "cell",
+            value: c.value,
+            display: c.display,
+            color: heatmapColor(c.value, vmin, vmax, scale),
+            title:
+              c.value == null
+                ? `${sub}: no data`
+                : `${sub}: ${c.display}${c.count != null ? ` (n=${c.count})` : ""}`,
+          });
+        });
+      });
+      return { columnCount: cols.length, items: flat };
+    },
+
+    /**
+     * Build the (failure-status × {submitter|tier}) count matrix. Same
+     * flat-array shape as `submitterTierMatrix`.
+     */
+    failuresMatrix(by) {
+      const raw =
+        by === "submitter"
+          ? this.heatmaps.failuresBySubmitter
+          : this.heatmaps.failuresByTier;
+      const colSet = new Set();
+      const byCell = new Map();
+      for (const r of raw) {
+        colSet.add(r.key);
+        byCell.set(`${r.status}|${r.key}`, r.count);
+      }
+      const cols = [...colSet].sort();
+      const values = raw.map((r) => r.count);
+      const vmin = values.length ? Math.min(...values) : 0;
+      const vmax = values.length ? Math.max(...values) : 0;
+      const flat = [];
+      flat.push({ kind: "corner" });
+      for (const col of cols) {
+        flat.push({
+          kind: "colHeader",
+          text: by === "tier" ? `tier ${col}` : col,
+        });
+      }
+      for (const status of FAILURE_STATUSES) {
+        flat.push({ kind: "rowHeader", text: status });
+        for (const col of cols) {
+          const v = byCell.get(`${status}|${col}`) ?? 0;
+          flat.push({
+            kind: "cell",
+            value: v === 0 ? null : v,
+            display: v === 0 ? "—" : String(v),
+            color: heatmapColor(v === 0 ? null : v, vmin, vmax, "count"),
+            title:
+              v === 0
+                ? `${status} × ${by === "tier" ? `tier ${col}` : col}: 0`
+                : `${status} × ${by === "tier" ? `tier ${col}` : col}: ${v}`,
+          });
+        }
+      }
+      return { columnCount: cols.length, items: flat };
+    },
+
+    // ============== Derived / formatting accessors ==============
+
+    versionLabel() {
+      const v = this.data.status?.version;
+      if (!v) return "";
+      return v.git_branch ? `${v.git_commit}@${v.git_branch}` : v.git_commit;
+    },
+
+    last24Completed() {
+      const c = this.data.counts?.windows?.last_24h?.counts || {};
+      return c.Complete ?? 0;
+    },
+
+    last24Failed() {
+      const c = this.data.counts?.windows?.last_24h?.counts || {};
+      let total = 0;
+      for (const s of TERMINAL_FAILURE) total += c[s] || 0;
+      return total;
+    },
+
+    relTime(iso) {
+      return relTime(iso);
+    },
+
+    freshnessCount(rec) {
+      if (!rec) return "—";
+      return `${rec.count} entries`;
+    },
+
+    freshnessSub(rec) {
+      if (!rec) return "not yet published";
+      return `refreshed ${relTime(rec.refreshed_at)}`;
+    },
+
+    mongoDetail() {
+      const m = this.data.status?.mongo;
+      if (!m) return "—";
+      const bits = [];
+      if (m.storage_mb != null) bits.push(`${formatMb(m.storage_mb)} MB storage`);
+      if (m.queue_depth != null) bits.push(`queue ${m.queue_depth}`);
+      return bits.length ? bits.join(" · ") : "connected";
+    },
+
+    redisDetail() {
+      const r = this.data.status?.redis;
+      if (!r) return "—";
+      if (r.used_memory_mb != null) return `${formatMb(r.used_memory_mb)} MB memory`;
+      return "connected";
+    },
+
+    tierRow(n) {
+      const tiers = this.data.status?.tiers || [];
+      return tiers.find((t) => t.tier === n);
+    },
+
+    processesEmptyHint() {
+      if (this.data.status === null) return "Loading…";
+      if (!this.data.status.processes)
+        return "No `processes` field in /status response.";
+      const p = this.data.status.processes;
+      const empty =
+        !p.main && !p.background && (p.workers ?? []).length === 0;
+      return empty
+        ? "Process registry empty — check Redis HGETALL {Retriever}:workers."
+        : "";
+    },
+
+    processRows() {
+      const p = this.data.status?.processes;
+      if (!p) return [];
+      const out = [];
+      if (p.main) {
+        out.push({
+          role: "main",
+          pid: p.main.pid,
+          uptime: formatUptime(p.main.uptime_seconds),
+          rss: formatMb(p.main.rss_mb),
+        });
+      }
+      if (p.background) {
+        out.push({
+          role: "background",
+          pid: p.background.pid,
+          uptime: formatUptime(p.background.uptime_seconds),
+          rss: formatMb(p.background.rss_mb),
+        });
+      }
+      (p.workers || []).forEach((w, i) => {
+        out.push({
+          role: `worker [${i}]`,
+          pid: w.pid,
+          uptime: formatUptime(w.uptime_seconds),
+          rss: formatMb(w.rss_mb),
+        });
+      });
+      return out;
+    },
+
+    // ============== Modal stack ==============
+
+    openModal(m) {
+      this.modalStack.push(m);
+      if (m.kind === "job") {
+        // Lazy-load the per-job metadata and log preview in parallel.
+        // No `lookback` on the logs query — job logs almost always span a
+        // short window so the time filter would just risk dropping
+        // useful lines.
+        const idx = this.modalStack.length - 1;
+        const target = this.modalStack[idx];
+        fetchJson(`/status/jobs/${encodeURIComponent(m.jobId)}`)
+          .then((detail) => {
+            target.detail = detail;
+          })
+          .catch((err) => {
+            console.warn("job detail fetch failed:", err);
+          });
+        fetchText(`/logs?job_id=${encodeURIComponent(m.jobId)}&fmt=flat`)
+          .then((text) => {
+            target.logs = truncateLogLines(text);
+          })
+          .catch((err) => {
+            target.logs = `Failed to load logs: ${err.message || err}`;
+          });
+      }
+    },
+
+    popModal() {
+      this.modalStack.pop();
+    },
+
+    closeModal() {
+      this.modalStack = [];
+    },
+
+    modalTitle(m) {
+      // Job modals build their own title inline (with a click-to-copy code
+      // chip); this is the fallback used for any other modal kind.
+      if (m.kind === "job") return `Job ${m.jobId}`;
+      return "Details";
+    },
+
+    async copyJobId(jobId) {
+      try {
+        await navigator.clipboard.writeText(jobId);
+      } catch (err) {
+        console.warn("copy failed:", err);
+      }
+    },
+
+    localTime(iso) {
+      return formatLocal(iso);
+    },
+
+    fmtDuration(seconds) {
+      return formatDurationSeconds(seconds);
+    },
+
+    fmtBool(v) {
+      if (v == null) return "—";
+      return v ? "yes" : "no";
+    },
+
+    fmtNum(v) {
+      return v == null ? "—" : v;
+    },
+
+    fmtTiers(arr) {
+      return !arr || arr.length === 0 ? "—" : arr.join(", ");
+    },
+
+    /** Failure percentage over terminal jobs (completed + failed).
+     * Returns "—" when no terminal jobs have happened in the window so
+     * the cell doesn't read as "0% (false negative)". */
+    failPct(failed, completed) {
+      const terminal = (failed || 0) + (completed || 0);
+      if (terminal === 0) return "—";
+      return `${((failed / terminal) * 100).toFixed(0)}%`;
+    },
+  };
+}
+
+// Expose so the inline `x-data="dashboard()"` finds it.
+window.dashboard = dashboard;

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -14,8 +14,8 @@ const AGGREGATE_INTERVAL_MS = 60_000;
 const TIMELINE_LOOKBACK_HOURS = 24;
 const RECENT_FAILURES_LIMIT = 25;
 const ACTIVITY_PAGE_SIZE = 25;
-const ACTIVITY_MODES = ["Active", "Stuck", "Completed", "Failed"];
-const ACTIVITY_LIVE_MODES = new Set(["Active", "Stuck"]);
+const ACTIVITY_MODES = ["Running", "Stuck", "Completed", "Failed"];
+const ACTIVITY_LIVE_MODES = new Set(["Running", "Stuck"]);
 const LOOKBACK_OPTIONS = ["Last 24h", "Last 3 days", "Last week", "All time"];
 const LOOKBACK_HOURS = {
   "Last 24h": 24,
@@ -31,10 +31,10 @@ const FAILURE_STATUSES = ["Failed", "QueryNotTraversable", "UnsupportedConstrain
 
 // Performance view filters. Lookback is shared with the activity LOOKBACK_*
 // vocabulary (so URL state survives a tab switch); the status filter is
-// either "Complete" or "any-failure" (matches `/status/durations`).
+// either "Success" or "any-failure" (matches `/status/durations`).
 const PERFORMANCE_STATUS_OPTIONS = [
-  { value: "Complete", label: "Completed" },
-  { value: "failed", label: "Failed" },
+  { value: "Completed", label: "Completed" },
+  { value: "Failed", label: "Failed" },
 ];
 const PERFORMANCE_STATUS_VALUES = new Set(
   PERFORMANCE_STATUS_OPTIONS.map((o) => o.value),
@@ -427,7 +427,7 @@ function dashboard() {
     },
     performance: {
       lookback: "Last 24h",
-      status: "Complete",
+      status: "Success",
       durations: null,
       tiers: [],
       timeline: [],
@@ -652,7 +652,7 @@ function dashboard() {
       } else if (this.view === "performance") {
         if (this.performance.lookback !== "Last 24h")
           p.set("window", this.performance.lookback);
-        if (this.performance.status !== "Complete")
+        if (this.performance.status !== "Success")
           p.set("status", this.performance.status);
       } else if (this.view === "heatmaps") {
         if (this.heatmaps.lookback !== "Last week")
@@ -784,7 +784,7 @@ function dashboard() {
           // cursor protocol as Completed/Failed. The endpoints don't
           // accept submitter/tier/sort filters (they only sort by
           // created desc), so only forward the cursor/limit.
-          const path = mode === "Active" ? "/status/active" : "/status/stuck";
+          const path = mode === "Running" ? "/status/running" : "/status/stuck";
           const p = new URLSearchParams({ limit: String(ACTIVITY_PAGE_SIZE) });
           if (this.activity.cursor) p.set("cursor", this.activity.cursor);
           const page = await fetchJson(`${path}?${p}`);
@@ -879,7 +879,7 @@ function dashboard() {
 
     activityOutcome(row) {
       const m = this.activity.mode;
-      if (m === "Active") return "running";
+      if (m === "Running") return "running";
       if (m === "Stuck") return "stuck";
       if (m === "Failed") return row.status || "";
       const r = row.results;
@@ -904,7 +904,7 @@ function dashboard() {
       // from data.status.active_job_count (uncapped Mongo count).
       const [statusR, activeR, stuckR] = await Promise.allSettled([
         fetchJson("/status"),
-        fetchJson("/status/active?limit=500"),
+        fetchJson("/status/running?limit=500"),
         fetchJson("/status/stuck?limit=500"),
       ]);
       if (statusR.status === "fulfilled") {
@@ -1155,8 +1155,9 @@ function dashboard() {
       const vmax = values.length ? Math.max(...values) : 0;
       const scale = metric === "failed_pct" ? "fail" : "duration";
       // Click-through into Activity: failed% lands in Failed mode (default
-      // sort), p95 lands in Completed mode sorted by duration desc. Filters
-      // are limited to submitter/tier — no new "p95" or "failed%" filter.
+      // sort), p95 lands in Completed mode sorted by duration desc.
+      // Filters are limited to submitter/tier — no new "p95" or "failed%"
+      // filter.
       const baseJump =
         metric === "failed_pct"
           ? { mode: "Failed", lookback: this.heatmaps.lookback }
@@ -1272,7 +1273,8 @@ function dashboard() {
 
     last24Completed() {
       const c = this.data.counts?.windows?.last_24h?.counts || {};
-      return c.Complete ?? 0;
+      // Read both new ("Success") and legacy ("Complete") stored values.
+      return (c.Success ?? 0) + (c.Complete ?? 0);
     },
 
     last24Failed() {
@@ -1563,7 +1565,8 @@ function dashboard() {
     statusTone(status) {
       if (!status) return "";
       if (TERMINAL_FAILURE.has(status)) return "modal-tag--bad";
-      if (status === "Complete") return "modal-tag--good";
+      // "Complete" recognized for back-compat with pre-rename docs in MongoDB.
+      if (status === "Success" || status === "Complete") return "modal-tag--good";
       return "modal-tag--info";
     },
 

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -760,12 +760,16 @@ function dashboard() {
       const mode = this.activity.mode;
       try {
         if (ACTIVITY_LIVE_MODES.has(mode)) {
-          // Active/Stuck — flat list, no cursor, no server-side filters.
-          // Sort is applied client-side over the in-memory list.
+          // Active/Stuck are paginated server-side too, with the same
+          // cursor protocol as Completed/Failed. The endpoints don't
+          // accept submitter/tier/sort filters (they only sort by
+          // created desc), so only forward the cursor/limit.
           const path = mode === "Active" ? "/status/active" : "/status/stuck";
-          const rows = await fetchJson(path);
-          this.activity.items = rows;
-          this.activity.nextCursor = null;
+          const p = new URLSearchParams({ limit: String(ACTIVITY_PAGE_SIZE) });
+          if (this.activity.cursor) p.set("cursor", this.activity.cursor);
+          const page = await fetchJson(`${path}?${p}`);
+          this.activity.items = page.items || [];
+          this.activity.nextCursor = page.next_cursor || null;
           return;
         }
         const endpoint =
@@ -873,14 +877,18 @@ function dashboard() {
 
     async refreshRealtime() {
       try {
+        // Request the server-side max so the Stuck home card and the
+        // data.active fallback for the Active card aren't artificially
+        // capped at the default page size. The Active count itself comes
+        // from data.status.active_job_count (uncapped Mongo count).
         const [status, active, stuck] = await Promise.all([
           fetchJson("/status"),
-          fetchJson("/status/active"),
-          fetchJson("/status/stuck"),
+          fetchJson("/status/active?limit=500"),
+          fetchJson("/status/stuck?limit=500"),
         ]);
         this.data.status = status;
-        this.data.active = active;
-        this.data.stuck = stuck;
+        this.data.active = active.items || [];
+        this.data.stuck = stuck.items || [];
       } catch (err) {
         console.warn("realtime refresh failed:", err);
       }

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -190,6 +190,15 @@ function heatmapColor(value, vmin, vmax, scale) {
   return `hsl(${h}, ${c.s}%, ${c.l}%)`;
 }
 
+// Submitters are TRAPI user-agent strings; some clients send 100+ char
+// values that wreck grid layouts. Trim the *display* form to ~30 chars
+// and keep the full value in title attrs so hover still reveals it.
+const SUBMITTER_DISPLAY_MAX = 30;
+function truncateSubmitter(s) {
+  if (typeof s !== "string" || s.length <= SUBMITTER_DISPLAY_MAX) return s;
+  return s.slice(0, SUBMITTER_DISPLAY_MAX - 1) + "…";
+}
+
 function truncateLogLines(text) {
   if (!text) return "(no logs)";
   const lines = text.split("\n");
@@ -1143,11 +1152,14 @@ function dashboard() {
           jump: { ...baseJump, tier: t },
         });
       }
-      // Each data row: row label then its cells.
+      // Each data row: row label then its cells. Submitter labels can be
+      // 100+ chars and would wreck the grid; truncate the display and keep
+      // the full value in `title` for hover.
       subRows.forEach((sub, i) => {
         flat.push({
           kind: "rowHeader",
-          text: sub,
+          text: truncateSubmitter(sub),
+          title: sub,
           jump: { ...baseJump, submitter: sub },
         });
         cellGrid[i].forEach((c, j) => {
@@ -1197,9 +1209,11 @@ function dashboard() {
       const flat = [];
       flat.push({ kind: "corner" });
       for (const col of cols) {
+        const isSubmitter = by === "submitter";
         flat.push({
           kind: "colHeader",
-          text: by === "tier" ? `tier ${col}` : col,
+          text: isSubmitter ? truncateSubmitter(col) : `tier ${col}`,
+          title: isSubmitter ? col : undefined,
           jump: colJump(col),
         });
       }
@@ -1245,6 +1259,10 @@ function dashboard() {
 
     relTime(iso) {
       return relTime(iso);
+    },
+
+    truncateSubmitter(s) {
+      return truncateSubmitter(s);
     },
 
     freshnessCount(rec) {

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -1533,6 +1533,20 @@ function dashboard() {
       return formatDurationSeconds(seconds);
     },
 
+    // Treats negative timeouts (config's -1 sentinel) as "disabled".
+    fmtTimeout(seconds) {
+      if (seconds == null || seconds < 0) return "-";
+      return formatDurationSeconds(seconds);
+    },
+
+    durationTone(detail) {
+      if (!detail) return "";
+      const d = detail.duration_seconds;
+      const t = detail.job_timeout;
+      if (d == null || t == null || t < 0) return "";
+      return d > t ? "timeout-exceeded" : "";
+    },
+
     fmtBool(v) {
       if (v == null) return "—";
       return v ? "yes" : "no";
@@ -1542,8 +1556,15 @@ function dashboard() {
       return v == null ? "—" : v;
     },
 
-    fmtTiers(arr) {
-      return !arr || arr.length === 0 ? "—" : arr.join(", ");
+    fmtTier(v) {
+      return v == null ? "-" : String(v);
+    },
+
+    statusTone(status) {
+      if (!status) return "";
+      if (TERMINAL_FAILURE.has(status)) return "modal-tag--bad";
+      if (status === "Complete") return "modal-tag--good";
+      return "modal-tag--info";
     },
 
     /** Failure percentage over terminal jobs (completed + failed).

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -564,12 +564,15 @@ function dashboard() {
       redrawAllPlots();
     },
 
-    jumpToActivity({ mode, lookback, submitter, tier } = {}) {
+    jumpToActivity({ mode, lookback, submitter, tier, sortField, sortDir } = {}) {
       if (mode && ACTIVITY_MODES.includes(mode)) this.activity.mode = mode;
       if (lookback && LOOKBACK_HOURS[lookback] !== undefined)
         this.activity.lookback = lookback;
       this.activity.submitter = submitter || null;
-      this.activity.tier = tier === 0 || tier === 1 ? tier : null;
+      this.activity.tier = TIER_VALUES.has(tier) ? tier : null;
+      if (sortField && SORT_FIELD_VALUES.has(sortField))
+        this.activity.sortField = sortField;
+      if (sortDir === "asc" || sortDir === "desc") this.activity.sortDir = sortDir;
       this.activity.cursor = null;
       this.activity.history = [];
       this.view = "activity";
@@ -1117,17 +1120,37 @@ function dashboard() {
       const vmin = values.length ? Math.min(...values) : 0;
       const vmax = values.length ? Math.max(...values) : 0;
       const scale = metric === "failed_pct" ? "fail" : "duration";
+      // Click-through into Activity: failed% lands in Failed mode (default
+      // sort), p95 lands in Completed mode sorted by duration desc. Filters
+      // are limited to submitter/tier — no new "p95" or "failed%" filter.
+      const baseJump =
+        metric === "failed_pct"
+          ? { mode: "Failed", lookback: this.heatmaps.lookback }
+          : {
+              mode: "Completed",
+              lookback: this.heatmaps.lookback,
+              sortField: "duration",
+              sortDir: "desc",
+            };
       const flat = [];
       // Top-left corner.
       flat.push({ kind: "corner" });
-      // Column headers.
+      // Column headers — click filters by tier alone.
       for (const t of cols) {
-        flat.push({ kind: "colHeader", text: `tier ${t}` });
+        flat.push({
+          kind: "colHeader",
+          text: `tier ${t}`,
+          jump: { ...baseJump, tier: t },
+        });
       }
       // Each data row: row label then its cells.
       subRows.forEach((sub, i) => {
-        flat.push({ kind: "rowHeader", text: sub });
-        cellGrid[i].forEach((c) => {
+        flat.push({
+          kind: "rowHeader",
+          text: sub,
+          jump: { ...baseJump, submitter: sub },
+        });
+        cellGrid[i].forEach((c, j) => {
           flat.push({
             kind: "cell",
             value: c.value,
@@ -1137,6 +1160,7 @@ function dashboard() {
               c.value == null
                 ? `${sub}: no data`
                 : `${sub}: ${c.display}${c.count != null ? ` (n=${c.count})` : ""}`,
+            jump: { ...baseJump, submitter: sub, tier: cols[j] },
           });
         });
       });
@@ -1162,12 +1186,21 @@ function dashboard() {
       const values = raw.map((r) => r.count);
       const vmin = values.length ? Math.min(...values) : 0;
       const vmax = values.length ? Math.max(...values) : 0;
+      // Click-through lands in Failed mode filtered by the column (submitter
+      // or tier). Failure-reason rows aren't filterable from the activity
+      // tab today, so row headers don't jump.
+      const baseJump = { mode: "Failed", lookback: this.heatmaps.lookback };
+      const colJump = (col) =>
+        by === "tier"
+          ? { ...baseJump, tier: col }
+          : { ...baseJump, submitter: col };
       const flat = [];
       flat.push({ kind: "corner" });
       for (const col of cols) {
         flat.push({
           kind: "colHeader",
           text: by === "tier" ? `tier ${col}` : col,
+          jump: colJump(col),
         });
       }
       for (const status of FAILURE_STATUSES) {
@@ -1183,6 +1216,7 @@ function dashboard() {
               v === 0
                 ? `${status} × ${by === "tier" ? `tier ${col}` : col}: 0`
                 : `${status} × ${by === "tier" ? `tier ${col}` : col}: ${v}`,
+            jump: colJump(col),
           });
         }
       }

--- a/src/retriever/monitor/static/app.js
+++ b/src/retriever/monitor/static/app.js
@@ -403,6 +403,14 @@ function dashboard() {
       counts: null,
       timeline: [],
       failures: [],
+      // Timestamp of the last successful /status fetch — drives the
+      // "last heartbeat" indicator on the Server health pane so viewers
+      // can see when fresh data stops arriving (e.g. workers all down).
+      lastStatusUpdate: null,
+      // Last-known sibling workers carried across a Redis outage so the
+      // Processes panel can grey them out as cached rather than blanking
+      // entirely. Self-only when `registry_available` is false.
+      cachedWorkers: [],
     },
     activity: {
       mode: "Completed",
@@ -888,43 +896,59 @@ function dashboard() {
     },
 
     async refreshRealtime() {
-      try {
-        // Request the server-side max so the Stuck home card and the
-        // data.active fallback for the Active card aren't artificially
-        // capped at the default page size. The Active count itself comes
-        // from data.status.active_job_count (uncapped Mongo count).
-        const [status, active, stuck] = await Promise.all([
-          fetchJson("/status"),
-          fetchJson("/status/active?limit=500"),
-          fetchJson("/status/stuck?limit=500"),
-        ]);
+      // Settled, not all — so a Mongo-down 424 on /active/stuck still
+      // lets the /status snapshot reach the UI (and vice versa).
+      // Request the server-side max so the Stuck home card and the
+      // data.active fallback for the Active card aren't artificially
+      // capped at the default page size. The Active count itself comes
+      // from data.status.active_job_count (uncapped Mongo count).
+      const [statusR, activeR, stuckR] = await Promise.allSettled([
+        fetchJson("/status"),
+        fetchJson("/status/active?limit=500"),
+        fetchJson("/status/stuck?limit=500"),
+      ]);
+      if (statusR.status === "fulfilled") {
+        const status = statusR.value;
         this.data.status = status;
-        this.data.active = active.items || [];
-        this.data.stuck = stuck.items || [];
-      } catch (err) {
-        console.warn("realtime refresh failed:", err);
+        this.data.lastStatusUpdate = new Date().toISOString();
+        // Cache sibling workers while the registry is fresh so a later
+        // Redis outage still has something to render alongside the
+        // self-reporting worker.
+        if (status?.processes?.registry_available) {
+          this.data.cachedWorkers = (status.processes.workers || []).map(
+            (w) => ({ ...w, cachedAt: this.data.lastStatusUpdate }),
+          );
+        }
+      } else {
+        console.warn("realtime /status fetch failed:", statusR.reason);
+      }
+      if (activeR.status === "fulfilled") {
+        this.data.active = activeR.value.items || [];
+      }
+      if (stuckR.status === "fulfilled") {
+        this.data.stuck = stuckR.value.items || [];
       }
     },
 
     async refreshAggregates() {
-      try {
-        const [counts, timeline, failures] = await Promise.all([
-          fetchJson("/status/counts"),
-          fetchJson(
-            `/status/timeline?field=completed&granularity=hour&lookback=${TIMELINE_LOOKBACK_HOURS}`,
-          ),
-          fetchJson(`/status/failed?limit=${RECENT_FAILURES_LIMIT}`),
-        ]);
-        this.data.counts = counts;
-        this.data.timeline = timeline;
-        this.data.failures = failures.items || [];
+      const [countsR, timelineR, failuresR] = await Promise.allSettled([
+        fetchJson("/status/counts"),
+        fetchJson(
+          `/status/timeline?field=completed&granularity=hour&lookback=${TIMELINE_LOOKBACK_HOURS}`,
+        ),
+        fetchJson(`/status/failed?limit=${RECENT_FAILURES_LIMIT}`),
+      ]);
+      if (countsR.status === "fulfilled") this.data.counts = countsR.value;
+      if (timelineR.status === "fulfilled") {
+        this.data.timeline = timelineR.value;
         applyTimelineData(
           throughputPlot,
-          timeline,
-          computeTimelineRange(TIMELINE_LOOKBACK_HOURS, timeline),
+          timelineR.value,
+          computeTimelineRange(TIMELINE_LOOKBACK_HOURS, timelineR.value),
         );
-      } catch (err) {
-        console.warn("aggregate refresh failed:", err);
+      }
+      if (failuresR.status === "fulfilled") {
+        this.data.failures = failuresR.value.items || [];
       }
       // Refresh the submitter dropdown on the same cadence so a
       // long-lived session picks up new submitters without a reload.
@@ -968,32 +992,33 @@ function dashboard() {
     async fetchPerformance() {
       const lookback = this.performanceLookbackHours();
       const status = this.performance.status;
-      try {
-        const [durations, tiers, timeline] = await Promise.all([
-          fetchJson(buildUrl("/status/durations", { status, lookback })),
-          fetchJson(buildUrl("/status/tiers", { lookback })),
-          fetchJson(
-            buildUrl("/status/timeline", {
-              field: "completed",
-              granularity: "hour",
-              lookback,
-            }),
-          ),
-        ]);
-        this.performance.durations = durations;
-        this.performance.tiers = tiers;
-        this.performance.timeline = timeline;
+      const [durationsR, tiersR, timelineR] = await Promise.allSettled([
+        fetchJson(buildUrl("/status/durations", { status, lookback })),
+        fetchJson(buildUrl("/status/tiers", { lookback })),
+        fetchJson(
+          buildUrl("/status/timeline", {
+            field: "completed",
+            granularity: "hour",
+            lookback,
+          }),
+        ),
+      ]);
+      if (durationsR.status === "fulfilled")
+        this.performance.durations = durationsR.value;
+      if (tiersR.status === "fulfilled") this.performance.tiers = tiersR.value;
+      if (timelineR.status === "fulfilled") {
+        this.performance.timeline = timelineR.value;
         // Compute the shared x-range for every chart on the page.
         // Lookback gives an exact window; "All time" derives it from
         // the union timeline so tier charts still line up.
-        const range = computeTimelineRange(lookback, timeline);
+        const range = computeTimelineRange(lookback, timelineR.value);
         this.performance.xRange = range;
-        applyTimelineData(performancePlot, timeline, range);
+        applyTimelineData(performancePlot, timelineR.value, range);
         // Per-tier timelines fan out in parallel after we know which
         // tiers showed activity.
-        await this.fetchTierTimelines(tiers, range);
-      } catch (err) {
-        console.warn("performance fetch failed:", err);
+        if (tiersR.status === "fulfilled") {
+          await this.fetchTierTimelines(tiersR.value, range);
+        }
       }
     },
 
@@ -1064,8 +1089,8 @@ function dashboard() {
 
     async fetchHeatmaps() {
       const lookback = LOOKBACK_HOURS[this.heatmaps.lookback];
-      try {
-        const [submitters, tiers, st, failsSub, failsTier] = await Promise.all([
+      const [submittersR, tiersR, stR, failsSubR, failsTierR] =
+        await Promise.allSettled([
           fetchJson(buildUrl("/status/submitters", { top: 100, lookback })),
           fetchJson(buildUrl("/status/tiers", { lookback })),
           fetchJson(buildUrl("/status/submitter_tier_stats", { lookback })),
@@ -1076,14 +1101,14 @@ function dashboard() {
             buildUrl("/status/failure_breakdown", { by: "tier", lookback }),
           ),
         ]);
-        this.heatmaps.submitterTable = submitters;
-        this.heatmaps.tierTable = tiers;
-        this.heatmaps.submitterTier = st;
-        this.heatmaps.failuresBySubmitter = failsSub.rows || [];
-        this.heatmaps.failuresByTier = failsTier.rows || [];
-      } catch (err) {
-        console.warn("heatmaps fetch failed:", err);
-      }
+      if (submittersR.status === "fulfilled")
+        this.heatmaps.submitterTable = submittersR.value;
+      if (tiersR.status === "fulfilled") this.heatmaps.tierTable = tiersR.value;
+      if (stR.status === "fulfilled") this.heatmaps.submitterTier = stR.value;
+      if (failsSubR.status === "fulfilled")
+        this.heatmaps.failuresBySubmitter = failsSubR.value.rows || [];
+      if (failsTierR.status === "fulfilled")
+        this.heatmaps.failuresByTier = failsTierR.value.rows || [];
     },
 
     setHeatmapsLookback(value) {
@@ -1296,6 +1321,84 @@ function dashboard() {
       return tiers.find((t) => t.tier === n);
     },
 
+    /** Human-readable lines for a BackendHealth-shaped block when down.
+     * Returned as an array so the template can render one per div. */
+    healthDetails(block) {
+      if (!block || block.up) return [];
+      const lines = [];
+      if (block.error) lines.push(block.error);
+      if (block.last_outage) lines.push(`down since ${relTime(block.last_outage)}`);
+      if (block.last_recovery)
+        lines.push(`last recovery ${relTime(block.last_recovery)}`);
+      return lines;
+    },
+
+    /** Flags to surface beside the MetaKG tile heading. Each carries its
+     * own severity so the renderer doesn't have to map label → CSS class. */
+    metakgFlags() {
+      const m = this.data.status?.metakg;
+      if (!m) return [];
+      const flags = [];
+      if (m.self_reported)
+        flags.push({ label: "self-reported", severity: "warn" });
+      if (m.stale) flags.push({ label: "stale", severity: "bad" });
+      return flags;
+    },
+
+    /** Text for the subclass-map tile big-line. Replaces the count when
+     * the map can't be served at all. */
+    subclassBig() {
+      const s = this.data.status?.subclass_map;
+      if (!s) return "—";
+      if (!s.available) return "unavailable";
+      return `${s.count} entries`;
+    },
+
+    /** Sub-text for the subclass-map tile. Distinguishes the
+     * unavailable state (no map at all) from the "serving cached"
+     * state (map present but Tier 1 is down so it can't refresh). */
+    subclassSub() {
+      const s = this.data.status?.subclass_map;
+      if (!s) return "not yet published";
+      if (!s.available) return "Redis outage — subclass expansion skipped";
+      const tier1 = this.tierRow(1);
+      const refreshed = relTime(s.refreshed_at);
+      if (tier1 && !tier1.up) return `serving cached from ${refreshed}`;
+      return `refreshed ${refreshed}`;
+    },
+
+    /** Top-of-pane "served by" / "last update" indicator. Returns null
+     * when no status data has arrived yet. */
+    servedByText() {
+      const sb = this.data.status?.served_by;
+      if (!sb) return null;
+      return `worker ${sb.pid}`;
+    },
+
+    lastUpdateText() {
+      return this.data.lastStatusUpdate
+        ? `updated ${relTime(this.data.lastStatusUpdate)}`
+        : "no data yet";
+    },
+
+    registryAvailable() {
+      return this.data.status?.processes?.registry_available !== false;
+    },
+
+    /** Active card value — null from /status means Mongo is down; render "—". */
+    activeCardValue() {
+      const n = this.data.status?.active_job_count;
+      if (n === null) return "—";
+      return n ?? (this.data.active || []).length;
+    },
+
+    /** Stuck card value — null from /status means Mongo is down; render "—". */
+    stuckCardValue() {
+      const n = this.data.status?.stuck_job_count;
+      if (n === null) return "—";
+      return n ?? (this.data.stuck || []).length;
+    },
+
     processesEmptyHint() {
       if (this.data.status === null) return "Loading…";
       if (!this.data.status.processes)
@@ -1311,6 +1414,7 @@ function dashboard() {
     processRows() {
       const p = this.data.status?.processes;
       if (!p) return [];
+      const selfPid = this.data.status?.served_by?.pid;
       const out = [];
       if (p.main) {
         out.push({
@@ -1318,6 +1422,7 @@ function dashboard() {
           pid: p.main.pid,
           uptime: formatUptime(p.main.uptime_seconds),
           rss: formatMb(p.main.rss_mb),
+          stale: false,
         });
       }
       if (p.background) {
@@ -1326,14 +1431,44 @@ function dashboard() {
           pid: p.background.pid,
           uptime: formatUptime(p.background.uptime_seconds),
           rss: formatMb(p.background.rss_mb),
+          stale: false,
         });
       }
-      (p.workers || []).forEach((w, i) => {
+      // When the registry is available, render workers as-is. When it's
+      // not, the answering worker self-reports as the only fresh row;
+      // cached siblings (from a prior healthy poll) ride along marked
+      // stale so the operator can see who *was* up.
+      const liveWorkers = p.workers || [];
+      if (p.registry_available !== false) {
+        liveWorkers.forEach((w, i) => {
+          out.push({
+            role: `worker [${i}]`,
+            pid: w.pid,
+            uptime: formatUptime(w.uptime_seconds),
+            rss: formatMb(w.rss_mb),
+            stale: false,
+          });
+        });
+        return out;
+      }
+      const livePids = new Set(liveWorkers.map((w) => w.pid));
+      liveWorkers.forEach((w, i) => {
         out.push({
-          role: `worker [${i}]`,
+          role: `worker [${i}] (self)`,
           pid: w.pid,
           uptime: formatUptime(w.uptime_seconds),
           rss: formatMb(w.rss_mb),
+          stale: false,
+        });
+      });
+      this.data.cachedWorkers.forEach((w) => {
+        if (livePids.has(w.pid) || w.pid === selfPid) return;
+        out.push({
+          role: `worker (cached, last seen ${relTime(w.cachedAt)})`,
+          pid: w.pid,
+          uptime: formatUptime(w.uptime_seconds),
+          rss: formatMb(w.rss_mb),
+          stale: true,
         });
       });
       return out;

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -57,13 +57,23 @@
           Heatmaps
         </button>
       </nav>
-      <button
-        class="theme-toggle"
-        @click="toggleTheme()"
-        :title="theme === 'dark' ? 'Switch to light' : 'Switch to dark'"
-      >
-        <span x-text="theme === 'dark' ? '☀' : '🌙'"></span>
-      </button>
+      <div class="header-right">
+        <div
+          class="outage-banner"
+          role="alert"
+          x-show="data.status?.mongo && !data.status.mongo.up"
+        >
+          <span class="outage-banner-icon" aria-hidden="true">⚠</span>
+          <span>MongoDB down: Job tracking is unavailable!</span>
+        </div>
+        <button
+          class="theme-toggle"
+          @click="toggleTheme()"
+          :title="theme === 'dark' ? 'Switch to light' : 'Switch to dark'"
+        >
+          <span x-text="theme === 'dark' ? '🌙' : '☀️'"></span>
+        </button>
+      </div>
     </header>
 
     <main>
@@ -84,7 +94,7 @@
                 <span class="stat-icon stat-icon-good">▶</span>
                 <span class="stat-label">Active</span>
               </div>
-              <div class="stat-value" x-text="data.status?.active_job_count ?? (data.active || []).length"></div>
+              <div class="stat-value" x-text="activeCardValue()"></div>
             </button>
             <button
               class="stat-card"
@@ -94,7 +104,7 @@
                 <span class="stat-icon stat-icon-warn">⧗</span>
                 <span class="stat-label">Stuck</span>
               </div>
-              <div class="stat-value" x-text="data.status?.stuck_job_count ?? (data.stuck || []).length"></div>
+              <div class="stat-value" x-text="stuckCardValue()"></div>
             </button>
             <button
               class="stat-card"
@@ -148,6 +158,12 @@
           <header class="pane-header">
             <h3>Server health</h3>
             <span class="version" x-text="versionLabel()"></span>
+            <span
+              class="served-by"
+              x-show="servedByText()"
+              x-text="servedByText()"
+            ></span>
+            <span class="heartbeat" x-text="lastUpdateText()"></span>
             <span class="spacer"></span>
             <a
               class="btn btn-outline"
@@ -180,6 +196,13 @@
               <div class="tile-head">
                 <span class="tile-icon">⌬</span>
                 <span class="tile-title">MetaKG</span>
+                <template x-for="flag in metakgFlags()" :key="flag.label">
+                  <span
+                    class="tile-flag"
+                    :class="flag.severity === 'bad' ? 'flag-bad' : 'flag-warn'"
+                    x-text="flag.label"
+                  ></span>
+                </template>
                 <span class="ext-icon">↗</span>
               </div>
               <div
@@ -191,25 +214,25 @@
                 x-text="freshnessSub(data.status?.metakg)"
               ></div>
             </a>
-            <div class="tile">
+            <div
+              class="tile"
+              :class="data.status?.subclass_map && !data.status.subclass_map.available ? 'tile-bad' : ''"
+            >
               <div class="tile-head">
                 <span class="tile-icon">⌬</span>
                 <span class="tile-title">Subclass map</span>
               </div>
-              <div
-                class="tile-big"
-                x-text="freshnessCount(data.status?.subclass_map)"
-              ></div>
-              <div
-                class="tile-sub"
-                x-text="freshnessSub(data.status?.subclass_map)"
-              ></div>
+              <div class="tile-big" x-text="subclassBig()"></div>
+              <div class="tile-sub" x-text="subclassSub()"></div>
             </div>
           </div>
 
           <h4 class="section-label">Dependencies</h4>
           <div class="card-row">
-            <div class="tile">
+            <div
+              class="tile"
+              :class="data.status?.mongo && !data.status.mongo.up ? 'tile-bad' : ''"
+            >
               <div class="tile-head">
                 <span class="tile-icon">⛁</span>
                 <span class="tile-title">MongoDB</span>
@@ -217,12 +240,18 @@
               <div class="tile-row">
                 <span
                   class="dot"
-                  :class="data.status?.mongo?.connected ? 'good' : 'bad'"
+                  :class="data.status?.mongo?.up ? 'good' : 'bad'"
                 ></span>
                 <span x-text="mongoDetail()"></span>
               </div>
+              <template x-for="line in healthDetails(data.status?.mongo)" :key="line">
+                <div class="tile-sub tile-sub-bad" x-text="line"></div>
+              </template>
             </div>
-            <div class="tile">
+            <div
+              class="tile"
+              :class="data.status?.redis && !data.status.redis.up ? 'tile-bad' : ''"
+            >
               <div class="tile-head">
                 <span class="tile-icon">⚡</span>
                 <span class="tile-title">Dragonfly</span>
@@ -230,10 +259,13 @@
               <div class="tile-row">
                 <span
                   class="dot"
-                  :class="data.status?.redis?.connected ? 'good' : 'bad'"
+                  :class="data.status?.redis?.up ? 'good' : 'bad'"
                 ></span>
                 <span x-text="redisDetail()"></span>
               </div>
+              <template x-for="line in healthDetails(data.status?.redis)" :key="line">
+                <div class="tile-sub tile-sub-bad" x-text="line"></div>
+              </template>
             </div>
           </div>
 
@@ -242,6 +274,7 @@
             <template x-for="n in TIERS" :key="n">
               <a
                 class="tile tile-link"
+                :class="tierRow(n) && !tierRow(n).up ? 'tile-bad' : ''"
                 :href="`/metadata/tier_${n}`"
                 target="_blank"
                 rel="noopener"
@@ -254,15 +287,22 @@
                 <div class="tile-row">
                   <span
                     class="dot"
-                    :class="tierRow(n)?.connected ? 'good' : (tierRow(n) ? 'bad' : 'unknown')"
+                    :class="tierRow(n)?.up ? 'good' : (tierRow(n) ? 'bad' : 'unknown')"
                   ></span>
                   <span x-text="tierRow(n)?.backend || 'not configured'"></span>
                 </div>
+                <template x-for="line in healthDetails(tierRow(n))" :key="line">
+                  <div class="tile-sub tile-sub-bad" x-text="line"></div>
+                </template>
               </a>
             </template>
           </div>
 
           <h4 class="section-label">Processes</h4>
+          <div class="proc-banner" x-show="!registryAvailable()">
+            Process registry unavailable (Redis down). Showing this worker
+            + last-known siblings from cache.
+          </div>
           <div class="proc-table">
             <div class="proc-row proc-header">
               <div>Role</div>
@@ -276,7 +316,7 @@
               </div>
             </template>
             <template x-for="row in processRows()" :key="row.role + ':' + row.pid">
-              <div class="proc-row">
+              <div class="proc-row" :class="row.stale ? 'proc-stale' : ''">
                 <div x-text="row.role"></div>
                 <div class="ar mono" x-text="row.pid"></div>
                 <div class="ar mono" x-text="row.uptime"></div>

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -700,11 +700,13 @@
                     'heatmap-label-col':  item.kind === 'colHeader',
                     'heatmap-label-row':  item.kind === 'rowHeader',
                     'heatmap-cell':       item.kind === 'cell',
+                    'is-clickable':       !!item.jump,
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
                   :title="item.kind === 'cell' ? item.title : ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                  @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
               </template>
             </div>
@@ -723,11 +725,13 @@
                     'heatmap-label-col':  item.kind === 'colHeader',
                     'heatmap-label-row':  item.kind === 'rowHeader',
                     'heatmap-cell':       item.kind === 'cell',
+                    'is-clickable':       !!item.jump,
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
                   :title="item.kind === 'cell' ? item.title : ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                  @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
               </template>
             </div>
@@ -751,11 +755,13 @@
                     'heatmap-label-col':  item.kind === 'colHeader',
                     'heatmap-label-row':  item.kind === 'rowHeader',
                     'heatmap-cell':       item.kind === 'cell',
+                    'is-clickable':       !!item.jump,
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
                   :title="item.kind === 'cell' ? item.title : ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                  @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
               </template>
             </div>
@@ -775,11 +781,13 @@
                     'heatmap-label-col':  item.kind === 'colHeader',
                     'heatmap-label-row':  item.kind === 'rowHeader',
                     'heatmap-cell':       item.kind === 'cell',
+                    'is-clickable':       !!item.jump,
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
                   :title="item.kind === 'cell' ? item.title : ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                  @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
               </template>
             </div>

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -641,7 +641,7 @@
                   @click="jumpToActivity({ submitter: row.submitter, lookback: heatmaps.lookback })"
                   :title="`Open ${row.submitter} in Activity view`"
                 >
-                  <div x-text="row.submitter"></div>
+                  <div x-text="truncateSubmitter(row.submitter)" :title="row.submitter"></div>
                   <div class="ar mono" x-text="row.count"></div>
                   <div class="ar mono" x-text="row.completed"></div>
                   <div class="ar mono" x-text="row.failed"></div>
@@ -704,7 +704,7 @@
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
-                  :title="item.kind === 'cell' ? item.title : ''"
+                  :title="item.title || ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
                   @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
@@ -729,7 +729,7 @@
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
-                  :title="item.kind === 'cell' ? item.title : ''"
+                  :title="item.title || ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
                   @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
@@ -759,7 +759,7 @@
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
-                  :title="item.kind === 'cell' ? item.title : ''"
+                  :title="item.title || ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
                   @click="item.jump && jumpToActivity(item.jump)"
                 ></div>
@@ -785,7 +785,7 @@
                   }"
                   :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
                   :data-empty="item.kind === 'cell' && item.value == null"
-                  :title="item.kind === 'cell' ? item.title : ''"
+                  :title="item.title || ''"
                   x-text="item.kind === 'cell' ? item.display : (item.text || '')"
                   @click="item.jump && jumpToActivity(item.jump)"
                 ></div>

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -491,7 +491,7 @@
                 <div x-text="activityWhen(row)"></div>
                 <div class="ar mono" x-text="activityDuration(row)"></div>
                 <div x-text="activityOutcome(row)"></div>
-                <div class="ar mono" x-text="(row.data_tiers || []).join(',')"></div>
+                <div class="ar mono" x-text="row.data_tier ?? '-'"></div>
               </button>
             </template>
           </div>
@@ -868,6 +868,23 @@
                 :title="copied ? 'Copied!' : 'Click to copy'"
                 x-text="m.jobId"
               ></code>
+              <span class="modal-tags" x-show="m.detail">
+                <span
+                  class="modal-tag"
+                  :class="statusTone(m.detail?.status)"
+                  x-show="m.detail?.status"
+                  x-text="m.detail?.status"
+                ></span>
+                <span
+                  class="modal-tag"
+                  x-text="m.detail?.is_async ? '/asyncquery' : '/query'"
+                ></span>
+                <span
+                  class="modal-tag"
+                  x-show="m.detail?.data_tier != null"
+                  x-text="'Tier ' + m.detail?.data_tier"
+                ></span>
+              </span>
             </h3>
             <h3
               class="modal-title"
@@ -904,43 +921,63 @@
               <div class="job-detail-block">
                 <h4 class="section-label">Lifecycle</h4>
                 <dl class="job-detail">
-                  <dt>Status</dt>
-                  <dd x-text="m.detail.status"></dd>
                   <dt>Submitter</dt>
-                  <dd x-text="m.detail.submitter || '—'"></dd>
-                  <dt>Async</dt>
-                  <dd x-text="fmtBool(m.detail.is_async)"></dd>
-                  <dt>Tiers</dt>
-                  <dd x-text="fmtTiers(m.detail.data_tiers)"></dd>
+                  <dd x-text="m.detail.submitter || '-'"></dd>
                   <dt>Created</dt>
                   <dd x-text="localTime(m.detail.created)"></dd>
                   <dt>Completed</dt>
                   <dd x-text="localTime(m.detail.completed)"></dd>
+                  <dt>Timeout</dt>
+                  <dd x-text="fmtTimeout(m.detail.job_timeout)"></dd>
                   <dt>Duration</dt>
-                  <dd x-text="fmtDuration(m.detail.duration_seconds)"></dd>
+                  <dd>
+                    <span
+                      :class="durationTone(m.detail)"
+                      x-text="fmtDuration(m.detail.duration_seconds)"
+                    ></span>
+                  </dd>
                 </dl>
 
-                <h4 class="section-label">Query graph</h4>
-                <dl class="job-detail">
-                  <dt>Nodes</dt>
-                  <dd x-text="fmtNum(m.detail.qnodes)"></dd>
-                  <dt>Edges</dt>
-                  <dd x-text="fmtNum(m.detail.qedges)"></dd>
-                  <dt>Paths</dt>
-                  <dd x-text="fmtNum(m.detail.qpaths)"></dd>
-                </dl>
-
-                <h4 class="section-label">Response graph</h4>
-                <dl class="job-detail">
-                  <dt>Nodes</dt>
-                  <dd x-text="fmtNum(m.detail.knodes)"></dd>
-                  <dt>Edges</dt>
-                  <dd x-text="fmtNum(m.detail.kedges)"></dd>
-                  <dt>Aux graphs</dt>
-                  <dd x-text="fmtNum(m.detail.aux_graphs)"></dd>
-                  <dt>Results</dt>
-                  <dd x-text="fmtNum(m.detail.results)"></dd>
-                </dl>
+                <div class="detail-row">
+                  <div class="detail-col">
+                    <h4 class="section-label">Query graph</h4>
+                    <div class="stat-cards">
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Nodes</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.qnodes)"></div>
+                      </div>
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Edges</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.qedges)"></div>
+                      </div>
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Paths</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.qpaths)"></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="detail-col">
+                    <h4 class="section-label">Response graph</h4>
+                    <div class="stat-cards">
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Nodes</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.knodes)"></div>
+                      </div>
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Edges</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.kedges)"></div>
+                      </div>
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Aux graphs</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.aux_graphs)"></div>
+                      </div>
+                      <div class="stat-card stat-card-static">
+                        <div class="stat-label">Results</div>
+                        <div class="stat-value-sm mono" x-text="fmtNum(m.detail.results)"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </template>
 

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -84,7 +84,7 @@
                 <span class="stat-icon stat-icon-good">▶</span>
                 <span class="stat-label">Active</span>
               </div>
-              <div class="stat-value" x-text="(data.active || []).length"></div>
+              <div class="stat-value" x-text="data.status?.active_job_count ?? (data.active || []).length"></div>
             </button>
             <button
               class="stat-card"
@@ -94,7 +94,7 @@
                 <span class="stat-icon stat-icon-warn">⧗</span>
                 <span class="stat-label">Stuck</span>
               </div>
-              <div class="stat-value" x-text="(data.stuck || []).length"></div>
+              <div class="stat-value" x-text="data.status?.stuck_job_count ?? (data.stuck || []).length"></div>
             </button>
             <button
               class="stat-card"

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -1,0 +1,910 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Retriever — Dashboard</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/uplot@1.6.31/dist/uPlot.min.css"
+      integrity="sha384-IfV0B7MIOYuO95kO9G5ySKPz/85zqFNOAs8iy4tkK5zd9izhJAB8b7lHrwYqqmYE"
+      crossorigin="anonymous"
+    />
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/uplot@1.6.31/dist/uPlot.iife.min.js"
+      integrity="sha384-XMP23k7YSCFr13Xrkxh4IO0v1W+8fB6AP+3Vycxphp2Z0V2vocAZHyuGaFCysrtM"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      defer
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"
+      integrity="sha384-l8f0VcPi/M1iHPv8egOnY/15TDwqgbOR1anMIJWvU6nLRgZVLTLSaNqi/TOoT5Fh"
+      crossorigin="anonymous"
+    ></script>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="app.js"></script>
+  </head>
+  <body x-data="dashboard()" x-cloak>
+    <header class="app-header">
+      <nav class="tabs">
+        <button
+          class="tab"
+          :class="{ active: view === 'home' }"
+          @click="setView('home')"
+        >
+          Home
+        </button>
+        <button
+          class="tab"
+          :class="{ active: view === 'activity' }"
+          @click="setView('activity')"
+        >
+          Activity
+        </button>
+        <button
+          class="tab"
+          :class="{ active: view === 'performance' }"
+          @click="setView('performance')"
+        >
+          Performance
+        </button>
+        <button
+          class="tab"
+          :class="{ active: view === 'heatmaps' }"
+          @click="setView('heatmaps')"
+        >
+          Heatmaps
+        </button>
+      </nav>
+      <button
+        class="theme-toggle"
+        @click="toggleTheme()"
+        :title="theme === 'dark' ? 'Switch to light' : 'Switch to dark'"
+      >
+        <span x-text="theme === 'dark' ? '☀' : '🌙'"></span>
+      </button>
+    </header>
+
+    <main>
+      <!-- ================== Home view ================== -->
+      <section x-show="view === 'home'" class="view">
+        <!-- Pane: jobs headline -->
+        <div class="pane">
+          <header class="pane-header">
+            <h3>Jobs</h3>
+          </header>
+
+          <div class="stat-cards">
+            <button
+              class="stat-card"
+              @click="jumpToActivity({ mode: 'Active' })"
+            >
+              <div class="stat-row">
+                <span class="stat-icon stat-icon-good">▶</span>
+                <span class="stat-label">Active</span>
+              </div>
+              <div class="stat-value" x-text="(data.active || []).length"></div>
+            </button>
+            <button
+              class="stat-card"
+              @click="jumpToActivity({ mode: 'Stuck' })"
+            >
+              <div class="stat-row">
+                <span class="stat-icon stat-icon-warn">⧗</span>
+                <span class="stat-label">Stuck</span>
+              </div>
+              <div class="stat-value" x-text="(data.stuck || []).length"></div>
+            </button>
+            <button
+              class="stat-card"
+              @click="jumpToActivity({ mode: 'Completed', lookback: 'Last 24h' })"
+            >
+              <div class="stat-row">
+                <span class="stat-icon stat-icon-good">✓</span>
+                <span class="stat-label">Completed (24h)</span>
+              </div>
+              <div class="stat-value" x-text="last24Completed()"></div>
+            </button>
+            <button
+              class="stat-card"
+              @click="jumpToActivity({ mode: 'Failed', lookback: 'Last 24h' })"
+            >
+              <div class="stat-row">
+                <span class="stat-icon stat-icon-bad">!</span>
+                <span class="stat-label">Failed (24h)</span>
+              </div>
+              <div class="stat-value" x-text="last24Failed()"></div>
+            </button>
+          </div>
+
+          <h3 class="section-label">Throughput (last 24h, hourly)</h3>
+          <div id="throughput-chart" class="chart-container"></div>
+
+          <h3 class="section-label">Recent failures</h3>
+          <div class="failures-scroll">
+            <template x-if="(data.failures || []).length === 0">
+              <div class="empty">No recent failures.</div>
+            </template>
+            <template x-for="row in (data.failures || [])" :key="row.job_id">
+              <button
+                class="failure-row"
+                @click="openModal({ kind: 'job', jobId: row.job_id })"
+              >
+                <code class="job-short" x-text="row.job_id.slice(0, 12)"></code>
+                <span class="status-pill" x-text="row.status"></span>
+                <span class="submitter" x-text="row.submitter"></span>
+                <span
+                  class="time"
+                  x-text="relTime(row.completed)"
+                ></span>
+              </button>
+            </template>
+          </div>
+        </div>
+
+        <!-- Pane: server health -->
+        <div class="pane">
+          <header class="pane-header">
+            <h3>Server health</h3>
+            <span class="version" x-text="versionLabel()"></span>
+            <span class="spacer"></span>
+            <a
+              class="btn btn-outline"
+              href="/status/server_logs?fmt=flat&lookback=1"
+              target="_blank"
+              rel="noopener"
+            >
+              <span>Server Logs</span>
+              <span class="ext-icon">↗</span>
+            </a>
+            <a
+              class="btn btn-outline"
+              href="/logs"
+              target="_blank"
+              rel="noopener"
+            >
+              <span>All Logs</span>
+              <span class="ext-icon">↗</span>
+            </a>
+          </header>
+
+          <h4 class="section-label">Background refreshes</h4>
+          <div class="card-row">
+            <a
+              class="tile tile-link"
+              href="/meta_knowledge_graph"
+              target="_blank"
+              rel="noopener"
+            >
+              <div class="tile-head">
+                <span class="tile-icon">⌬</span>
+                <span class="tile-title">MetaKG</span>
+                <span class="ext-icon">↗</span>
+              </div>
+              <div
+                class="tile-big"
+                x-text="freshnessCount(data.status?.metakg)"
+              ></div>
+              <div
+                class="tile-sub"
+                x-text="freshnessSub(data.status?.metakg)"
+              ></div>
+            </a>
+            <div class="tile">
+              <div class="tile-head">
+                <span class="tile-icon">⌬</span>
+                <span class="tile-title">Subclass map</span>
+              </div>
+              <div
+                class="tile-big"
+                x-text="freshnessCount(data.status?.subclass_map)"
+              ></div>
+              <div
+                class="tile-sub"
+                x-text="freshnessSub(data.status?.subclass_map)"
+              ></div>
+            </div>
+          </div>
+
+          <h4 class="section-label">Dependencies</h4>
+          <div class="card-row">
+            <div class="tile">
+              <div class="tile-head">
+                <span class="tile-icon">⛁</span>
+                <span class="tile-title">MongoDB</span>
+              </div>
+              <div class="tile-row">
+                <span
+                  class="dot"
+                  :class="data.status?.mongo?.connected ? 'good' : 'bad'"
+                ></span>
+                <span x-text="mongoDetail()"></span>
+              </div>
+            </div>
+            <div class="tile">
+              <div class="tile-head">
+                <span class="tile-icon">⚡</span>
+                <span class="tile-title">Dragonfly</span>
+              </div>
+              <div class="tile-row">
+                <span
+                  class="dot"
+                  :class="data.status?.redis?.connected ? 'good' : 'bad'"
+                ></span>
+                <span x-text="redisDetail()"></span>
+              </div>
+            </div>
+          </div>
+
+          <h4 class="section-label">Tiers</h4>
+          <div class="card-row">
+            <template x-for="n in TIERS" :key="n">
+              <a
+                class="tile tile-link"
+                :href="`/metadata/tier_${n}`"
+                target="_blank"
+                rel="noopener"
+              >
+                <div class="tile-head">
+                  <span class="tile-icon">≡</span>
+                  <span class="tile-title" x-text="`Tier ${n}`"></span>
+                  <span class="ext-icon">↗</span>
+                </div>
+                <div class="tile-row">
+                  <span
+                    class="dot"
+                    :class="tierRow(n)?.connected ? 'good' : (tierRow(n) ? 'bad' : 'unknown')"
+                  ></span>
+                  <span x-text="tierRow(n)?.backend || 'not configured'"></span>
+                </div>
+              </a>
+            </template>
+          </div>
+
+          <h4 class="section-label">Processes</h4>
+          <div class="proc-table">
+            <div class="proc-row proc-header">
+              <div>Role</div>
+              <div class="ar">PID</div>
+              <div class="ar">Uptime</div>
+              <div class="ar">RSS (MB)</div>
+            </div>
+            <template x-if="processRows().length === 0">
+              <div class="proc-row proc-empty">
+                <span x-text="processesEmptyHint()"></span>
+              </div>
+            </template>
+            <template x-for="row in processRows()" :key="row.role + ':' + row.pid">
+              <div class="proc-row">
+                <div x-text="row.role"></div>
+                <div class="ar mono" x-text="row.pid"></div>
+                <div class="ar mono" x-text="row.uptime"></div>
+                <div class="ar mono" x-text="row.rss"></div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </section>
+
+      <!-- ================== Activity view ================== -->
+      <section x-show="view === 'activity'" class="view">
+        <div class="pane">
+          <header class="pane-header">
+            <h3>Activity</h3>
+          </header>
+
+          <!-- Mode chips: Active / Stuck / Completed / Failed -->
+          <div class="filter-chips">
+            <template x-for="mode in ACTIVITY_MODES" :key="mode">
+              <button
+                class="chip"
+                :class="{ active: activity.mode === mode }"
+                @click="setActivityMode(mode)"
+                x-text="mode"
+              ></button>
+            </template>
+          </div>
+
+          <!-- Filter bar: lookback / submitter / tier -->
+          <div class="filter-bar">
+            <label class="filter-field">
+              <span>Window</span>
+              <select
+                @change="setActivityLookback($event.target.value)"
+                :disabled="isLiveMode()"
+              >
+                <template x-for="opt in LOOKBACK_OPTIONS" :key="opt">
+                  <option
+                    :value="opt"
+                    :selected="activity.lookback === opt"
+                    x-text="opt"
+                  ></option>
+                </template>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Submitter</span>
+              <select
+                @change="setActivitySubmitter($event.target.value)"
+                :disabled="isLiveMode()"
+              >
+                <option
+                  value=""
+                  :selected="activity.submitter === null"
+                >
+                  (any submitter)
+                </option>
+                <template
+                  x-for="name in activity.submitterOptions"
+                  :key="name"
+                >
+                  <option
+                    :value="name"
+                    :selected="activity.submitter === name"
+                    x-text="name"
+                  ></option>
+                </template>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Tier</span>
+              <select
+                @change="setActivityTier($event.target.value)"
+                :disabled="isLiveMode()"
+              >
+                <option
+                  value=""
+                  :selected="activity.tier === null"
+                >
+                  All tiers
+                </option>
+                <template x-for="n in TIERS" :key="n">
+                  <option
+                    :value="n"
+                    :selected="activity.tier === n"
+                    x-text="`Tier ${n}`"
+                  ></option>
+                </template>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Sort by</span>
+              <select @change="setActivitySortField($event.target.value)">
+                <template x-for="opt in SORT_FIELDS" :key="opt.value">
+                  <option
+                    :value="opt.value"
+                    :selected="activity.sortField === opt.value"
+                    x-text="opt.label"
+                  ></option>
+                </template>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Direction</span>
+              <button
+                type="button"
+                class="dir-toggle"
+                @click="toggleActivitySortDir()"
+                :title="activity.sortDir === 'desc' ? 'Descending — click for ascending' : 'Ascending — click for descending'"
+              >
+                <span x-text="activity.sortDir === 'desc' ? '↓ Desc' : '↑ Asc'"></span>
+              </button>
+            </label>
+          </div>
+
+          <div class="activity-status" x-text="activityStatusText()"></div>
+
+          <div class="data-table">
+            <div class="data-row data-header">
+              <div>Job</div>
+              <div>
+                <button
+                  type="button"
+                  class="col-sort"
+                  @click="headerSortClick('submitter')"
+                >
+                  Submitter<span class="col-arrow" x-text="headerArrow('submitter')"></span>
+                </button>
+              </div>
+              <div>
+                <button
+                  type="button"
+                  class="col-sort"
+                  @click="headerSortClick(whenSortField())"
+                >
+                  <span x-text="isLiveMode() ? 'Started' : 'Completed'"></span><span class="col-arrow" x-text="headerArrow(whenSortField())"></span>
+                </button>
+              </div>
+              <div class="ar">
+                <button
+                  type="button"
+                  class="col-sort"
+                  @click="headerSortClick('duration')"
+                >
+                  Duration<span class="col-arrow" x-text="headerArrow('duration')"></span>
+                </button>
+              </div>
+              <div>
+                <button
+                  type="button"
+                  class="col-sort"
+                  @click="headerSortClick(outcomeSortField())"
+                >
+                  Outcome<span class="col-arrow" x-text="headerArrow(outcomeSortField())"></span>
+                </button>
+              </div>
+              <div class="ar">Tiers</div>
+            </div>
+            <template x-if="activity.items.length === 0">
+              <div class="data-row data-empty">
+                No jobs match the current filter.
+              </div>
+            </template>
+            <template x-for="row in sortedItems()" :key="row.job_id">
+              <button
+                class="data-row data-clickable"
+                @click="openModal({ kind: 'job', jobId: row.job_id })"
+              >
+                <code class="job-short" x-text="row.job_id.slice(0, 12)"></code>
+                <div x-text="row.submitter || ''"></div>
+                <div x-text="activityWhen(row)"></div>
+                <div class="ar mono" x-text="activityDuration(row)"></div>
+                <div x-text="activityOutcome(row)"></div>
+                <div class="ar mono" x-text="(row.data_tiers || []).join(',')"></div>
+              </button>
+            </template>
+          </div>
+
+          <div class="pagination" x-show="!isLiveMode()">
+            <button
+              class="btn"
+              :disabled="activity.history.length === 0"
+              @click="activityPrev()"
+            >
+              ← Previous
+            </button>
+            <button
+              class="btn"
+              :disabled="!activity.nextCursor"
+              @click="activityNext()"
+            >
+              Next →
+            </button>
+          </div>
+        </div>
+      </section>
+      <!-- ================== Performance view ================== -->
+      <section x-show="view === 'performance'" class="view">
+        <div class="pane">
+          <header class="pane-header">
+            <h3>Performance</h3>
+          </header>
+          <div class="filter-bar">
+            <label class="filter-field">
+              <span>Window</span>
+              <select @change="setPerformanceLookback($event.target.value)">
+                <template x-for="opt in LOOKBACK_OPTIONS" :key="opt">
+                  <option
+                    :value="opt"
+                    :selected="performance.lookback === opt"
+                    x-text="opt"
+                  ></option>
+                </template>
+              </select>
+            </label>
+            <label class="filter-field">
+              <span>Status</span>
+              <select @change="setPerformanceStatus($event.target.value)">
+                <template x-for="opt in PERFORMANCE_STATUS_OPTIONS" :key="opt.value">
+                  <option
+                    :value="opt.value"
+                    :selected="performance.status === opt.value"
+                    x-text="opt.label"
+                  ></option>
+                </template>
+              </select>
+            </label>
+          </div>
+
+          <h3 class="section-label">
+            Durations — <span x-text="(performance.durations?.sample_size ?? 0)"></span> samples
+          </h3>
+          <div class="stat-cards">
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">p50</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.p50_seconds) : '—'"></div>
+            </div>
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">p95</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.p95_seconds) : '—'"></div>
+            </div>
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">p99</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.p99_seconds) : '—'"></div>
+            </div>
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">Min</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.min_seconds) : '—'"></div>
+            </div>
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">Mean</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.avg_seconds) : '—'"></div>
+            </div>
+            <div class="stat-card stat-card-static">
+              <div class="stat-label">Max</div>
+              <div class="stat-value-sm mono" x-text="performance.durations ? fmtDuration(performance.durations.max_seconds) : '—'"></div>
+            </div>
+          </div>
+
+          <h3 class="section-label">Throughput (hourly)</h3>
+          <div id="performance-chart" class="chart-container"></div>
+        </div>
+
+        <template x-if="performance.tiers.length === 0">
+          <div class="pane">
+            <em>No tier activity in this window.</em>
+          </div>
+        </template>
+        <template x-for="row in performance.tiers" :key="row.tier">
+          <div class="pane">
+            <header class="pane-header">
+              <h3 x-text="`Tier ${row.tier}`"></h3>
+              <span class="version">
+                <span x-text="row.active"></span> active ·
+                <span x-text="row.completed"></span> completed ·
+                <span x-text="row.failed"></span> failed
+                <template x-if="row.last_activity">
+                  <span> · last <span x-text="relTime(row.last_activity)"></span></span>
+                </template>
+              </span>
+            </header>
+
+            <h3 class="section-label">
+              Durations — <span x-text="row.completed + row.failed"></span> samples
+            </h3>
+            <div class="stat-cards">
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">p50</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.p50_seconds)"></div>
+              </div>
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">p95</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.p95_seconds)"></div>
+              </div>
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">p99</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.p99_seconds)"></div>
+              </div>
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">Min</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.min_seconds)"></div>
+              </div>
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">Mean</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.avg_seconds)"></div>
+              </div>
+              <div class="stat-card stat-card-static">
+                <div class="stat-label">Max</div>
+                <div class="stat-value-sm mono" x-text="fmtDuration(row.durations.max_seconds)"></div>
+              </div>
+            </div>
+
+            <h3 class="section-label">Throughput (hourly)</h3>
+            <div
+              class="chart-container"
+              :id="`performance-chart-tier-${row.tier}`"
+              x-init="ensureTierPlot(row.tier)"
+            ></div>
+          </div>
+        </template>
+      </section>
+
+      <!-- ================== Heatmaps view ================== -->
+      <section x-show="view === 'heatmaps'" class="view">
+        <!-- Slim toolbar — window control drives every panel below it. -->
+        <div class="heatmaps-toolbar">
+          <label class="filter-field">
+            <span>Window</span>
+            <select @change="setHeatmapsLookback($event.target.value)">
+              <template x-for="opt in LOOKBACK_OPTIONS" :key="opt">
+                <option
+                  :value="opt"
+                  :selected="heatmaps.lookback === opt"
+                  x-text="opt"
+                ></option>
+              </template>
+            </select>
+          </label>
+        </div>
+
+        <!-- Row 1: simplified tables (submitters | tiers). -->
+        <div class="heatmaps-row">
+          <div class="pane">
+            <header class="pane-header"><h3>Submitters</h3></header>
+            <div class="data-table heatmaps-submitter-table">
+              <div class="data-row data-header">
+                <div>Submitter</div>
+                <div class="ar">Count</div>
+                <div class="ar">Completed</div>
+                <div class="ar">Failed</div>
+                <div class="ar">Fail %</div>
+                <div>Last seen</div>
+              </div>
+              <template x-if="heatmaps.submitterTable.length === 0">
+                <div class="data-row data-empty">No submitter activity in this window.</div>
+              </template>
+              <template x-for="row in heatmaps.submitterTable" :key="row.submitter">
+                <button
+                  type="button"
+                  class="data-row data-clickable"
+                  @click="jumpToActivity({ submitter: row.submitter, lookback: heatmaps.lookback })"
+                  :title="`Open ${row.submitter} in Activity view`"
+                >
+                  <div x-text="row.submitter"></div>
+                  <div class="ar mono" x-text="row.count"></div>
+                  <div class="ar mono" x-text="row.completed"></div>
+                  <div class="ar mono" x-text="row.failed"></div>
+                  <div class="ar mono" x-text="failPct(row.failed, row.completed)"></div>
+                  <div x-text="relTime(row.last_seen)"></div>
+                </button>
+              </template>
+            </div>
+          </div>
+          <div class="pane">
+            <header class="pane-header"><h3>Tiers</h3></header>
+            <div class="data-table heatmaps-tier-table">
+              <div class="data-row data-header">
+                <div>Tier</div>
+                <div class="ar">Count</div>
+                <div class="ar">Completed</div>
+                <div class="ar">Failed</div>
+                <div class="ar">Fail %</div>
+                <div>Last activity</div>
+              </div>
+              <template x-if="heatmaps.tierTable.length === 0">
+                <div class="data-row data-empty">No tier activity in this window.</div>
+              </template>
+              <template x-for="row in heatmaps.tierTable" :key="row.tier">
+                <button
+                  type="button"
+                  class="data-row data-clickable"
+                  @click="jumpToActivity({ tier: row.tier, lookback: heatmaps.lookback })"
+                  :title="`Open tier ${row.tier} in Activity view`"
+                >
+                  <div class="mono" x-text="`tier ${row.tier}`"></div>
+                  <div class="ar mono" x-text="row.completed + row.failed + row.active"></div>
+                  <div class="ar mono" x-text="row.completed"></div>
+                  <div class="ar mono" x-text="row.failed"></div>
+                  <div class="ar mono" x-text="failPct(row.failed, row.completed)"></div>
+                  <div x-text="row.last_activity ? relTime(row.last_activity) : '—'"></div>
+                </button>
+              </template>
+            </div>
+          </div>
+        </div>
+
+        <!-- Row 2: submitter × tier heatmaps (failed%, p95 duration). -->
+        <div class="heatmaps-row">
+          <div class="pane">
+            <header class="pane-header"><h3>Failed % by submitter × tier</h3></header>
+            <div
+              class="heatmap"
+              x-data="{ get m() { return submitterTierMatrix('failed_pct'); } }"
+              :style="`grid-template-columns: minmax(120px, max-content) repeat(${m.columnCount}, 1fr)`"
+            >
+              <template x-for="(item, idx) in m.items" :key="idx">
+                <div
+                  :class="{
+                    'heatmap-corner':     item.kind === 'corner',
+                    'heatmap-label-col':  item.kind === 'colHeader',
+                    'heatmap-label-row':  item.kind === 'rowHeader',
+                    'heatmap-cell':       item.kind === 'cell',
+                  }"
+                  :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
+                  :data-empty="item.kind === 'cell' && item.value == null"
+                  :title="item.kind === 'cell' ? item.title : ''"
+                  x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                ></div>
+              </template>
+            </div>
+          </div>
+          <div class="pane">
+            <header class="pane-header"><h3>p95 duration by submitter × tier</h3></header>
+            <div
+              class="heatmap"
+              x-data="{ get m() { return submitterTierMatrix('p95_seconds'); } }"
+              :style="`grid-template-columns: minmax(120px, max-content) repeat(${m.columnCount}, 1fr)`"
+            >
+              <template x-for="(item, idx) in m.items" :key="idx">
+                <div
+                  :class="{
+                    'heatmap-corner':     item.kind === 'corner',
+                    'heatmap-label-col':  item.kind === 'colHeader',
+                    'heatmap-label-row':  item.kind === 'rowHeader',
+                    'heatmap-cell':       item.kind === 'cell',
+                  }"
+                  :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
+                  :data-empty="item.kind === 'cell' && item.value == null"
+                  :title="item.kind === 'cell' ? item.title : ''"
+                  x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                ></div>
+              </template>
+            </div>
+          </div>
+        </div>
+
+        <!-- Row 3: failure-type × submitter / tier (count). -->
+        <div class="heatmaps-row">
+          <div class="pane" x-data="{ get m() { return failuresMatrix('submitter'); } }">
+            <header class="pane-header"><h3>Failures by submitter</h3></header>
+            <div class="empty" x-show="m.columnCount === 0">No failures in this window.</div>
+            <div
+              class="heatmap"
+              x-show="m.columnCount > 0"
+              :style="`grid-template-columns: minmax(160px, max-content) repeat(${m.columnCount}, 1fr)`"
+            >
+              <template x-for="(item, idx) in m.items" :key="idx">
+                <div
+                  :class="{
+                    'heatmap-corner':     item.kind === 'corner',
+                    'heatmap-label-col':  item.kind === 'colHeader',
+                    'heatmap-label-row':  item.kind === 'rowHeader',
+                    'heatmap-cell':       item.kind === 'cell',
+                  }"
+                  :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
+                  :data-empty="item.kind === 'cell' && item.value == null"
+                  :title="item.kind === 'cell' ? item.title : ''"
+                  x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                ></div>
+              </template>
+            </div>
+          </div>
+          <div class="pane" x-data="{ get m() { return failuresMatrix('tier'); } }">
+            <header class="pane-header"><h3>Failures by tier</h3></header>
+            <div class="empty" x-show="m.columnCount === 0">No failures in this window.</div>
+            <div
+              class="heatmap"
+              x-show="m.columnCount > 0"
+              :style="`grid-template-columns: minmax(160px, max-content) repeat(${m.columnCount}, 1fr)`"
+            >
+              <template x-for="(item, idx) in m.items" :key="idx">
+                <div
+                  :class="{
+                    'heatmap-corner':     item.kind === 'corner',
+                    'heatmap-label-col':  item.kind === 'colHeader',
+                    'heatmap-label-row':  item.kind === 'rowHeader',
+                    'heatmap-cell':       item.kind === 'cell',
+                  }"
+                  :style="item.kind === 'cell' ? `background: ${item.color}` : ''"
+                  :data-empty="item.kind === 'cell' && item.value == null"
+                  :title="item.kind === 'cell' ? item.title : ''"
+                  x-text="item.kind === 'cell' ? item.display : (item.text || '')"
+                ></div>
+              </template>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- ================== Modal stack ================== -->
+    <div
+      class="modal-backdrop"
+      x-show="modalStack.length > 0"
+      x-transition.opacity
+      @click.self="closeModal()"
+      @keydown.escape.window="modalStack.length > 0 && closeModal()"
+    >
+      <template x-for="(m, idx) in modalStack" :key="idx + ':' + m.kind + ':' + (m.jobId || '')">
+        <div
+          class="modal"
+          x-show="idx === modalStack.length - 1"
+        >
+          <header class="modal-header">
+            <button
+              class="btn btn-icon"
+              x-show="modalStack.length > 1"
+              @click="popModal()"
+              title="Back"
+            >
+              ←
+            </button>
+            <h3 class="modal-title" x-show="m.kind === 'job'">
+              <span>Job</span>
+              <code
+                class="job-id-code"
+                x-data="{ copied: false }"
+                @click="copyJobId(m.jobId); copied = true; setTimeout(() => copied = false, 1500)"
+                :class="{ 'job-id-code--copied': copied }"
+                :title="copied ? 'Copied!' : 'Click to copy'"
+                x-text="m.jobId"
+              ></code>
+            </h3>
+            <h3
+              class="modal-title"
+              x-show="m.kind !== 'job'"
+              x-text="modalTitle(m)"
+            ></h3>
+            <span class="spacer"></span>
+            <a
+              class="btn btn-flat"
+              x-show="m.kind === 'job'"
+              :href="`/response/${m.jobId}`"
+              target="_blank"
+              rel="noopener"
+            >
+              <span>Open response</span>
+              <span class="ext-icon">↗</span>
+            </a>
+            <a
+              class="btn btn-flat"
+              x-show="m.kind === 'job'"
+              :href="`/logs?job_id=${m.jobId}`"
+              target="_blank"
+              rel="noopener"
+            >
+              <span>Open full logs</span>
+              <span class="ext-icon">↗</span>
+            </a>
+            <button class="btn btn-icon" @click="closeModal()" title="Close">
+              ✕
+            </button>
+          </header>
+          <div class="modal-body">
+            <template x-if="m.kind === 'job' && m.detail">
+              <div class="job-detail-block">
+                <h4 class="section-label">Lifecycle</h4>
+                <dl class="job-detail">
+                  <dt>Status</dt>
+                  <dd x-text="m.detail.status"></dd>
+                  <dt>Submitter</dt>
+                  <dd x-text="m.detail.submitter || '—'"></dd>
+                  <dt>Async</dt>
+                  <dd x-text="fmtBool(m.detail.is_async)"></dd>
+                  <dt>Tiers</dt>
+                  <dd x-text="fmtTiers(m.detail.data_tiers)"></dd>
+                  <dt>Created</dt>
+                  <dd x-text="localTime(m.detail.created)"></dd>
+                  <dt>Completed</dt>
+                  <dd x-text="localTime(m.detail.completed)"></dd>
+                  <dt>Duration</dt>
+                  <dd x-text="fmtDuration(m.detail.duration_seconds)"></dd>
+                </dl>
+
+                <h4 class="section-label">Query graph</h4>
+                <dl class="job-detail">
+                  <dt>Nodes</dt>
+                  <dd x-text="fmtNum(m.detail.qnodes)"></dd>
+                  <dt>Edges</dt>
+                  <dd x-text="fmtNum(m.detail.qedges)"></dd>
+                  <dt>Paths</dt>
+                  <dd x-text="fmtNum(m.detail.qpaths)"></dd>
+                </dl>
+
+                <h4 class="section-label">Response graph</h4>
+                <dl class="job-detail">
+                  <dt>Nodes</dt>
+                  <dd x-text="fmtNum(m.detail.knodes)"></dd>
+                  <dt>Edges</dt>
+                  <dd x-text="fmtNum(m.detail.kedges)"></dd>
+                  <dt>Aux graphs</dt>
+                  <dd x-text="fmtNum(m.detail.aux_graphs)"></dd>
+                  <dt>Results</dt>
+                  <dd x-text="fmtNum(m.detail.results)"></dd>
+                </dl>
+              </div>
+            </template>
+
+            <h4 class="section-label" x-show="m.kind === 'job'">Logs</h4>
+            <pre
+              class="log-preview"
+              x-show="m.kind === 'job'"
+              x-text="m.logs ?? 'Loading…'"
+            ></pre>
+          </div>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/src/retriever/monitor/static/index.html
+++ b/src/retriever/monitor/static/index.html
@@ -88,11 +88,11 @@
           <div class="stat-cards">
             <button
               class="stat-card"
-              @click="jumpToActivity({ mode: 'Active' })"
+              @click="jumpToActivity({ mode: 'Running' })"
             >
               <div class="stat-row">
                 <span class="stat-icon stat-icon-good">▶</span>
-                <span class="stat-label">Active</span>
+                <span class="stat-label">Running</span>
               </div>
               <div class="stat-value" x-text="activeCardValue()"></div>
             </button>
@@ -921,6 +921,8 @@
               <div class="job-detail-block">
                 <h4 class="section-label">Lifecycle</h4>
                 <dl class="job-detail">
+                  <dt>Description</dt>
+                  <dd x-text="m.detail.description || '-'"></dd>
                   <dt>Submitter</dt>
                   <dd x-text="m.detail.submitter || '-'"></dd>
                   <dt>Created</dt>

--- a/src/retriever/monitor/static/styles.css
+++ b/src/retriever/monitor/static/styles.css
@@ -1,0 +1,911 @@
+/* Retriever dashboard.
+   Color palette is brightness-layered: body (level 0) < pane (level 1) < inner tile (level 2).
+   Dark is the default; light is opt-in via the theme toggle. */
+
+:root {
+  /* Dark palette */
+  --bg: #0f1115;
+  --surface: #1d1d1d;
+  --surface-elev: #2a2a2a;
+  --text: #e5e7eb;
+  --text-soft: #9ca3af;
+  --text-faint: #6b7280;
+  --axis-label: #e5e7eb;
+  --axis-tick: #d8dde5;
+  --border: #2f2f33;
+  --accent: #3b82f6;
+  --accent-fg: #ffffff;
+  --good: #22c55e;
+  --warn: #f59e0b;
+  --bad: #ef4444;
+  --unknown: #6b7280;
+  --hover: rgba(255, 255, 255, 0.04);
+  --radius: 8px;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+[data-theme="light"] {
+  --bg: #e5e7eb;
+  --surface: #ffffff;
+  --surface-elev: #f3f4f6;
+  --text: #111827;
+  --text-soft: #4b5563;
+  --text-faint: #6b7280;
+  --axis-label: #374151;
+  --axis-tick: #9ca3af;
+  --border: #d1d5db;
+  --accent: #2563eb;
+  --accent-fg: #ffffff;
+  --hover: rgba(0, 0, 0, 0.04);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+[x-cloak] {
+  display: none !important;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+}
+
+/* ============== Header / tabs ============== */
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.tab {
+  background: transparent;
+  border: none;
+  color: var(--text-soft);
+  padding: 8px 14px;
+  font: inherit;
+  font-size: 14px;
+  cursor: pointer;
+  border-radius: var(--radius);
+}
+
+.tab:hover {
+  background: var(--hover);
+  color: var(--text);
+}
+
+.tab.active {
+  color: var(--accent);
+  font-weight: 600;
+  border-bottom: 2px solid var(--accent);
+  border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.theme-toggle {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.theme-toggle:hover {
+  background: var(--hover);
+}
+
+/* ============== Layout ============== */
+
+main {
+  padding: 16px;
+}
+
+.view {
+  display: flex;
+  flex-direction: column;
+  gap: 16px; /* gap between panes lets the body bg show through */
+}
+
+.view.placeholder {
+  color: var(--text-soft);
+}
+
+.pane {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pane-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pane-header h3 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.section-label {
+  margin: 4px 0 0 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+  color: var(--text-faint);
+  font-weight: 600;
+}
+
+/* ============== Buttons / links ============== */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text);
+  padding: 6px 12px;
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 13px;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--hover);
+}
+
+.btn-outline {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.btn-outline:hover {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.btn-flat {
+  color: var(--text-soft);
+}
+
+.btn-icon {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  justify-content: center;
+  border: none;
+}
+
+.ext-icon {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+/* ============== Health strip ============== */
+
+.health-strip {
+  min-height: 24px;
+}
+
+.health-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+}
+
+.health-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--unknown);
+  display: inline-block;
+}
+
+.dot.good {
+  background: var(--good);
+}
+
+.dot.bad {
+  background: var(--bad);
+}
+
+.dot.unknown {
+  background: var(--unknown);
+}
+
+.version {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+/* ============== Stat cards ============== */
+
+.stat-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.stat-card {
+  background: var(--surface-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.stat-card:hover {
+  border-color: var(--accent);
+  background: var(--hover);
+}
+
+.stat-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-soft);
+}
+
+.stat-icon {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.stat-icon-good {
+  color: var(--good);
+}
+
+.stat-icon-warn {
+  color: var(--warn);
+}
+
+.stat-icon-bad {
+  color: var(--bad);
+}
+
+.stat-value {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+/* ============== Chart ============== */
+
+.chart-container {
+  width: 100%;
+  height: 180px;
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+/* ============== Recent failures ============== */
+
+.failures-scroll {
+  max-height: 400px; /* ~10 rows */
+  overflow-y: auto;
+  /* Container holds the columns so every .failure-row shares track
+   * widths via subgrid — the status-pill column then sizes once to the
+   * widest pill across all rows, not arbitrarily wide. */
+  display: grid;
+  grid-template-columns: 110px max-content 1fr auto;
+  column-gap: 12px;
+  row-gap: 4px;
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  padding: 6px;
+}
+
+.failure-row {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  text-align: left;
+}
+
+.failures-scroll > .empty {
+  grid-column: 1 / -1;
+}
+
+.failure-row:hover {
+  background: var(--hover);
+}
+
+.job-short {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.status-pill {
+  display: inline-block;
+  justify-self: start;
+  padding: 2px 0.5em;
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--bad);
+}
+
+.submitter {
+  color: var(--text-soft);
+}
+
+.time {
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.empty {
+  padding: 8px 10px;
+  color: var(--text-soft);
+  font-size: 13px;
+}
+
+/* ============== Tiles (server pane) ============== */
+
+.card-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.tile {
+  background: var(--surface-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tile-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.tile-head .ext-icon {
+  margin-left: auto;
+}
+
+.tile-link {
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.tile-link:hover {
+  border-color: var(--accent);
+}
+
+.tile-link:hover .ext-icon {
+  opacity: 1;
+  color: var(--accent);
+}
+
+.tile-icon {
+  display: inline-block;
+  width: 16px;
+}
+
+.tile-title {
+  font-weight: 500;
+}
+
+.tile-big {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.tile-sub {
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+.tile-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+
+/* ============== Activity view ============== */
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  padding: 6px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.chip:hover {
+  background: var(--hover);
+}
+
+.chip.active {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: end;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.filter-field select {
+  padding: 6px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--surface-elev);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  min-width: 160px;
+  cursor: pointer;
+}
+
+.filter-field select:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.activity-status {
+  font-size: 12px;
+  color: var(--text-soft);
+}
+
+.data-table {
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  overflow: hidden;
+  font-size: 13px;
+}
+
+.data-row {
+  display: grid;
+  grid-template-columns: 130px 1fr 130px 110px 200px 90px;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+}
+
+.tier-table .data-row {
+  grid-template-columns: 70px 80px 100px 80px 80px 80px 80px 80px 1fr;
+}
+
+.heatmaps-submitter-table .data-row {
+  grid-template-columns: 1.4fr 70px 90px 70px 70px 1.1fr;
+}
+
+.heatmaps-tier-table .data-row {
+  grid-template-columns: 80px 70px 90px 70px 70px 1.1fr;
+}
+
+/* Slim toolbar — just the window selector, no pane chrome. */
+.heatmaps-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.heatmaps-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.heatmap {
+  display: grid;
+  gap: 2px;
+  font-size: 12px;
+  align-items: stretch;
+}
+
+.heatmap-corner {
+  background: transparent;
+}
+
+.heatmap-label-col {
+  color: var(--text-soft);
+  text-align: center;
+  font-weight: 500;
+  padding: 4px 8px;
+}
+
+.heatmap-label-row {
+  color: var(--text-soft);
+  text-align: left;
+  padding: 4px 8px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.heatmap-cell {
+  background: var(--surface-elev);
+  color: var(--text);
+  padding: 4px 8px;
+  border-radius: 3px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
+  /* Drop a subtle text shadow so labels stay legible across the
+   * colored cells (light-on-dark or dark-on-light depending on theme). */
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+.heatmap-cell[data-empty="true"] {
+  background: var(--surface-elev);
+  color: var(--text-faint);
+  text-shadow: none;
+}
+
+.stat-card-static {
+  cursor: default;
+  background: var(--surface-elev);
+}
+
+.stat-card-static:hover {
+  background: var(--surface-elev);
+  border-color: var(--border);
+}
+
+.stat-value-sm {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.data-row:last-child {
+  border-bottom: none;
+}
+
+.data-header {
+  color: var(--text-soft);
+  font-weight: 500;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.col-sort {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.col-sort:hover {
+  color: var(--text);
+}
+
+.col-arrow {
+  font-size: 10px;
+  opacity: 0.85;
+  min-width: 8px;
+  display: inline-block;
+}
+
+.dir-toggle {
+  background: var(--surface-inner);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font: inherit;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  min-width: 84px;
+  text-align: center;
+}
+
+.dir-toggle:hover {
+  border-color: var(--text-soft);
+}
+
+.data-clickable {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+
+.data-clickable:hover {
+  background: var(--hover);
+}
+
+.data-empty {
+  grid-template-columns: 1fr;
+  color: var(--text-soft);
+  font-style: italic;
+}
+
+.pagination {
+  display: flex;
+  gap: 8px;
+}
+
+.btn:disabled,
+.btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ============== Process "table" (CSS grid) ============== */
+
+.proc-table {
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  overflow: hidden;
+  font-size: 13px;
+}
+
+.proc-row {
+  display: grid;
+  grid-template-columns: 1fr 100px 120px 100px;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+}
+
+.proc-row:last-child {
+  border-bottom: none;
+}
+
+.proc-header {
+  color: var(--text-soft);
+  font-weight: 500;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.proc-empty {
+  color: var(--text-soft);
+  font-style: italic;
+  grid-template-columns: 1fr; /* take full width when empty */
+}
+
+.al {
+  text-align: left;
+}
+
+.ar {
+  text-align: right;
+}
+
+.mono {
+  font-family: var(--font-mono);
+}
+
+/* ============== Modal ============== */
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 24px;
+}
+
+.modal {
+  background: var(--surface);
+  border-radius: var(--radius);
+  /* Fixed 75% of viewport in both dimensions — no responsive resize. */
+  width: 75vw;
+  height: 75vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.modal-header h3,
+.modal-header .modal-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex-shrink: 1;
+}
+
+.job-id-code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: 400;
+  background: var(--surface-elev);
+  color: var(--text);
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  word-break: break-all;
+  transition: background 0.15s, color 0.15s;
+  user-select: all; /* triple-click selects the whole id */
+}
+
+.job-id-code:hover {
+  background: var(--hover);
+}
+
+.job-id-code--copied {
+  background: var(--good);
+  color: var(--accent-fg);
+}
+
+.modal-body {
+  padding: 16px;
+  /* Modal is fixed at 75vh — let the body fill the remaining space
+   * and only scroll if a tiny viewport forces it (the log preview
+   * below takes the leftover height and handles its own overflow). */
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+}
+
+.job-detail-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.job-detail {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  font-size: 13px;
+}
+
+.job-detail dt {
+  color: var(--text-soft);
+  font-weight: 500;
+}
+
+.job-detail dd {
+  margin: 0;
+  color: var(--text);
+  word-break: break-word;
+}
+
+.log-preview {
+  background: var(--surface-elev);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  /* Take the remaining modal-body height and scroll internally. The
+   * min-height keeps the viewport usable when metadata is bulky; if
+   * the viewport is small enough that even that won't fit, the
+   * modal-body's overflow takes over. */
+  flex: 1 1 0;
+  min-height: 160px;
+  overflow-y: auto;
+  margin: 0;
+}

--- a/src/retriever/monitor/static/styles.css
+++ b/src/retriever/monitor/static/styles.css
@@ -934,6 +934,40 @@ main {
   color: var(--accent-fg);
 }
 
+/* Inline tag chips placed in the modal title bar after the job id. */
+.modal-tags {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.modal-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: 500;
+  background: var(--surface-elev);
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.modal-tag--good {
+  background: color-mix(in srgb, var(--good) 18%, transparent);
+  color: var(--good);
+}
+
+.modal-tag--info {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+}
+
+.modal-tag--bad {
+  background: color-mix(in srgb, var(--bad) 18%, transparent);
+  color: var(--bad);
+}
+
 .modal-body {
   padding: 16px;
   /* Modal is fixed at 75vh — let the body fill the remaining space
@@ -952,6 +986,27 @@ main {
   flex-direction: column;
   gap: 8px;
   margin-bottom: 16px;
+}
+
+.detail-row {
+  display: grid;
+  /* 3:4 ratio matches the 3 query-graph cards vs 4 response-graph cards,
+   * keeping individual card widths roughly equal across the two columns. */
+  grid-template-columns: 3fr 4fr;
+  gap: 16px;
+}
+
+.detail-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Stat cards inside a half-width column need a smaller minimum so 3
+ * cards still line up horizontally. */
+.detail-col .stat-cards {
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
 }
 
 .job-detail {
@@ -974,6 +1029,15 @@ main {
   margin: 0;
   color: var(--text);
   word-break: break-word;
+}
+
+.timeout-exceeded {
+  display: inline-block;
+  padding: 2px 0;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--bad) 18%, transparent);
+  color: var(--bad);
+  font-weight: 600;
 }
 
 .log-preview {

--- a/src/retriever/monitor/static/styles.css
+++ b/src/retriever/monitor/static/styles.css
@@ -100,8 +100,32 @@ body {
   border-radius: var(--radius) var(--radius) 0 0;
 }
 
-.theme-toggle {
+.outage-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border: 2px solid var(--bad);
+  border-radius: var(--radius);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--bad);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.outage-banner-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.header-right {
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.theme-toggle {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -258,6 +282,13 @@ main {
 
 .version {
   margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-faint);
+}
+
+.served-by,
+.heartbeat {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-faint);
@@ -477,6 +508,33 @@ main {
   align-items: center;
   gap: 6px;
   font-size: 13px;
+}
+
+.tile-bad {
+  border-color: var(--bad);
+}
+
+.tile-sub-bad {
+  color: var(--bad);
+}
+
+.tile-flag {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.flag-warn {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--warn);
+}
+
+.flag-bad {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--bad);
 }
 
 /* ============== Activity view ============== */
@@ -780,6 +838,21 @@ main {
   color: var(--text-soft);
   font-style: italic;
   grid-template-columns: 1fr; /* take full width when empty */
+}
+
+.proc-stale {
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.proc-banner {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid var(--bad);
+  color: var(--bad);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  font-size: 12px;
+  margin-bottom: 8px;
 }
 
 .al {

--- a/src/retriever/monitor/static/styles.css
+++ b/src/retriever/monitor/static/styles.css
@@ -633,6 +633,17 @@ main {
   text-shadow: none;
 }
 
+/* Click-to-jump affordance for heatmap items wired to jumpToActivity.
+ * Applies to cells, row headers, and column headers — anything the
+ * matrix builder stamped with a `jump` payload. */
+.heatmap .is-clickable {
+  cursor: pointer;
+}
+.heatmap .is-clickable:hover {
+  outline: 1px solid var(--accent, currentColor);
+  outline-offset: -1px;
+}
+
 .stat-card-static {
   cursor: default;
   background: var(--surface-elev);

--- a/src/retriever/query.py
+++ b/src/retriever/query.py
@@ -19,6 +19,7 @@ from retriever.types.general import APIInfo, ErrorDetail, QueryInfo
 from retriever.types.trapi import (
     AsyncQueryDict,
     AsyncQueryResponseDict,
+    LogEntryDict,
     MetaKnowledgeGraphDict,
     QueryDict,
     ResponseDict,
@@ -26,9 +27,16 @@ from retriever.types.trapi import (
 from retriever.types.trapi_pydantic import AsyncQuery as TRAPIAsyncQuery
 from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import TierNumber
-from retriever.utils import telemetry
+from retriever.utils import telemetry, worker
+from retriever.utils.job_status import NON_TERMINAL, TERMINAL_SUCCESS
 from retriever.utils.logs import TRAPILogger, structured_log_to_trapi
-from retriever.utils.mongo import JobDocs, MongoClient, MongoQueue, QueryState
+from retriever.utils.mongo import (
+    JobDoc,
+    JobStatus,
+    MongoClient,
+    MongoQueue,
+    QueryState,
+)
 
 tracer = trace.get_tracer("lookup.execution.tracer")
 MONGO_QUEUE = MongoQueue()
@@ -169,6 +177,8 @@ async def make_query(
                 query=ZSTD_COMPRESSOR.compress(ormsgpack.packb(query.body)),
                 status="Running",
                 is_async=ctx.background_tasks is not None,
+                worker_pid=worker.get_pid(),
+                worker_started_at=worker.get_started_at(),
                 **{
                     k: v
                     for k, v in query_metadata._asdict().items()
@@ -227,65 +237,152 @@ def contextualize_query_telemetry(info: dict[str, Any]) -> None:
     sentry_sdk.set_tags(info)
 
 
-async def get_job_state(job_id: str, request: Request) -> tuple[int, dict[str, Any]]:
-    """Retrieve job information from MongoDB.
+_TERMINAL_STATUS_DESCRIPTIONS: dict[str, str] = {
+    "Complete": "Job is complete.",
+    "Failed": "Job failed.",
+    "QueryNotTraversable": "Query graph was not traversable.",
+    "UnsupportedConstraint": "Query graph contained an unsupported constraint.",
+}
 
-    Returns whole job response so it can be used by either `/asyncquery_status` or `/response`.
+
+async def job_logs(job_id: str) -> list[LogEntryDict]:
+    """Return all stored logs for a job, formatted as TRAPI LogEntries."""
+    return [
+        log
+        async for log in structured_log_to_trapi(MongoClient().get_logs(job_id=job_id))
+    ]
+
+
+async def fetch_job_status(
+    job_id: str, ctx_log: TRAPILogger
+) -> tuple[JobStatus | None, Exception | None]:
+    """Read the JobStatus + bump TTL."""
+    try:
+        status_doc = await MongoClient().get_job_status(job_id, touch=True)
+        if status_doc is not None:
+            ctx_log.debug(f"Got job {job_id} status from MongoDB.", no_mongo_log=True)
+    except Exception as e:
+        ctx_log.exception(
+            f"Encountered exception retrieving job {job_id} status from MongoDB.",
+            no_mongo_log=True,
+        )
+        telemetry.capture_exception(e)
+        return None, e
+    return status_doc, None
+
+
+async def in_progress_payload(
+    job_id: str,
+    ctx_log: TRAPILogger,
+    exists: bool,
+    error: Exception | None,
+) -> tuple[int, dict[str, Any]]:
+    """Return an AsyncQueryStatusResponse for in-progress or missing job.
+
+    "Running" if the row exists or there's log evidence, "Error" if the
+    fetch raised, otherwise "Not Found".
     """
-    job: JobDocs | None = None
-    error: Exception | None = None
-    ctx_log = TRAPILogger(job_id)
+    logs = await job_logs(job_id)
+    if exists or len(logs) > 0:
+        return 200, {
+            "status": "Running",
+            "logs": logs,
+            "description": "Job is running.",
+        }
+    if error is not None:
+        return 500, {
+            "status": "Error",
+            "description": "An error occurred while attempting to retrieve job status",
+            "logs": list(ctx_log.get_logs()),
+            "error": str(error),
+            "trace": traceback.format_exc(),
+        }
+    return 404, {
+        "status": "Not Found",
+        "description": f"The provided job ID ({job_id}) was not found. It may have expired.",
+        "logs": list(ctx_log.get_logs()),
+    }
 
+
+async def terminal_status_payload(
+    job_id: str, request: Request, job_status: str
+) -> dict[str, Any]:
+    """Build an AsyncQueryStatusResponse a terminal job."""
+    return {
+        "status": job_status,
+        "description": _TERMINAL_STATUS_DESCRIPTIONS.get(
+            job_status,
+            "Job is complete."
+            if job_status in TERMINAL_SUCCESS
+            else f"Job ended with status: {job_status}.",
+        ),
+        "logs": await job_logs(job_id),
+        "response_url": f"{request.base_url}response/{job_id}",
+    }
+
+
+def unpack_doc(job: JobDoc) -> dict[str, Any]:
+    """Decompress + unpack the stored doc bytes, return {} if absent."""
+    doc_bytes = job.get("doc")
+    if doc_bytes is None:
+        return {}
+    return ormsgpack.unpackb(ZSTD_DECOMPRESSOR.decompress(doc_bytes))
+
+
+async def get_job_status(job_id: str, request: Request) -> tuple[int, dict[str, Any]]:
+    """Get the current job status and return an AsyncQueryStatusResponse."""
+    ctx_log = TRAPILogger(job_id)
+    status_doc, error = await fetch_job_status(job_id, ctx_log)
+
+    job_status = (status_doc or {}).get("status") or "Running"
+    if status_doc is None or job_status in NON_TERMINAL:
+        return await in_progress_payload(
+            job_id, ctx_log, exists=status_doc is not None, error=error
+        )
+
+    return 200, await terminal_status_payload(job_id, request, job_status)
+
+
+async def get_job_response(job_id: str, request: Request) -> tuple[int, dict[str, Any]]:
+    """Return a Response if completed, or AsyncQueryStatusResponse otherwise."""
+    ctx_log = TRAPILogger(job_id)
+    status_doc, error = await fetch_job_status(job_id, ctx_log)
+
+    job_status = (status_doc or {}).get("status") or "Running"
+    if status_doc is None or job_status in NON_TERMINAL:
+        return await in_progress_payload(
+            job_id, ctx_log, exists=status_doc is not None, error=error
+        )
+
+    # Terminal status: get the response body, otherwise build a status response.
+    job: JobDoc | None = None
     try:
         job = await MongoClient().get_job_doc(job_id)
-        if job is not None:
-            ctx_log.debug(f"Got job {job_id} response from MongoDB.", no_mongo_log=True)
     except Exception as e:
         ctx_log.exception(
             f"Encountered exception retrieving job {job_id} from MongoDB.",
             no_mongo_log=True,
         )
         telemetry.capture_exception(e)
-        error = e
-    if job is None or job.get("completed") is None:
-        job_logs = [
-            log
-            async for log in structured_log_to_trapi(
-                MongoClient().get_logs(job_id=job_id)
-            )
-        ]
-        if job is not None or len(job_logs) > 0:
-            return 200, {
-                "status": "Running",
-                "logs": job_logs,
-                "description": "Job is running.",
+
+    # If job is abandoned, respond with the query
+    if status_doc.get("abandoned"):
+        payload = await terminal_status_payload(job_id, request, job_status)
+        if job is not None and job.get("doc") is not None:
+            query = unpack_doc(job)
+            payload = {
+                **{k: v for k, v in query.items() if v is not None},
+                **payload,
             }
+        return 200, payload
 
-        if error is not None:
-            return 500, {
-                "status": "Error",
-                "description": "An error occurred while attempting to retrieve job status",
-                "logs": list(ctx_log.get_logs()),
-                "error": str(error),
-                "trace": traceback.format_exc(),
-            }
+    if job is None or job.get("doc") is None:
+        return 200, await terminal_status_payload(job_id, request, job_status)
 
-        # Otherwise we have no evidence job exists
-        return 404, {
-            "status": "Not Found",
-            "description": f"The job ID you provided ({job_id}) was not found. It may have expired.",
-            "logs": list(ctx_log.get_logs()),
-        }
-
-    # Job is terminal
-    response_bytes = job.get("doc")
-    response: dict[str, Any] = (
-        ormsgpack.unpackb(ZSTD_DECOMPRESSOR.decompress(response_bytes))
-        if response_bytes is not None
-        else {}
-    )
+    response = unpack_doc(job)
     return 200, {
         **response,
+        "status": job_status,
         "response_url": f"{request.base_url}response/{job_id}",
         "logs": response.get("logs", []),
     }

--- a/src/retriever/query.py
+++ b/src/retriever/query.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import traceback
 import uuid
-from typing import Any, Literal, NamedTuple, overload
+from http import HTTPStatus
+from typing import Any, NamedTuple, cast
 
 import ormsgpack
 import sentry_sdk
@@ -27,13 +30,14 @@ from retriever.types.trapi import (
 from retriever.types.trapi_pydantic import AsyncQuery as TRAPIAsyncQuery
 from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import TierNumber
-from retriever.utils import telemetry, worker
+from retriever.utils import service_health, telemetry, worker
 from retriever.utils.job_status import NON_TERMINAL, TERMINAL_SUCCESS
 from retriever.utils.logs import TRAPILogger, structured_log_to_trapi
 from retriever.utils.mongo import (
     JobDoc,
     JobStatus,
     MongoClient,
+    MongoOutage,
     MongoQueue,
     QueryState,
 )
@@ -57,101 +61,22 @@ class QueryMetadata(NamedTuple):
     qpaths: int
 
 
-@overload
-async def make_query(
-    func: Literal["lookup"],
-    ctx: APIInfo,
-    *,
-    body: TRAPIQuery,
-) -> tuple[int, ResponseDict]: ...
+def _resolve_lookup_timeout(
+    body: TRAPIQuery | TRAPIAsyncQuery, tier: TierNumber
+) -> float:
+    """Lookup timeout: explicit `parameters.timeout` else the per-tier default."""
+    custom = body.parameters.timeout if body.parameters is not None else None
+    if custom is not None:
+        return custom
+    return {
+        0: CONFIG.job.lookup.tier0_timeout,
+        1: CONFIG.job.lookup.tier1_timeout,
+        2: CONFIG.job.lookup.tier2_timeout,
+    }[tier]
 
 
-@overload
-async def make_query(
-    func: Literal["lookup"],
-    ctx: APIInfo,
-    *,
-    body: TRAPIAsyncQuery,
-) -> tuple[int, AsyncQueryResponseDict]: ...
-
-
-@overload
-async def make_query(
-    func: Literal["metakg"],
-    ctx: APIInfo,
-    *,
-    tier: TierNumber | None,
-) -> tuple[int, MetaKnowledgeGraphDict]: ...
-
-
-@overload
-async def make_query(
-    func: Literal["metadata"],
-    ctx: APIInfo,
-    *,
-    tier: TierNumber,
-) -> tuple[int, DINGOMetadata]: ...
-
-
-async def make_query(
-    func: Literal["lookup", "metakg", "metadata"],
-    ctx: APIInfo,
-    *,
-    body: TRAPIQuery | TRAPIAsyncQuery | None = None,
-    tier: TierNumber | None = None,  # Guaranteed to be 0 <= x <= 2
-) -> tuple[
-    int,
-    ResponseDict
-    | AsyncQueryResponseDict
-    | MetaKnowledgeGraphDict
-    | DINGOMetadata
-    | ErrorDetail,
-]:
-    """Process a request and await its response before returning.
-
-    Unhandled errors are handled by middleware.
-    """
-    job_id = uuid.uuid4().hex
-
-    if tier is None and func != "metakg":
-        tier = 0
-    if deprecated_tiers := body and body.parameters and body.parameters.tiers:
-        tier = deprecated_tiers[0]
-    if custom_tier := body and body.parameters and body.parameters.tier:
-        tier = custom_tier
-
-    custom_timeout = (
-        body.parameters.timeout
-        if body is not None and body.parameters is not None
-        else None
-    )
-    timeout = custom_timeout
-    if timeout is None and func in ("metakg", "metadata"):
-        timeout = CONFIG.job.metakg.timeout
-    elif timeout is None:
-        timeout = {
-            0: CONFIG.job.lookup.tier0_timeout,
-            1: CONFIG.job.lookup.tier1_timeout,
-            2: CONFIG.job.lookup.tier2_timeout,
-        }[tier or 0]
-
-    body_transformed: QueryDict | AsyncQueryDict | None = None
-    if body is not None:
-        if isinstance(body, TRAPIQuery):
-            body_transformed = QueryDict(**body.model_dump(mode="json"))
-        else:
-            body_transformed = AsyncQueryDict(**body.model_dump(mode="json"))
-
-    query = QueryInfo(
-        endpoint=ctx.request.url.path,
-        method=ctx.request.method,
-        body=body_transformed,
-        job_id=job_id,
-        tier=tier,
-        timeout=timeout,
-    )
-
-    query_metadata = get_query_metadata(query, func, ctx.background_tasks is not None)
+def _contextualize(query_metadata: QueryMetadata, timeout: float) -> None:
+    """Tag telemetry with the resolved query metadata; failures are logged, not raised."""
     with logger.catch(
         Exception,
         level="ERROR",
@@ -165,12 +90,21 @@ async def make_query(
             }
         )
 
-    query_function = {
-        "lookup": lookup,
-        "metakg": trapi_metakg,
-        "metadata": get_metadata,
-    }[func]
-    if func == "lookup":
+
+def _record_initial_state(
+    query: QueryInfo,
+    ctx: APIInfo,
+    query_metadata: QueryMetadata,
+) -> None:
+    """Persist the initial Running state; drop quietly to the server log on outage.
+
+    Server-side log only, no TRAPI/job-log entry: the final-state write at
+    lookup completion is the user-visible signal - it attaches the mongo-outage
+    warning to the response. An initial-state drop just means /asyncquery_status
+    can't observe the job; logging at the server gives operators the signal
+    without polluting the response.
+    """
+    try:
         MONGO_QUEUE.put(
             "job_state",
             QueryState(
@@ -186,23 +120,125 @@ async def make_query(
                 },
             ),
         )
+    except MongoOutage:
+        logger.warning(
+            f"Initial job state for {query.job_id} dropped - MongoDB unavailable.",
+            no_mongo_log=True,
+        )
 
-    # TRAPI Async vs Sync query (client wants callback vs. will wait)
-    if ctx.background_tasks is not None:  # TRAPI Asyncquery lookup
+
+async def make_lookup_query(
+    ctx: APIInfo,
+    body: TRAPIQuery | TRAPIAsyncQuery,
+) -> tuple[HTTPStatus, ResponseDict | AsyncQueryResponseDict | ErrorDetail]:
+    """Process a TRAPI /query or /asyncquery request.
+
+    Unhandled errors are handled by middleware.
+    """
+    job_id = uuid.uuid4().hex
+
+    tier: TierNumber = 0
+    if deprecated_tiers := body.parameters and body.parameters.tiers:
+        tier = deprecated_tiers[0]
+    if custom_tier := body.parameters and body.parameters.tier:
+        tier = custom_tier
+
+    timeout = _resolve_lookup_timeout(body, tier)
+
+    body_transformed: QueryDict | AsyncQueryDict
+    if isinstance(body, TRAPIQuery):
+        body_transformed = QueryDict(**body.model_dump(mode="json"))
+    else:
+        body_transformed = AsyncQueryDict(**body.model_dump(mode="json"))
+
+    resolved = service_health.Snapshot().select_tier(body, tier)
+    if isinstance(resolved[0], HTTPStatus):
+        return cast("tuple[HTTPStatus, ErrorDetail]", resolved)
+    tier, extra_warnings = cast("tuple[TierNumber, list[LogEntryDict]]", resolved)
+
+    query = QueryInfo(
+        endpoint=ctx.request.url.path,
+        method=ctx.request.method,
+        body=body_transformed,
+        job_id=job_id,
+        tier=tier,
+        timeout=timeout,
+    )
+
+    query_type = "lookup-async" if ctx.background_tasks is not None else "lookup"
+    query_metadata = get_query_metadata(query, query_type)
+    _contextualize(query_metadata, timeout)
+    _record_initial_state(query, ctx, query_metadata)
+
+    if ctx.background_tasks is not None:
         carrier = dict[str, str]()
         propagate.inject(carrier, context.get_current())
-        ctx.background_tasks.add_task(async_lookup, query=query, ctx=carrier)
-        return 200, AsyncQueryResponseDict(
+        ctx.background_tasks.add_task(
+            async_lookup, query=query, ctx=carrier, extra_warnings=extra_warnings
+        )
+        return HTTPStatus.OK, AsyncQueryResponseDict(
             status="Accepted",
             description="Query has been queued for processing.",
             job_id=job_id,
         )
-    else:  # Sync query
-        status_code, response_body = await query_function(query)
-        return status_code, response_body
+
+    status_code, response = await lookup(query)
+    if extra_warnings:
+        response["logs"] = [*(response.get("logs") or []), *extra_warnings]
+    return status_code, response
 
 
-def get_query_metadata(query: QueryInfo, func: str, is_async: bool) -> QueryMetadata:
+async def make_metakg_query(
+    ctx: APIInfo,
+    tier: TierNumber | None,
+) -> tuple[HTTPStatus, MetaKnowledgeGraphDict | ErrorDetail]:
+    """Process a /meta_knowledge_graph request.
+
+    Unhandled errors are handled by middleware.
+    """
+    job_id = uuid.uuid4().hex
+    timeout = CONFIG.job.metakg.timeout
+
+    query = QueryInfo(
+        endpoint=ctx.request.url.path,
+        method=ctx.request.method,
+        body=None,
+        job_id=job_id,
+        tier=tier,
+        timeout=timeout,
+    )
+    query_metadata = get_query_metadata(query, "metakg")
+    _contextualize(query_metadata, timeout)
+
+    return await trapi_metakg(query)
+
+
+async def make_metadata_query(
+    ctx: APIInfo,
+    tier: TierNumber,
+) -> tuple[HTTPStatus, DINGOMetadata | ErrorDetail]:
+    """Process a /metadata/tier_N request.
+
+    Unhandled errors are handled by middleware.
+    """
+    job_id = uuid.uuid4().hex
+    timeout = CONFIG.job.metakg.timeout
+
+    query = QueryInfo(
+        endpoint=ctx.request.url.path,
+        method=ctx.request.method,
+        body=None,
+        job_id=job_id,
+        tier=tier,
+        timeout=timeout,
+    )
+    query_metadata = get_query_metadata(query, "metadata")
+    _contextualize(query_metadata, timeout)
+
+    return await get_metadata(query)
+
+
+def get_query_metadata(query: QueryInfo, query_type: str) -> QueryMetadata:
     """Obtain useful metrics about the query."""
     qnodes, qedges, qpaths = 0, 0, 0
     body = query.body
@@ -221,7 +257,7 @@ def get_query_metadata(query: QueryInfo, func: str, is_async: bool) -> QueryMeta
         job_id=query.job_id,
         job_timeout=query.timeout,
         data_tier=query.tier,
-        query_type=func if not is_async else f"{func}-async",
+        query_type=query_type,
         submitter=get_submitter(query),
         qnodes=qnodes,
         qedges=qedges,
@@ -276,7 +312,7 @@ async def in_progress_payload(
     ctx_log: TRAPILogger,
     exists: bool,
     error: Exception | None,
-) -> tuple[int, dict[str, Any]]:
+) -> tuple[HTTPStatus, dict[str, Any]]:
     """Return an AsyncQueryStatusResponse for in-progress or missing job.
 
     "Running" if the row exists or there's log evidence, "Error" if the
@@ -284,20 +320,20 @@ async def in_progress_payload(
     """
     logs = await job_logs(job_id)
     if exists or len(logs) > 0:
-        return 200, {
+        return HTTPStatus.OK, {
             "status": "Running",
             "logs": logs,
             "description": "Job is running.",
         }
     if error is not None:
-        return 500, {
+        return HTTPStatus.INTERNAL_SERVER_ERROR, {
             "status": "Error",
             "description": "An error occurred while attempting to retrieve job status",
             "logs": list(ctx_log.get_logs()),
             "error": str(error),
             "trace": traceback.format_exc(),
         }
-    return 404, {
+    return HTTPStatus.NOT_FOUND, {
         "status": "Not Found",
         "description": f"The provided job ID ({job_id}) was not found. It may have expired.",
         "logs": list(ctx_log.get_logs()),
@@ -329,7 +365,9 @@ def unpack_doc(job: JobDoc) -> dict[str, Any]:
     return ormsgpack.unpackb(ZSTD_DECOMPRESSOR.decompress(doc_bytes))
 
 
-async def get_job_status(job_id: str, request: Request) -> tuple[int, dict[str, Any]]:
+async def get_job_status(
+    job_id: str, request: Request
+) -> tuple[HTTPStatus, dict[str, Any]]:
     """Get the current job status and return an AsyncQueryStatusResponse."""
     ctx_log = TRAPILogger(job_id)
     status_doc, error = await fetch_job_status(job_id, ctx_log)
@@ -340,10 +378,12 @@ async def get_job_status(job_id: str, request: Request) -> tuple[int, dict[str, 
             job_id, ctx_log, exists=status_doc is not None, error=error
         )
 
-    return 200, await terminal_status_payload(job_id, request, job_status)
+    return HTTPStatus.OK, await terminal_status_payload(job_id, request, job_status)
 
 
-async def get_job_response(job_id: str, request: Request) -> tuple[int, dict[str, Any]]:
+async def get_job_response(
+    job_id: str, request: Request
+) -> tuple[HTTPStatus, dict[str, Any]]:
     """Return a Response if completed, or AsyncQueryStatusResponse otherwise."""
     ctx_log = TRAPILogger(job_id)
     status_doc, error = await fetch_job_status(job_id, ctx_log)
@@ -374,13 +414,13 @@ async def get_job_response(job_id: str, request: Request) -> tuple[int, dict[str
                 **{k: v for k, v in query.items() if v is not None},
                 **payload,
             }
-        return 200, payload
+        return HTTPStatus.OK, payload
 
     if job is None or job.get("doc") is None:
-        return 200, await terminal_status_payload(job_id, request, job_status)
+        return HTTPStatus.OK, await terminal_status_payload(job_id, request, job_status)
 
     response = unpack_doc(job)
-    return 200, {
+    return HTTPStatus.OK, {
         **response,
         "status": job_status,
         "response_url": f"{request.base_url}response/{job_id}",

--- a/src/retriever/query.py
+++ b/src/retriever/query.py
@@ -31,7 +31,11 @@ from retriever.types.trapi_pydantic import AsyncQuery as TRAPIAsyncQuery
 from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import TierNumber
 from retriever.utils import service_health, telemetry, worker
-from retriever.utils.job_status import NON_TERMINAL, TERMINAL_SUCCESS
+from retriever.utils.job_status import (
+    NON_TERMINAL,
+    TERMINAL_SUCCESS,
+    to_async_lifecycle,
+)
 from retriever.utils.logs import TRAPILogger, structured_log_to_trapi
 from retriever.utils.mongo import (
     JobDoc,
@@ -274,7 +278,7 @@ def contextualize_query_telemetry(info: dict[str, Any]) -> None:
 
 
 _TERMINAL_STATUS_DESCRIPTIONS: dict[str, str] = {
-    "Complete": "Job is complete.",
+    "Success": "Job is complete.",
     "Failed": "Job failed.",
     "QueryNotTraversable": "Query graph was not traversable.",
     "UnsupportedConstraint": "Query graph contained an unsupported constraint.",
@@ -341,17 +345,27 @@ async def in_progress_payload(
 
 
 async def terminal_status_payload(
-    job_id: str, request: Request, job_status: str
+    job_id: str, request: Request, status_doc: JobStatus
 ) -> dict[str, Any]:
-    """Build an AsyncQueryStatusResponse a terminal job."""
+    """Build an AsyncQueryStatusResponse for a terminal job.
+
+    Stored status is an outcome shortcode (Success, QueryNotTraversable, ...);
+    we emit its TRAPI 1.6 lifecycle equivalent (Completed / Failed) on the
+    response. Description prefers the per-job string written by the lookup
+    engine (which can include constraint names, edge ids, etc.) and falls
+    back to a status-keyed default for legacy docs that pre-date the field.
+    """
+    job_status = status_doc["status"]
+    stored_description = status_doc.get("description")
+    description = stored_description or _TERMINAL_STATUS_DESCRIPTIONS.get(
+        job_status,
+        "Job is complete."
+        if job_status in TERMINAL_SUCCESS
+        else f"Job ended with status: {job_status}.",
+    )
     return {
-        "status": job_status,
-        "description": _TERMINAL_STATUS_DESCRIPTIONS.get(
-            job_status,
-            "Job is complete."
-            if job_status in TERMINAL_SUCCESS
-            else f"Job ended with status: {job_status}.",
-        ),
+        "status": to_async_lifecycle(job_status),
+        "description": description,
         "logs": await job_logs(job_id),
         "response_url": f"{request.base_url}response/{job_id}",
     }
@@ -378,7 +392,7 @@ async def get_job_status(
             job_id, ctx_log, exists=status_doc is not None, error=error
         )
 
-    return HTTPStatus.OK, await terminal_status_payload(job_id, request, job_status)
+    return HTTPStatus.OK, await terminal_status_payload(job_id, request, status_doc)
 
 
 async def get_job_response(
@@ -407,7 +421,7 @@ async def get_job_response(
 
     # If job is abandoned, respond with the query
     if status_doc.get("abandoned"):
-        payload = await terminal_status_payload(job_id, request, job_status)
+        payload = await terminal_status_payload(job_id, request, status_doc)
         if job is not None and job.get("doc") is not None:
             query = unpack_doc(job)
             payload = {
@@ -417,7 +431,7 @@ async def get_job_response(
         return HTTPStatus.OK, payload
 
     if job is None or job.get("doc") is None:
-        return HTTPStatus.OK, await terminal_status_payload(job_id, request, job_status)
+        return HTTPStatus.OK, await terminal_status_payload(job_id, request, status_doc)
 
     response = unpack_doc(job)
     return HTTPStatus.OK, {

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -17,6 +17,7 @@ from fastapi.responses import (
     Response,
     StreamingResponse,
 )
+from loguru import logger
 from reasoner_pydantic import AsyncQueryStatusResponse as TRAPIAsyncQueryStatusResponse
 
 from retriever.config.general import CONFIG
@@ -27,12 +28,13 @@ from retriever.lookup.subclass import SubclassMapping
 from retriever.lookup.subquery import SubqueryDispatcher
 from retriever.lookup.utils import QueryDumper
 from retriever.metadata.optable import OpTableManager
-from retriever.query import get_job_state, make_query
+from retriever.query import get_job_response, get_job_status, make_query
 from retriever.types.general import APIInfo, ErrorDetail, LogLevel
 from retriever.types.trapi_pydantic import AsyncQuery as TRAPIAsyncQuery
 from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import Response as TRAPIResponse
 from retriever.types.trapi_pydantic import TierNumber
+from retriever.utils import worker
 from retriever.utils.examples import EXAMPLE_QUERY
 from retriever.utils.exception_handlers import ensure_cors
 from retriever.utils.logs import (
@@ -77,6 +79,7 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
 
     worker_pid = os.getpid()
     worker_started_at = datetime.now().astimezone()
+    worker.init(worker_started_at)
     await RedisClient().register_worker(
         worker_pid, worker_started_at, PROCESS_TTL_SECONDS
     )
@@ -109,6 +112,15 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     heartbeat_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await heartbeat_task
+    # Deregister immediately so orphan detection doesn't have to wait for
+    # TTL. Swallow failures: the entry will expire on its own.
+    try:
+        await RedisClient().unregister_worker(worker_pid)
+    except Exception:
+        logger.warning(
+            "Worker deregistration failed; entry will expire via TTL.",
+            no_mongo_log=True,
+        )
     await SubqueryDispatcher().wrapup()
     if query_dumper.initialized:
         await query_dumper.wrapup()
@@ -330,27 +342,7 @@ async def asyncquery(
 )
 async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
     """Get the status of an asynchronous query."""
-    job_id = job_id.lower()
-    status_code, job_dict = await get_job_state(job_id, request)
-
-    # Remove keys not meant for asyncquery_status
-    del_keys: list[str] = [
-        key
-        for key in job_dict
-        if key
-        not in (
-            "job_id",
-            "status",
-            "description",
-            "logs",
-            "response_url",
-            "error",
-            "trace",
-        )
-    ]
-    for key in del_keys:
-        del job_dict[key]
-
+    status_code, job_dict = await get_job_status(job_id.lower(), request)
     return ORJSONResponse(job_dict, status_code=status_code)
 
 
@@ -370,8 +362,7 @@ async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
 )
 async def response(request: Request, job_id: str) -> ORJSONResponse:
     """Get the response for a query (or logs if it's in progress)."""
-    job_id = job_id.lower()
-    status_code, job_dict = await get_job_state(job_id, request)
+    status_code, job_dict = await get_job_response(job_id.lower(), request)
     return ORJSONResponse(job_dict, status_code=status_code)
 
 

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -1,11 +1,10 @@
-import asyncio
-import contextlib
 import functools
 import io
 import os
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from typing import Annotated, Any, Literal
 
 import yaml
@@ -28,15 +27,22 @@ from retriever.lookup.subclass import SubclassMapping
 from retriever.lookup.subquery import SubqueryDispatcher
 from retriever.lookup.utils import QueryDumper
 from retriever.metadata.optable import OpTableManager
-from retriever.query import get_job_response, get_job_status, make_query
+from retriever.query import (
+    get_job_response,
+    get_job_status,
+    make_lookup_query,
+    make_metadata_query,
+    make_metakg_query,
+)
 from retriever.types.general import APIInfo, ErrorDetail, LogLevel
 from retriever.types.trapi_pydantic import AsyncQuery as TRAPIAsyncQuery
 from retriever.types.trapi_pydantic import Query as TRAPIQuery
 from retriever.types.trapi_pydantic import Response as TRAPIResponse
 from retriever.types.trapi_pydantic import TierNumber
-from retriever.utils import worker
+from retriever.utils import service_health, worker
 from retriever.utils.examples import EXAMPLE_QUERY
-from retriever.utils.exception_handlers import ensure_cors
+from retriever.utils.exception_handlers import ensure_cors, http_exception_handler
+from retriever.utils.general import tolerate_init
 from retriever.utils.logs import (
     add_mongo_sink,
     cleanup,
@@ -44,11 +50,7 @@ from retriever.utils.logs import (
     structured_log_to_trapi,
 )
 from retriever.utils.mongo import MongoClient, MongoQueue
-from retriever.utils.redis import (
-    PROCESS_TTL_SECONDS,
-    RedisClient,
-    heartbeat,
-)
+from retriever.utils.redis import RedisClient
 from retriever.utils.telemetry import configure_telemetry
 from retriever.utils.trapi import append_aggregator_source
 from retriever.utils.version import get_version
@@ -61,10 +63,14 @@ JOB_ID_PATTERN = r"^[a-zA-Z0-9]+$"
 # Lifespan handling for each FastAPI worker (not main process, see __main__.py)
 async def _refresh_worker_registration(pid: int, started_at: datetime) -> None:
     """One heartbeat tick: re-register the worker (and main, in debug)."""
-    await RedisClient().register_worker(pid, started_at, PROCESS_TTL_SECONDS)
+    await RedisClient().register_worker(
+        pid, started_at, CONFIG.redis.process_ttl_seconds
+    )
     if CONFIG.debug:
         # In debug mode this worker is also the main entry-point.
-        await RedisClient().register_main(pid, started_at, PROCESS_TTL_SECONDS)
+        await RedisClient().register_main(
+            pid, started_at, CONFIG.redis.process_ttl_seconds
+        )
 
 
 @asynccontextmanager
@@ -80,27 +86,30 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     worker_pid = os.getpid()
     worker_started_at = datetime.now().astimezone()
     worker.init(worker_started_at)
-    await RedisClient().register_worker(
-        worker_pid, worker_started_at, PROCESS_TTL_SECONDS
-    )
-    heartbeat_task = asyncio.create_task(
-        heartbeat(
-            lambda: _refresh_worker_registration(worker_pid, worker_started_at),
-            role_label="Worker",
+    await tolerate_init(
+        "Worker registration",
+        RedisClient().register_worker(
+            worker_pid, worker_started_at, CONFIG.redis.process_ttl_seconds
         ),
-        name="worker-heartbeat",
     )
-    # In debug mode there's no separate entry-point process — this worker
-    # *is* the main. Register it under both so /status.processes.main isn't
+    RedisClient().start_heartbeat(
+        lambda: _refresh_worker_registration(worker_pid, worker_started_at),
+        role_label="Worker",
+    )
+    # In debug mode main and worker are the same.
+    # Register it under both so /status.processes.main isn't
     # null. In production main is registered by __main__.py.
     if CONFIG.debug:
-        await RedisClient().register_main(
-            worker_pid, worker_started_at, PROCESS_TTL_SECONDS
+        await tolerate_init(
+            "Main registration",
+            RedisClient().register_main(
+                worker_pid, worker_started_at, CONFIG.redis.process_ttl_seconds
+            ),
         )
 
-    await OpTableManager().initialize()
-    await tier_manager.connect_drivers()
-    await SubclassMapping().initialize()
+    await tolerate_init("OpTable pull", OpTableManager().initialize())
+    await tier_manager.initialize_drivers()
+    await tolerate_init("Subclass map pull", SubclassMapping().initialize())
     query_dumper = QueryDumper()
     if CONFIG.tier0.dump_queries or CONFIG.tier1.dump_queries:
         await query_dumper.initialize()
@@ -109,11 +118,6 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     yield  # Separates startup/shutdown phase
 
     # Shutdown
-    heartbeat_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await heartbeat_task
-    # Deregister immediately so orphan detection doesn't have to wait for
-    # TTL. Swallow failures: the entry will expire on its own.
     try:
         await RedisClient().unregister_worker(worker_pid)
     except Exception:
@@ -125,11 +129,11 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     if query_dumper.initialized:
         await query_dumper.wrapup()
     await SubclassMapping().wrapup()
-    await tier_manager.close_drivers()
+    await tier_manager.wrapup_drivers()
     await OpTableManager().wrapup()
     await RedisClient().wrapup()
     await MongoQueue().wrapup()
-    await MongoClient().close()
+    await MongoClient().wrapup()
     await cleanup()
 
 
@@ -140,7 +144,7 @@ from retriever.status import router as status_router  # noqa: E402
 
 app.include_router(status_router)
 
-# Mount the dashboard at /monitor — static HTML/JS/CSS that polls the
+# Mount the dashboard at /monitor - static HTML/JS/CSS that polls the
 # /status/* endpoints from the browser. No server-side session state.
 from pathlib import Path  # noqa: E402
 
@@ -167,6 +171,9 @@ app.add_middleware(
 async def exception_ensure_cors(request: Request, exc: Exception) -> Response:
     """Ensure CORS is not lost on exception."""
     return await ensure_cors(app, request, exc)
+
+
+app.add_exception_handler(HTTPException, http_exception_handler)  # pyright: ignore[reportArgumentType]
 
 
 # Configure profiling middleware
@@ -225,11 +232,31 @@ async def meta_knowledge_graph(
     ] = None,
 ) -> ORJSONResponse:
     """Retrieve the Meta-Knowledge Graph."""
-    status_code, response_dict = await make_query(
-        "metakg", APIInfo(request, response), tier=tier
+    snap = service_health.Snapshot()
+    if tier is not None:
+        resolved = snap.select_tier(None, tier, allow_fallback=False)
+        if isinstance(resolved[0], HTTPStatus):
+            status_code, detail = resolved
+            raise HTTPException(status_code, detail=detail)
+    elif snap.http_status_for("/meta_knowledge_graph") is not None:
+        tier_statuses = [tier_manager.get_driver(n).status() for n in range(2)]
+        raise HTTPException(
+            HTTPStatus.FAILED_DEPENDENCY,
+            detail=ErrorDetail(
+                detail="No tier backends are available.",
+                additional_info={
+                    f"tier_{n}": {
+                        "outage_time": s["last_outage"],
+                        "outage_error": s["error"],
+                    }
+                    for n, s in enumerate(tier_statuses)
+                },
+            ),
+        )
+    status_code, response_dict = await make_metakg_query(
+        APIInfo(request, response), tier=tier
     )
     return ORJSONResponse(response_dict, status_code=status_code)
-    # return {"logs": list(logs)}
 
 
 @app.get(
@@ -241,8 +268,12 @@ async def metadata(
     request: Request, response: Response, tier: TierNumber
 ) -> ORJSONResponse:
     """Retrieve the metadata associated with a given Data Tier."""
-    status_code, response_dict = await make_query(
-        func="metadata", ctx=APIInfo(request, response), tier=tier
+    resolved = service_health.Snapshot().select_tier(None, tier, allow_fallback=False)
+    if isinstance(resolved[0], HTTPStatus):
+        status_code, detail = resolved
+        raise HTTPException(status_code, detail=detail)
+    status_code, response_dict = await make_metadata_query(
+        APIInfo(request, response), tier=tier
     )
     return ORJSONResponse(response_dict, status_code=status_code)
 
@@ -277,8 +308,8 @@ async def query(
     body: Annotated[TRAPIQuery, Body(examples=[EXAMPLE_QUERY])],
 ) -> ORJSONResponse:
     """Initiate a synchronous query."""
-    status_code, response_dict = await make_query(
-        "lookup", APIInfo(request, response), body=body
+    status_code, response_dict = await make_lookup_query(
+        APIInfo(request, response), body=body
     )
     return ORJSONResponse(response_dict, status_code=status_code)
     # return {}
@@ -314,8 +345,8 @@ async def asyncquery(
     background_tasks: BackgroundTasks,
 ) -> ORJSONResponse:
     """Initiate an asynchronous query."""
-    status_code, response_dict = await make_query(
-        "lookup", APIInfo(request, response, background_tasks), body=body
+    status_code, response_dict = await make_lookup_query(
+        APIInfo(request, response, background_tasks), body=body
     )
     return ORJSONResponse(response_dict, status_code=status_code)
 
@@ -342,6 +373,14 @@ async def asyncquery(
 )
 async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
     """Get the status of an asynchronous query."""
+    if status_code := service_health.Snapshot().http_status_for("/asyncquery_status"):
+        raise HTTPException(
+            status_code,
+            detail=service_health.outage_detail(
+                "MongoDB is unavailable; job state cannot be retrieved.",
+                MongoClient(),
+            ),
+        )
     status_code, job_dict = await get_job_status(job_id.lower(), request)
     return ORJSONResponse(job_dict, status_code=status_code)
 
@@ -362,6 +401,14 @@ async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
 )
 async def response(request: Request, job_id: str) -> ORJSONResponse:
     """Get the response for a query (or logs if it's in progress)."""
+    if service_health.Snapshot().http_status_for("/response") is not None:
+        raise HTTPException(
+            HTTPStatus.FAILED_DEPENDENCY,
+            detail=service_health.outage_detail(
+                "MongoDB is unavailable; the response cannot be retrieved.",
+                MongoClient(),
+            ),
+        )
     status_code, job_dict = await get_job_response(job_id.lower(), request)
     return ORJSONResponse(job_dict, status_code=status_code)
 
@@ -429,7 +476,17 @@ async def logs(  # noqa: PLR0913 Can't reduce args due to FastAPI endpoint forma
 ) -> StreamingResponse:
     """Retrieve MongoDB-saved server logs."""
     if not CONFIG.log.log_to_mongo:
-        raise HTTPException(404, detail="Persisted logging not enabled.")
+        raise HTTPException(
+            HTTPStatus.NOT_FOUND, detail="Persisted logging not enabled."
+        )
+    if service_health.Snapshot().http_status_for("/logs") is not None:
+        raise HTTPException(
+            HTTPStatus.FAILED_DEPENDENCY,
+            detail=service_health.outage_detail(
+                "MongoDB is unavailable; logs cannot be served.",
+                MongoClient(),
+            ),
+        )
 
     if job_id is not None:
         job_id = job_id.lower()

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import functools
 import io
 import os
@@ -6,7 +8,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Annotated, Any, Literal
 
-import git
 import yaml
 from fastapi import BackgroundTasks, Body, FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -41,16 +42,29 @@ from retriever.utils.logs import (
     structured_log_to_trapi,
 )
 from retriever.utils.mongo import MongoClient, MongoQueue
-from retriever.utils.redis import RedisClient
+from retriever.utils.redis import (
+    PROCESS_TTL_SECONDS,
+    RedisClient,
+    heartbeat,
+)
 from retriever.utils.telemetry import configure_telemetry
 from retriever.utils.trapi import append_aggregator_source
+from retriever.utils.version import get_version
 
 configure_logging()
 
-JOB_ID_PATTERN = r"^[a-z0-9]+$"
+JOB_ID_PATTERN = r"^[a-zA-Z0-9]+$"
 
 
 # Lifespan handling for each FastAPI worker (not main process, see __main__.py)
+async def _refresh_worker_registration(pid: int, started_at: datetime) -> None:
+    """One heartbeat tick: re-register the worker (and main, in debug)."""
+    await RedisClient().register_worker(pid, started_at, PROCESS_TTL_SECONDS)
+    if CONFIG.debug:
+        # In debug mode this worker is also the main entry-point.
+        await RedisClient().register_main(pid, started_at, PROCESS_TTL_SECONDS)
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     """Lifespan hook for any setup/shutdown behavior."""
@@ -60,6 +74,27 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     await MongoQueue().initialize()
     add_mongo_sink()
     await RedisClient().initialize()
+
+    worker_pid = os.getpid()
+    worker_started_at = datetime.now().astimezone()
+    await RedisClient().register_worker(
+        worker_pid, worker_started_at, PROCESS_TTL_SECONDS
+    )
+    heartbeat_task = asyncio.create_task(
+        heartbeat(
+            lambda: _refresh_worker_registration(worker_pid, worker_started_at),
+            role_label="Worker",
+        ),
+        name="worker-heartbeat",
+    )
+    # In debug mode there's no separate entry-point process — this worker
+    # *is* the main. Register it under both so /status.processes.main isn't
+    # null. In production main is registered by __main__.py.
+    if CONFIG.debug:
+        await RedisClient().register_main(
+            worker_pid, worker_started_at, PROCESS_TTL_SECONDS
+        )
+
     await OpTableManager().initialize()
     await tier_manager.connect_drivers()
     await SubclassMapping().initialize()
@@ -71,6 +106,9 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     yield  # Separates startup/shutdown phase
 
     # Shutdown
+    heartbeat_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await heartbeat_task
     await SubqueryDispatcher().wrapup()
     if query_dumper.initialized:
         await query_dumper.wrapup()
@@ -84,6 +122,24 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
 
 
 app = TRAPI(lifespan=lifespan)
+
+# Mount the /status/* dashboard API (route handlers live in retriever.status).
+from retriever.status import router as status_router  # noqa: E402
+
+app.include_router(status_router)
+
+# Mount the dashboard at /monitor — static HTML/JS/CSS that polls the
+# /status/* endpoints from the browser. No server-side session state.
+from pathlib import Path  # noqa: E402
+
+from fastapi.staticfiles import StaticFiles  # noqa: E402
+
+_MONITOR_STATIC = Path(__file__).parent / "monitor" / "static"
+app.mount(
+    "/monitor",
+    StaticFiles(directory=_MONITOR_STATIC, html=True),
+    name="monitor",
+)
 
 # Set up CORS / exception handling
 app.add_middleware(
@@ -274,6 +330,7 @@ async def asyncquery(
 )
 async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
     """Get the status of an asynchronous query."""
+    job_id = job_id.lower()
     status_code, job_dict = await get_job_state(job_id, request)
 
     # Remove keys not meant for asyncquery_status
@@ -313,6 +370,7 @@ async def asyncquery_status(request: Request, job_id: str) -> ORJSONResponse:
 )
 async def response(request: Request, job_id: str) -> ORJSONResponse:
     """Get the response for a query (or logs if it's in progress)."""
+    job_id = job_id.lower()
     status_code, job_dict = await get_job_state(job_id, request)
     return ORJSONResponse(job_dict, status_code=status_code)
 
@@ -382,11 +440,14 @@ async def logs(  # noqa: PLR0913 Can't reduce args due to FastAPI endpoint forma
     if not CONFIG.log.log_to_mongo:
         raise HTTPException(404, detail="Persisted logging not enabled.")
 
+    if job_id is not None:
+        job_id = job_id.lower()
+
     if lookback is not None:
-        start = datetime.now() - timedelta(seconds=lookback * 60 * 60)
+        start = datetime.now().astimezone() - timedelta(seconds=lookback * 60 * 60)
 
     elif not start and not job_id:  # Get all logs from last hour
-        start = datetime.now() - timedelta(hours=1)
+        start = datetime.now().astimezone() - timedelta(hours=1)
 
     if fmt == "flat":
         logs = MongoClient().get_flat_logs(start, end, level, job_id)
@@ -411,15 +472,13 @@ async def logs(  # noqa: PLR0913 Can't reduce args due to FastAPI endpoint forma
 async def config() -> ORJSONResponse:
     """Get the current config of the server."""
     config = yaml.safe_load(CONFIG.model_dump_json())
-    try:
-        sha = git.Repo(search_parent_directories=True).head.object.hexsha
+    sha, branch = get_version()
+    if sha != "unknown":
         config["retriever_version"] = sha
+        config["retriever_branch"] = branch
         config["retriever_version_link"] = (
             f"https://github.com/BioPack-team/retriever/tree/{sha}"
         )
-    except Exception:
-        pass
-
     return ORJSONResponse(config)
 
 

--- a/src/retriever/status.py
+++ b/src/retriever/status.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
-from typing import Annotated, Any, Literal, cast
+from http import HTTPStatus
+from typing import Annotated, Literal, cast
 
 import psutil
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -34,12 +35,14 @@ from retriever.types.status import (
     FailureBreakdownResponse,
     JobDetail,
     Links,
-    StatusFreshness,
+    StatusMetaKG,
     StatusMongo,
     StatusProcess,
     StatusProcesses,
     StatusRedis,
+    StatusServedBy,
     StatusSnapshot,
+    StatusSubclassMap,
     StatusTier,
     StatusVersion,
     SubmitterRow,
@@ -48,6 +51,7 @@ from retriever.types.status import (
     TierRow,
     TimelineBucket,
 )
+from retriever.utils import service_health, worker
 from retriever.utils.job_status import (
     NON_TERMINAL,
     TERMINAL_FAILURE,
@@ -69,10 +73,6 @@ from retriever.utils.mongo import (
 from retriever.utils.redis import FreshnessRecord, RedisClient
 from retriever.utils.version import get_version
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
 MAX_LIMIT = 500
 """Server-side cap on per-page row count."""
 
@@ -88,11 +88,6 @@ _BYTES_PER_MB = 1024 * 1024
 
 STATUS_DESCRIPTIONS = OPENAPI_CONFIG.response_descriptions.status
 """Per-endpoint response_description strings keyed by short name."""
-
-
-# ---------------------------------------------------------------------------
-# Private helpers
-# ---------------------------------------------------------------------------
 
 
 def _now_aware() -> datetime:
@@ -131,7 +126,7 @@ def _resolve_time_window(
 
 
 def _build_links(request: Request, job_id: str) -> Links:
-    """Drill-down URLs for the existing per-job endpoints — absolute URLs.
+    """Drill-down URLs for the existing per-job endpoints - absolute URLs.
 
     Uses `request.base_url` so links are clickable when the dashboard is
     served from a different host / port than what a relative path would
@@ -220,25 +215,72 @@ def _process_row(pid: int, started_at: datetime, now: datetime) -> StatusProcess
 
 
 def _tier_snapshot() -> list[StatusTier]:
-    """Iterate configured tiers (0, 1) and report connection state."""
+    """Iterate configured tiers (0, 1) and report each driver's health."""
     backends = (CONFIG.tier0.backend, CONFIG.tier1.backend)
     rows: list[StatusTier] = []
     for tier_idx, backend in enumerate(backends):
         try:
-            connected = not tier_manager.get_driver(tier_idx).is_failed
-        except Exception:
-            connected = False
-        rows.append(StatusTier(tier=tier_idx, backend=backend, connected=connected))
+            health = tier_manager.get_driver(tier_idx).status()
+        except Exception as exc:
+            rows.append(
+                StatusTier(
+                    tier=tier_idx,
+                    backend=backend,
+                    up=False,
+                    last_outage=None,
+                    last_recovery=None,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            continue
+        rows.append(
+            StatusTier(
+                tier=tier_idx,
+                backend=backend,
+                up=health["up"],
+                last_outage=health["last_outage"],
+                last_recovery=health["last_recovery"],
+                error=health["error"],
+            )
+        )
     return rows
 
 
-def _freshness_row(record: FreshnessRecord | None) -> StatusFreshness | None:
-    """Project a FreshnessRecord into the response shape; None passes through."""
+def _metakg_row(
+    record: FreshnessRecord | None,
+    *,
+    self_reported: bool,
+    now: datetime,
+) -> StatusMetaKG:
+    """Build the metakg block; `stale` flips True past twice the refresh cadence."""
     if record is None:
-        return None
-    return StatusFreshness(
-        refreshed_at=record["refreshed_at"], count=int(record["count"])
+        return StatusMetaKG(
+            refreshed_at=None, count=None, self_reported=self_reported, stale=False
+        )
+    refreshed_at = record["refreshed_at"]
+    stale_after = timedelta(seconds=CONFIG.job.metakg.build_time * 2)
+    return StatusMetaKG(
+        refreshed_at=refreshed_at,
+        count=int(record["count"]),
+        self_reported=self_reported,
+        stale=(now - refreshed_at) > stale_after,
     )
+
+
+def _subclass_map_row(record: FreshnessRecord | None) -> StatusSubclassMap:
+    """Build the subclass_map block; `available` is False when no map can be served."""
+    if record is None:
+        return StatusSubclassMap(refreshed_at=None, count=None, available=False)
+    return StatusSubclassMap(
+        refreshed_at=record["refreshed_at"],
+        count=int(record["count"]),
+        available=True,
+    )
+
+
+def _unwrap(result: object) -> object:
+    """Return the value from a `gather(return_exceptions=True)` slot, or None on raise."""
+    return None if isinstance(result, BaseException) else result
 
 
 async def _window_snapshot(
@@ -247,10 +289,21 @@ async def _window_snapshot(
     lookback_hours: float | None,
 ) -> CountsWindow:
     """Total + status-breakdown + drill-down links for one /counts window."""
-    total, counts = await asyncio.gather(
-        MongoClient().count_jobs(times=times),
-        MongoClient().group_jobs(group_by="status", times=times),
-    )
+    try:
+        async with asyncio.TaskGroup() as tg:
+            total_task = tg.create_task(MongoClient().count_jobs(times=times))
+            counts_task = tg.create_task(
+                MongoClient().group_jobs(group_by="status", times=times)
+            )
+    except BaseExceptionGroup as eg:
+        # TaskGroup always wraps; preserve the original exception shape
+        # for callers and FastAPI exception handlers when only one
+        # branch actually failed.
+        if len(eg.exceptions) == 1:
+            raise eg.exceptions[0] from None
+        raise
+    total = total_task.result()
+    counts = counts_task.result()
     base = str(request.base_url)
     if lookback_hours is None:
         links = CountsLinks(
@@ -270,14 +323,7 @@ async def _window_snapshot(
     )
 
 
-# ---------------------------------------------------------------------------
-# Router
-# ---------------------------------------------------------------------------
-
 router = APIRouter(prefix="/status", tags=["status"])
-
-
-# === Bare /status root ====================================================
 
 
 @router.get(
@@ -286,79 +332,180 @@ router = APIRouter(prefix="/status", tags=["status"])
     response_description=STATUS_DESCRIPTIONS.get("root", ""),
 )
 async def status_root() -> StatusSnapshot:
-    """Operator-glance health snapshot."""
+    """Operator-glance health snapshot; per-dependency failures degrade fields, not the response."""
     redis_client = RedisClient()
     mongo_client = MongoClient()
     stuck_cutoff = _now_aware() - timedelta(hours=STUCK_DEFAULT_HOURS)
 
-    # Fan out all the independent IO calls in parallel — these are the
-    # bulk of the endpoint's wall time.
-    async with asyncio.TaskGroup() as tg:
-        t_main = tg.create_task(redis_client.list_main())
-        t_bg = tg.create_task(redis_client.list_background())
-        t_workers = tg.create_task(redis_client.list_workers())
-        t_mongo_ping = tg.create_task(mongo_client.ping())
-        t_mongo_storage = tg.create_task(mongo_client.db_storage_bytes())
-        t_redis_ping = tg.create_task(redis_client.ping())
-        t_redis_mem = tg.create_task(redis_client.used_memory_bytes())
-        t_in_flight = tg.create_task(mongo_client.count_in_flight())
-        t_stuck = tg.create_task(mongo_client.count_stuck(stuck_cutoff))
-        t_metakg = tg.create_task(redis_client.metakg_freshness())
-        t_subclass = tg.create_task(redis_client.subclass_freshness())
+    # Fan out independent IO in parallel. Both Redis and Mongo calls
+    # are gated on their health flags - otherwise redis-py's retry-with-
+    # backoff and Motor's 30s server-selection timeout would each stall
+    # the response during an outage.
+    #
+    # `gather(..., return_exceptions=True)` loses per-element type
+    # inference; cast back to a tuple of `object` so call sites stay typed.
+    main_registry_r: object = None
+    background_registry_r: object = None
+    worker_registry_r: object = None
+    redis_mem_r: object = None
+    metakg_r: object = None
+    subclass_r: object = None
+    if redis_client.up:
+        redis_results = cast(
+            tuple[object, object, object, object, object, object],
+            await asyncio.gather(
+                redis_client.list_main(),
+                redis_client.list_background(),
+                redis_client.list_workers(),
+                redis_client.used_memory_bytes(),
+                redis_client.metakg_freshness(),
+                redis_client.subclass_freshness(),
+                return_exceptions=True,
+            ),
+        )
+        (
+            main_registry_r,
+            background_registry_r,
+            worker_registry_r,
+            redis_mem_r,
+            metakg_r,
+            subclass_r,
+        ) = redis_results
+        if any(isinstance(r, BaseException) for r in redis_results):
+            redis_client.request_health_check()
 
-    main_registry = t_main.result()
-    background_registry = t_bg.result()
-    worker_registry = t_workers.result()
-    mongo_connected = t_mongo_ping.result()
-    mongo_storage = t_mongo_storage.result()
-    redis_connected = t_redis_ping.result()
-    redis_memory = t_redis_mem.result()
-    active_job_count = t_in_flight.result()
-    stuck_job_count = t_stuck.result()
-    metakg = t_metakg.result()
-    subclass = t_subclass.result()
+    mongo_storage_r: object = None
+    in_flight_r: object = None
+    stuck_r: object = None
+    if mongo_client.up:
+        mongo_results = cast(
+            tuple[object, object, object],
+            await asyncio.gather(
+                mongo_client.db_storage_bytes(),
+                mongo_client.count_in_flight(),
+                mongo_client.count_stuck(stuck_cutoff),
+                return_exceptions=True,
+            ),
+        )
+        mongo_storage_r, in_flight_r, stuck_r = mongo_results
+        if any(isinstance(r, BaseException) for r in mongo_results):
+            mongo_client.request_health_check()
+
+    main_registry = _unwrap(main_registry_r)
+    background_registry = _unwrap(background_registry_r)
+    worker_registry = _unwrap(worker_registry_r)
+    mongo_storage = _unwrap(mongo_storage_r)
+    redis_memory = _unwrap(redis_mem_r)
+    active_job_count = _unwrap(in_flight_r)
+    stuck_job_count = _unwrap(stuck_r)
+    metakg_record = cast(FreshnessRecord | None, _unwrap(metakg_r))
+    subclass_record = cast(FreshnessRecord | None, _unwrap(subclass_r))
+
+    # `registry_available` flips False when *any* of the three registry
+    # reads failed (they all hit Redis; one failing means we can't trust
+    # the others either).
+    registry_available = (
+        main_registry is not None
+        and background_registry is not None
+        and worker_registry is not None
+    )
 
     now = _now_aware()
-    main = next(
-        (
-            _process_row(pid, started, now)
-            for pid, started in sorted(main_registry.items())
-        ),
-        None,
+    main = (
+        next(
+            (
+                _process_row(pid, started, now)
+                for pid, started in sorted(
+                    cast(dict[int, datetime], main_registry).items()
+                )
+            ),
+            None,
+        )
+        if main_registry is not None
+        else None
     )
-    background = next(
-        (
-            _process_row(pid, started, now)
-            for pid, started in sorted(background_registry.items())
-        ),
-        None,
+    background = (
+        next(
+            (
+                _process_row(pid, started, now)
+                for pid, started in sorted(
+                    cast(dict[int, datetime], background_registry).items()
+                )
+            ),
+            None,
+        )
+        if background_registry is not None
+        else None
     )
-    workers = [
-        _process_row(pid, started, now)
-        for pid, started in sorted(worker_registry.items())
-    ]
+    if worker_registry is not None:
+        workers = [
+            _process_row(pid, started, now)
+            for pid, started in sorted(
+                cast(dict[int, datetime], worker_registry).items()
+            )
+        ]
+    else:
+        # Registry unavailable - fall back to self-reporting the worker
+        # serving this request so the dashboard still shows *something*.
+        self_pid = worker.get_pid()
+        self_started = worker.get_started_at()
+        workers = (
+            [_process_row(self_pid, self_started, now)]
+            if self_pid is not None and self_started is not None
+            else []
+        )
+
+    mongo_health = mongo_client.status()
+    redis_health = redis_client.status()
 
     return StatusSnapshot(
         version=_get_version(),
-        processes=StatusProcesses(main=main, background=background, workers=workers),
-        active_job_count=active_job_count,
-        stuck_job_count=stuck_job_count,
+        served_by=_served_by(now),
+        processes=StatusProcesses(
+            main=main,
+            background=background,
+            workers=workers,
+            registry_available=registry_available,
+        ),
+        active_job_count=cast(int, active_job_count)
+        if active_job_count is not None
+        else None,
+        stuck_job_count=cast(int, stuck_job_count)
+        if stuck_job_count is not None
+        else None,
         mongo=StatusMongo(
-            connected=mongo_connected,
-            storage_mb=mongo_storage / _BYTES_PER_MB,
+            up=mongo_health["up"],
+            last_outage=mongo_health["last_outage"],
+            last_recovery=mongo_health["last_recovery"],
+            error=mongo_health["error"],
+            storage_mb=cast(int, mongo_storage) / _BYTES_PER_MB
+            if mongo_storage is not None
+            else None,
             queue_depth=MongoQueue().qsize(),
         ),
         redis=StatusRedis(
-            connected=redis_connected,
-            used_memory_mb=redis_memory / _BYTES_PER_MB,
+            up=redis_health["up"],
+            last_outage=redis_health["last_outage"],
+            last_recovery=redis_health["last_recovery"],
+            error=redis_health["error"],
+            used_memory_mb=cast(int, redis_memory) / _BYTES_PER_MB
+            if redis_memory is not None
+            else None,
         ),
         tiers=_tier_snapshot(),
-        metakg=_freshness_row(metakg),
-        subclass_map=_freshness_row(subclass),
+        # `self_reported=False`: this path serves the Redis-published copy.
+        # Workers serving a degraded local copy would need to flip this
+        # True on their own snapshot - not currently wired.
+        metakg=_metakg_row(metakg_record, self_reported=False, now=now),
+        subclass_map=_subclass_map_row(subclass_record),
     )
 
 
-# === Per-job lookup =======================================================
+def _served_by(now: datetime) -> StatusServedBy:
+    """Identify the worker answering this `/status` request; `started_at` defaults to `now`."""
+    pid = worker.get_pid() or 0
+    started_at = worker.get_started_at() or now
+    return StatusServedBy(pid=pid, started_at=started_at)
 
 
 @router.get(
@@ -369,10 +516,15 @@ async def status_root() -> StatusSnapshot:
 )
 async def status_job(request: Request, job_id: str) -> JobDetail:
     """Return the full job_status doc for one job_id (metadata + geometry)."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; job detail cannot be retrieved."
+    )
     job_id = job_id.lower()
     row = await MongoClient().get_job_status(job_id)
     if row is None:
-        raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found.")
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail=f"Job {job_id!r} not found."
+        )
     created = row.get("created")
     completed = row.get("completed")
     duration: float | None = None
@@ -398,9 +550,6 @@ async def status_job(request: Request, job_id: str) -> JobDetail:
     )
 
 
-# === Realtime =============================================================
-
-
 @router.get(
     "/active",
     response_model=ActivePage,
@@ -412,6 +561,9 @@ async def status_active(
     limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
 ) -> ActivePage:
     """Paged scan of currently-in-flight jobs, newest first."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; active jobs cannot be listed."
+    )
     page = await _paged_jobs(
         identity=JobIdentityFilter(status=sorted(NON_TERMINAL)),
         times=None,
@@ -444,6 +596,7 @@ async def status_stuck(
     ] = None,
 ) -> ActivePage:
     """Paged scan of active jobs older than `min_age` (default 1h)."""
+    service_health.require_mongo("MongoDB is unavailable; stuck jobs cannot be listed.")
     effective_min_age = min_age if min_age is not None else STUCK_DEFAULT_HOURS
     cutoff = _now_aware() - timedelta(hours=effective_min_age)
     page = await _paged_jobs(
@@ -460,9 +613,6 @@ async def status_stuck(
     )
 
 
-# === Dashboard headlines ==================================================
-
-
 @router.get(
     "/counts",
     response_model=CountsSnapshot,
@@ -470,6 +620,7 @@ async def status_stuck(
 )
 async def status_counts(request: Request) -> CountsSnapshot:
     """Status breakdown across 24h / week / all-time windows."""
+    service_health.require_mongo("MongoDB is unavailable; job counts cannot be served.")
     now = _now_aware()
     last_24h_window = JobTimeFilter(created={"after": now - timedelta(hours=24)})
     last_week_window = JobTimeFilter(
@@ -513,6 +664,9 @@ async def status_timeline(  # noqa: PLR0913 Each arg is a query knob
     ] = None,
 ) -> list[TimelineBucket]:
     """Time-bucketed throughput counts."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; timeline data cannot be served."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field=field
     )
@@ -552,6 +706,9 @@ async def status_durations(
     ] = "Complete",
 ) -> DurationsResponse:
     """Aggregate runtime stats over terminal jobs in the window."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; duration stats cannot be served."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="completed"
     )
@@ -587,6 +744,9 @@ async def status_submitters(
     top: Annotated[int, Query(ge=1, le=200)] = 50,
 ) -> list[SubmitterRow]:
     """Per-submitter activity leaderboard."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; submitter stats cannot be served."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="created"
     )
@@ -608,6 +768,7 @@ async def status_tiers(
     ] = 24.0,
 ) -> list[TierRow]:
     """Per-tier activity + duration percentiles."""
+    service_health.require_mongo("MongoDB is unavailable; tier stats cannot be served.")
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="completed"
     )
@@ -639,6 +800,9 @@ async def status_submitter_tier_stats(
     ] = None,
 ) -> list[SubmitterTierRow]:
     """Per-(submitter, tier) cells. Drives the heatmaps view."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; submitter/tier stats cannot be served."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="created"
     )
@@ -664,8 +828,11 @@ async def status_failure_breakdown(
     ] = None,
 ) -> FailureBreakdownResponse:
     """Failure-status counts pivoted by submitter or by tier."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; failure breakdown cannot be served."
+    )
     # Time window filters on `completed` so "failures in the last 24h"
-    # means jobs that finished failing in that window — matches /failed
+    # means jobs that finished failing in that window - matches /failed
     # semantics and what the dashboard window selector intuitively
     # implies.
     times = _resolve_time_window(
@@ -678,9 +845,6 @@ async def status_failure_breakdown(
     return FailureBreakdownResponse(
         by=by, rows=[FailureBreakdownCell(**row) for row in raw]
     )
-
-
-# === History scans ========================================================
 
 
 def _identity_with(
@@ -716,7 +880,7 @@ async def _paged_jobs(
             cursor=cursor,
         )
     except CursorDecodeError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e)) from e
 
 
 @router.get(
@@ -746,6 +910,9 @@ async def status_completed(  # noqa: PLR0913 Each arg is a query knob
     ] = "desc",
 ) -> CompletedPage:
     """Paged scan of successfully-terminated jobs."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; completed jobs cannot be listed."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="completed"
     )
@@ -796,6 +963,9 @@ async def status_failed(  # noqa: PLR0913 Each arg is a query knob
     ] = "desc",
 ) -> FailedPage:
     """Paged scan of failed-or-errored terminal jobs."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; failed jobs cannot be listed."
+    )
     times = _resolve_time_window(
         since=since, until=until, lookback=lookback, field="completed"
     )
@@ -818,9 +988,6 @@ async def status_failed(  # noqa: PLR0913 Each arg is a query knob
     )
 
 
-# === Logs =================================================================
-
-
 @router.get(
     "/server_logs",
     response_description=STATUS_DESCRIPTIONS.get("server_logs", ""),
@@ -836,14 +1003,16 @@ async def status_server_logs(
     fmt: Literal["flat", "struct"] = "flat",
 ) -> StreamingResponse:
     """Stream logs not associated with any job."""
+    service_health.require_mongo(
+        "MongoDB is unavailable; server logs cannot be served."
+    )
     effective_start = start
     if lookback is not None:
         effective_start = _now_aware() - timedelta(hours=lookback)
 
+    body: AsyncGenerator[str]
     if fmt == "flat":
-        body: AsyncGenerator[str | dict[str, Any]] = MongoClient().get_flat_server_logs(
-            effective_start, end, level
-        )
+        body = MongoClient().get_flat_server_logs(effective_start, end, level)
         media = "text/plain"
     else:
         body = objs_to_json(

--- a/src/retriever/status.py
+++ b/src/retriever/status.py
@@ -1,0 +1,835 @@
+"""FastAPI route handlers for the `/status/*` dashboard API.
+
+A thin glue layer over MongoClient / RedisClient aggregations. Mounted on
+the main app by `server.py`'s `app.include_router(router)`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta
+from typing import Annotated, Any, Literal, cast
+
+import psutil
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+
+from retriever.config.general import CONFIG
+from retriever.config.openapi import OPENAPI_CONFIG
+from retriever.data_tiers import tier_manager
+from retriever.types.general import LogLevel
+from retriever.types.status import (
+    ActiveJobRow,
+    CompletedJobRow,
+    CompletedPage,
+    CountsLinks,
+    CountsSnapshot,
+    CountsWindow,
+    DurationsResponse,
+    FailedJobRow,
+    FailedPage,
+    FailureBreakdownCell,
+    FailureBreakdownResponse,
+    JobDetail,
+    Links,
+    StatusFreshness,
+    StatusMongo,
+    StatusProcess,
+    StatusProcesses,
+    StatusRedis,
+    StatusSnapshot,
+    StatusTier,
+    StatusVersion,
+    SubmitterRow,
+    SubmitterTierRow,
+    TierDurations,
+    TierRow,
+    TimelineBucket,
+)
+from retriever.utils.job_status import (
+    NON_TERMINAL,
+    TERMINAL_FAILURE,
+    TERMINAL_SUCCESS,
+    resolve_status_filter,
+)
+from retriever.utils.logs import objs_to_json
+from retriever.utils.mongo import (
+    CursorDecodeError,
+    JobIdentityFilter,
+    JobSortSpec,
+    JobStatus,
+    JobStatusPage,
+    JobTimeFilter,
+    MongoClient,
+    MongoQueue,
+    TimeRange,
+)
+from retriever.utils.redis import FreshnessRecord, RedisClient
+from retriever.utils.version import get_version
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_LIMIT = 500
+"""Server-side cap on per-page row count."""
+
+DEFAULT_LIMIT = 100
+
+STUCK_DEFAULT_HOURS = 1.0
+"""How long a job must have been running to count as 'stuck' by default."""
+
+HOURS_PER_WEEK = 168.0
+
+_BYTES_PER_MB = 1024 * 1024
+"""Mebibyte (binary). What `ps`, `top`, `free`, and friends report."""
+
+STATUS_DESCRIPTIONS = OPENAPI_CONFIG.response_descriptions.status
+"""Per-endpoint response_description strings keyed by short name."""
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_aware() -> datetime:
+    """Tz-aware current time."""
+    return datetime.now().astimezone()
+
+
+def _resolve_time_window(
+    *,
+    since: datetime | None,
+    until: datetime | None,
+    lookback: float | None,
+    field: Literal["created", "completed"],
+) -> JobTimeFilter | None:
+    """Build a JobTimeFilter from `since`/`until`/`lookback` query params.
+
+    `lookback` (hours back from now) overrides `since` when supplied.
+    """
+    effective_since = since
+    if lookback is not None:
+        effective_since = _now_aware() - timedelta(hours=lookback)
+
+    range_: TimeRange = {}
+    if effective_since is not None:
+        range_["after"] = effective_since
+    if until is not None:
+        range_["before"] = until
+    if not range_:
+        return None
+
+    return (
+        JobTimeFilter(created=range_)
+        if field == "created"
+        else JobTimeFilter(completed=range_)
+    )
+
+
+def _build_links(request: Request, job_id: str) -> Links:
+    """Drill-down URLs for the existing per-job endpoints — absolute URLs.
+
+    Uses `request.base_url` so links are clickable when the dashboard is
+    served from a different host / port than what a relative path would
+    resolve to.
+    """
+    base = str(request.base_url)
+    return Links(
+        logs=f"{base}logs?job_id={job_id}", response=f"{base}response/{job_id}"
+    )
+
+
+def _enrich_active(row: JobStatus, now: datetime, request: Request) -> ActiveJobRow:
+    """Project a JobStatus into the /active row shape."""
+    # `created` is always set on upsert; cast away the NotRequired narrowing.
+    created = cast(datetime, row.get("created"))
+    return ActiveJobRow(
+        job_id=row["job_id"],
+        created=created,
+        submitter=row.get("submitter", ""),
+        data_tiers=list(row.get("data_tiers", [])),
+        age_seconds=int((now - created).total_seconds()),
+        links=_build_links(request, row["job_id"]),
+    )
+
+
+def _enrich_completed(row: JobStatus, request: Request) -> CompletedJobRow:
+    """Project a JobStatus into the /completed row shape."""
+    created = cast(datetime, row.get("created"))
+    completed = cast(datetime, row.get("completed"))
+    return CompletedJobRow(
+        job_id=row["job_id"],
+        submitter=row.get("submitter", ""),
+        created=created,
+        completed=completed,
+        duration_seconds=float((completed - created).total_seconds()),
+        data_tiers=list(row.get("data_tiers", [])),
+        results=int(row.get("results", 0)),
+        links=_build_links(request, row["job_id"]),
+    )
+
+
+def _enrich_failed(row: JobStatus, request: Request) -> FailedJobRow:
+    """Project a JobStatus into the /failed row shape."""
+    created = cast(datetime, row.get("created"))
+    completed = cast(datetime, row.get("completed"))
+    return FailedJobRow(
+        job_id=row["job_id"],
+        submitter=row.get("submitter", ""),
+        created=created,
+        completed=completed,
+        duration_seconds=float((completed - created).total_seconds()),
+        data_tiers=list(row.get("data_tiers", [])),
+        status=row["status"],
+        links=_build_links(request, row["job_id"]),
+    )
+
+
+def _get_version() -> StatusVersion:
+    """Return the /status `version` block from the cached version lookup."""
+    sha, branch = get_version()
+    # 12-char short form is enough for the dashboard's at-a-glance display.
+    return StatusVersion(git_commit=sha[:12], git_branch=branch)
+
+
+def _bytes_to_mb(value: int | None) -> float | None:
+    """Convert a byte count (or None) to MB (mebibytes)."""
+    return None if value is None else value / _BYTES_PER_MB
+
+
+def _get_rss_mb(pid: int) -> float | None:
+    """Return the resident set size for `pid` in MB, or None if not inspectable."""
+    try:
+        rss = psutil.Process(pid).memory_info().rss
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
+        return None
+    return _bytes_to_mb(rss)
+
+
+def _process_row(pid: int, started_at: datetime, now: datetime) -> StatusProcess:
+    """Turn a registry entry into the StatusProcess response shape."""
+    return StatusProcess(
+        pid=pid,
+        uptime_seconds=float((now - started_at).total_seconds()),
+        rss_mb=_get_rss_mb(pid),
+    )
+
+
+def _tier_snapshot() -> list[StatusTier]:
+    """Iterate configured tiers (0, 1) and report connection state."""
+    backends = (CONFIG.tier0.backend, CONFIG.tier1.backend)
+    rows: list[StatusTier] = []
+    for tier_idx, backend in enumerate(backends):
+        try:
+            connected = not tier_manager.get_driver(tier_idx).is_failed
+        except Exception:
+            connected = False
+        rows.append(StatusTier(tier=tier_idx, backend=backend, connected=connected))
+    return rows
+
+
+def _freshness_row(record: FreshnessRecord | None) -> StatusFreshness | None:
+    """Project a FreshnessRecord into the response shape; None passes through."""
+    if record is None:
+        return None
+    return StatusFreshness(
+        refreshed_at=record["refreshed_at"], count=int(record["count"])
+    )
+
+
+async def _window_snapshot(
+    request: Request,
+    times: JobTimeFilter | None,
+    lookback_hours: float | None,
+) -> CountsWindow:
+    """Total + status-breakdown + drill-down links for one /counts window."""
+    total, counts = await asyncio.gather(
+        MongoClient().count_jobs(times=times),
+        MongoClient().group_jobs(group_by="status", times=times),
+    )
+    base = str(request.base_url)
+    if lookback_hours is None:
+        links = CountsLinks(
+            completed=f"{base}status/completed", failed=f"{base}status/failed"
+        )
+    else:
+        # `:g` strips trailing zeros on whole-number hours (24, 168).
+        suffix = f"?lookback={lookback_hours:g}"
+        links = CountsLinks(
+            completed=f"{base}status/completed{suffix}",
+            failed=f"{base}status/failed{suffix}",
+        )
+    return CountsWindow(
+        total=total,
+        counts={str(row["key"]): int(row["count"]) for row in counts},
+        links=links,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+router = APIRouter(prefix="/status", tags=["status"])
+
+
+# === Bare /status root ====================================================
+
+
+@router.get(
+    "",
+    response_model=StatusSnapshot,
+    response_description=STATUS_DESCRIPTIONS.get("root", ""),
+)
+async def status_root() -> StatusSnapshot:
+    """Operator-glance health snapshot."""
+    redis_client = RedisClient()
+    mongo_client = MongoClient()
+
+    # Fan out all the independent IO calls in parallel — these are the
+    # bulk of the endpoint's wall time.
+    async with asyncio.TaskGroup() as tg:
+        t_main = tg.create_task(redis_client.list_main())
+        t_bg = tg.create_task(redis_client.list_background())
+        t_workers = tg.create_task(redis_client.list_workers())
+        t_mongo_ping = tg.create_task(mongo_client.ping())
+        t_mongo_storage = tg.create_task(mongo_client.db_storage_bytes())
+        t_redis_ping = tg.create_task(redis_client.ping())
+        t_redis_mem = tg.create_task(redis_client.used_memory_bytes())
+        t_in_flight = tg.create_task(mongo_client.count_in_flight())
+        t_metakg = tg.create_task(redis_client.metakg_freshness())
+        t_subclass = tg.create_task(redis_client.subclass_freshness())
+
+    main_registry = t_main.result()
+    background_registry = t_bg.result()
+    worker_registry = t_workers.result()
+    mongo_connected = t_mongo_ping.result()
+    mongo_storage = t_mongo_storage.result()
+    redis_connected = t_redis_ping.result()
+    redis_memory = t_redis_mem.result()
+    active_job_count = t_in_flight.result()
+    metakg = t_metakg.result()
+    subclass = t_subclass.result()
+
+    now = _now_aware()
+    main = next(
+        (
+            _process_row(pid, started, now)
+            for pid, started in sorted(main_registry.items())
+        ),
+        None,
+    )
+    background = next(
+        (
+            _process_row(pid, started, now)
+            for pid, started in sorted(background_registry.items())
+        ),
+        None,
+    )
+    workers = [
+        _process_row(pid, started, now)
+        for pid, started in sorted(worker_registry.items())
+    ]
+
+    return StatusSnapshot(
+        version=_get_version(),
+        processes=StatusProcesses(main=main, background=background, workers=workers),
+        active_job_count=active_job_count,
+        mongo=StatusMongo(
+            connected=mongo_connected,
+            storage_mb=mongo_storage / _BYTES_PER_MB,
+            queue_depth=MongoQueue().qsize(),
+        ),
+        redis=StatusRedis(
+            connected=redis_connected,
+            used_memory_mb=redis_memory / _BYTES_PER_MB,
+        ),
+        tiers=_tier_snapshot(),
+        metakg=_freshness_row(metakg),
+        subclass_map=_freshness_row(subclass),
+    )
+
+
+# === Per-job lookup =======================================================
+
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=JobDetail,
+    response_description=STATUS_DESCRIPTIONS.get("jobs", ""),
+    responses={404: {"description": "No job_status doc with that job_id."}},
+)
+async def status_job(request: Request, job_id: str) -> JobDetail:
+    """Return the full job_status doc for one job_id (metadata + geometry)."""
+    job_id = job_id.lower()
+    row = await MongoClient().get_job_status(job_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found.")
+    created = row.get("created")
+    completed = row.get("completed")
+    duration: float | None = None
+    if isinstance(created, datetime) and isinstance(completed, datetime):
+        duration = float((completed - created).total_seconds())
+    return JobDetail(
+        job_id=row["job_id"],
+        status=row["status"],
+        submitter=row.get("submitter"),
+        data_tiers=list(row.get("data_tiers", [])),
+        is_async=row.get("is_async"),
+        created=created,
+        completed=completed,
+        duration_seconds=duration,
+        qnodes=row.get("qnodes"),
+        qedges=row.get("qedges"),
+        qpaths=row.get("qpaths"),
+        knodes=row.get("knodes"),
+        kedges=row.get("kedges"),
+        aux_graphs=row.get("aux_graphs"),
+        results=row.get("results"),
+        links=_build_links(request, job_id),
+    )
+
+
+# === Realtime =============================================================
+
+
+@router.get(
+    "/active",
+    response_model=list[ActiveJobRow],
+    response_description=STATUS_DESCRIPTIONS.get("active", ""),
+)
+async def status_active(request: Request) -> list[ActiveJobRow]:
+    """All currently-in-flight jobs, newest first."""
+    page = await MongoClient().get_job_statuses(
+        identity=JobIdentityFilter(status=sorted(NON_TERMINAL)),
+        sort={"field": "created", "direction": "desc"},
+        limit=MAX_LIMIT,
+    )
+    now = _now_aware()
+    return [_enrich_active(row, now, request) for row in page["items"]]
+
+
+@router.get(
+    "/stuck",
+    response_model=list[ActiveJobRow],
+    response_description=STATUS_DESCRIPTIONS.get("stuck", ""),
+)
+async def status_stuck(
+    request: Request,
+    min_age: Annotated[
+        float | None,
+        Query(
+            ge=0,
+            description="Hours; jobs running longer than this are returned.",
+        ),
+    ] = None,
+) -> list[ActiveJobRow]:
+    """Active jobs older than `min_age` (default 1h)."""
+    effective_min_age = min_age if min_age is not None else STUCK_DEFAULT_HOURS
+    cutoff = _now_aware() - timedelta(hours=effective_min_age)
+    page = await MongoClient().get_job_statuses(
+        identity=JobIdentityFilter(status=sorted(NON_TERMINAL)),
+        times=JobTimeFilter(created={"before": cutoff}),
+        sort={"field": "created", "direction": "desc"},
+        limit=MAX_LIMIT,
+    )
+    now = _now_aware()
+    return [_enrich_active(row, now, request) for row in page["items"]]
+
+
+# === Dashboard headlines ==================================================
+
+
+@router.get(
+    "/counts",
+    response_model=CountsSnapshot,
+    response_description=STATUS_DESCRIPTIONS.get("counts", ""),
+)
+async def status_counts(request: Request) -> CountsSnapshot:
+    """Status breakdown across 24h / week / all-time windows."""
+    now = _now_aware()
+    last_24h_window = JobTimeFilter(created={"after": now - timedelta(hours=24)})
+    last_week_window = JobTimeFilter(
+        created={"after": now - timedelta(hours=HOURS_PER_WEEK)}
+    )
+    last_24h, last_week, all_time = await asyncio.gather(
+        _window_snapshot(request, last_24h_window, 24.0),
+        _window_snapshot(request, last_week_window, HOURS_PER_WEEK),
+        _window_snapshot(request, None, None),
+    )
+    return CountsSnapshot(
+        windows={
+            "last_24h": last_24h,
+            "last_week": last_week,
+            "all_time": all_time,
+        }
+    )
+
+
+@router.get(
+    "/timeline",
+    response_model=list[TimelineBucket],
+    response_description=STATUS_DESCRIPTIONS.get("timeline", ""),
+)
+async def status_timeline(  # noqa: PLR0913 Each arg is a query knob
+    field: Literal["created", "completed"] = "completed",
+    granularity: Literal["hour", "day", "week", "month"] = "hour",
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = 24.0,
+    status: Annotated[
+        str | None,
+        Query(description="Specific status or alias 'failed'."),
+    ] = None,
+    data_tier: Annotated[
+        int | None,
+        Query(ge=0, le=2, description="Restrict to jobs run on this tier."),
+    ] = None,
+) -> list[TimelineBucket]:
+    """Time-bucketed throughput counts."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field=field
+    )
+    identity: JobIdentityFilter | None = None
+    resolved = resolve_status_filter(status)
+    if resolved is not None or data_tier is not None:
+        identity = JobIdentityFilter()
+        if resolved is not None:
+            identity["status"] = resolved
+        if data_tier is not None:
+            identity["data_tiers"] = [data_tier]  # pyright: ignore[reportGeneralTypeIssues]
+
+    buckets = await MongoClient().bucket_jobs_over_time(
+        field=field, granularity=granularity, identity=identity, times=times
+    )
+    return [
+        TimelineBucket(bucket_start=row["bucket_start"], count=int(row["count"]))
+        for row in buckets
+    ]
+
+
+@router.get(
+    "/durations",
+    response_model=DurationsResponse,
+    response_description=STATUS_DESCRIPTIONS.get("durations", ""),
+)
+async def status_durations(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = 24.0,
+    status: Annotated[
+        str | None,
+        Query(description="Specific status or alias 'failed'."),
+    ] = "Complete",
+) -> DurationsResponse:
+    """Aggregate runtime stats over terminal jobs in the window."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="completed"
+    )
+    identity: JobIdentityFilter | None = None
+    resolved = resolve_status_filter(status)
+    if resolved is not None:
+        identity = JobIdentityFilter(status=resolved)
+
+    stats = await MongoClient().compute_durations(identity=identity, times=times)
+    return DurationsResponse(
+        sample_size=stats["sample_size"],
+        min_seconds=stats["min_seconds"],
+        max_seconds=stats["max_seconds"],
+        avg_seconds=stats["avg_seconds"],
+        p50_seconds=stats.get("p50_seconds"),
+        p95_seconds=stats.get("p95_seconds"),
+        p99_seconds=stats.get("p99_seconds"),
+    )
+
+
+@router.get(
+    "/submitters",
+    response_model=list[SubmitterRow],
+    response_description=STATUS_DESCRIPTIONS.get("submitters", ""),
+)
+async def status_submitters(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = None,
+    top: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> list[SubmitterRow]:
+    """Per-submitter activity leaderboard."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="created"
+    )
+    rows = await MongoClient().submitter_stats(times=times, top=top)
+    return [SubmitterRow(**row) for row in rows]
+
+
+@router.get(
+    "/tiers",
+    response_model=list[TierRow],
+    response_description=STATUS_DESCRIPTIONS.get("tiers", ""),
+)
+async def status_tiers(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = 24.0,
+) -> list[TierRow]:
+    """Per-tier activity + duration percentiles."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="completed"
+    )
+    rows = await MongoClient().tier_stats(times=times)
+    return [
+        TierRow(
+            tier=row["tier"],
+            active=row["active"],
+            completed=row["completed"],
+            failed=row["failed"],
+            durations=TierDurations(**row["durations"]),
+            last_activity=row["last_activity"],
+        )
+        for row in rows
+    ]
+
+
+@router.get(
+    "/submitter_tier_stats",
+    response_model=list[SubmitterTierRow],
+    response_description=STATUS_DESCRIPTIONS.get("submitter_tier_stats", ""),
+)
+async def status_submitter_tier_stats(
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = None,
+) -> list[SubmitterTierRow]:
+    """Per-(submitter, tier) cells. Drives the heatmaps view."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="created"
+    )
+    rows = await MongoClient().submitter_tier_stats(times=times)
+    return [SubmitterTierRow(**row) for row in rows]
+
+
+@router.get(
+    "/failure_breakdown",
+    response_model=FailureBreakdownResponse,
+    response_description=STATUS_DESCRIPTIONS.get("failure_breakdown", ""),
+)
+async def status_failure_breakdown(
+    by: Annotated[
+        Literal["submitter", "tier"],
+        Query(description="Group key for the breakdown."),
+    ],
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = None,
+) -> FailureBreakdownResponse:
+    """Failure-status counts pivoted by submitter or by tier."""
+    # Time window filters on `completed` so "failures in the last 24h"
+    # means jobs that finished failing in that window — matches /failed
+    # semantics and what the dashboard window selector intuitively
+    # implies.
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="completed"
+    )
+    if by == "submitter":
+        raw = await MongoClient().failure_breakdown_by_submitter(times=times)
+    else:
+        raw = await MongoClient().failure_breakdown_by_tier(times=times)
+    return FailureBreakdownResponse(
+        by=by, rows=[FailureBreakdownCell(**row) for row in raw]
+    )
+
+
+# === History scans ========================================================
+
+
+def _identity_with(
+    *,
+    status: str | list[str],
+    submitter: str | None,
+    data_tier: int | None,
+) -> JobIdentityFilter:
+    """Build a JobIdentityFilter from the common history-scan query params."""
+    identity: JobIdentityFilter = {"status": status}
+    if submitter is not None:
+        identity["submitter"] = submitter
+    if data_tier is not None:
+        identity["data_tiers"] = [data_tier]  # pyright: ignore[reportGeneralTypeIssues]
+    return identity
+
+
+async def _paged_jobs(
+    *,
+    identity: JobIdentityFilter,
+    times: JobTimeFilter | None,
+    sort: JobSortSpec,
+    limit: int,
+    cursor: str | None,
+) -> JobStatusPage:
+    """Fetch a paged JobStatus result, translating cursor errors to HTTP 400."""
+    try:
+        return await MongoClient().get_job_statuses(
+            identity=identity,
+            times=times,
+            sort=sort,
+            limit=limit,
+            cursor=cursor,
+        )
+    except CursorDecodeError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.get(
+    "/completed",
+    response_model=CompletedPage,
+    response_description=STATUS_DESCRIPTIONS.get("completed", ""),
+)
+async def status_completed(  # noqa: PLR0913 Each arg is a query knob
+    request: Request,
+    cursor: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = None,
+    data_tier: Annotated[int | None, Query(ge=0, le=2)] = None,
+    submitter: str | None = None,
+    sort: Annotated[
+        Literal["created", "completed", "duration", "results", "submitter", "status"],
+        Query(description="Sort field; default `completed`."),
+    ] = "completed",
+    direction: Annotated[
+        Literal["asc", "desc"],
+        Query(description="Sort direction; default `desc`."),
+    ] = "desc",
+) -> CompletedPage:
+    """Paged scan of successfully-terminated jobs."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="completed"
+    )
+    identity = _identity_with(
+        status=sorted(TERMINAL_SUCCESS), submitter=submitter, data_tier=data_tier
+    )
+    page = await _paged_jobs(
+        identity=identity,
+        times=times,
+        sort={"field": sort, "direction": direction},
+        limit=limit,
+        cursor=cursor,
+    )
+    return CompletedPage(
+        items=[_enrich_completed(row, request) for row in page["items"]],
+        next_cursor=page["next_cursor"],
+    )
+
+
+@router.get(
+    "/failed",
+    response_model=FailedPage,
+    response_description=STATUS_DESCRIPTIONS.get("failed", ""),
+)
+async def status_failed(  # noqa: PLR0913 Each arg is a query knob
+    request: Request,
+    cursor: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `since`."),
+    ] = None,
+    data_tier: Annotated[int | None, Query(ge=0, le=2)] = None,
+    submitter: str | None = None,
+    reason: Annotated[
+        str | None,
+        Query(description="Narrow to one specific failure status."),
+    ] = None,
+    sort: Annotated[
+        Literal["created", "completed", "duration", "results", "submitter", "status"],
+        Query(description="Sort field; default `completed`."),
+    ] = "completed",
+    direction: Annotated[
+        Literal["asc", "desc"],
+        Query(description="Sort direction; default `desc`."),
+    ] = "desc",
+) -> FailedPage:
+    """Paged scan of failed-or-errored terminal jobs."""
+    times = _resolve_time_window(
+        since=since, until=until, lookback=lookback, field="completed"
+    )
+    status_filter: str | list[str] = (
+        reason if reason is not None else sorted(TERMINAL_FAILURE)
+    )
+    identity = _identity_with(
+        status=status_filter, submitter=submitter, data_tier=data_tier
+    )
+    page = await _paged_jobs(
+        identity=identity,
+        times=times,
+        sort={"field": sort, "direction": direction},
+        limit=limit,
+        cursor=cursor,
+    )
+    return FailedPage(
+        items=[_enrich_failed(row, request) for row in page["items"]],
+        next_cursor=page["next_cursor"],
+    )
+
+
+# === Logs =================================================================
+
+
+@router.get(
+    "/server_logs",
+    response_description=STATUS_DESCRIPTIONS.get("server_logs", ""),
+)
+async def status_server_logs(
+    start: datetime | None = None,
+    end: datetime | None = None,
+    lookback: Annotated[
+        float | None,
+        Query(description="Hours back from now; overrides `start`."),
+    ] = None,
+    level: LogLevel = "DEBUG",
+    fmt: Literal["flat", "struct"] = "flat",
+) -> StreamingResponse:
+    """Stream logs not associated with any job."""
+    effective_start = start
+    if lookback is not None:
+        effective_start = _now_aware() - timedelta(hours=lookback)
+
+    if fmt == "flat":
+        body: AsyncGenerator[str | dict[str, Any]] = MongoClient().get_flat_server_logs(
+            effective_start, end, level
+        )
+        media = "text/plain"
+    else:
+        body = objs_to_json(
+            MongoClient().get_server_logs(effective_start, end, level),
+            jsonl=True,
+        )
+        media = "application/json"
+
+    return StreamingResponse(body, media_type=media)

--- a/src/retriever/status.py
+++ b/src/retriever/status.py
@@ -21,6 +21,7 @@ from retriever.data_tiers import tier_manager
 from retriever.types.general import LogLevel
 from retriever.types.status import (
     ActiveJobRow,
+    ActivePage,
     CompletedJobRow,
     CompletedPage,
     CountsLinks,
@@ -288,6 +289,7 @@ async def status_root() -> StatusSnapshot:
     """Operator-glance health snapshot."""
     redis_client = RedisClient()
     mongo_client = MongoClient()
+    stuck_cutoff = _now_aware() - timedelta(hours=STUCK_DEFAULT_HOURS)
 
     # Fan out all the independent IO calls in parallel — these are the
     # bulk of the endpoint's wall time.
@@ -300,6 +302,7 @@ async def status_root() -> StatusSnapshot:
         t_redis_ping = tg.create_task(redis_client.ping())
         t_redis_mem = tg.create_task(redis_client.used_memory_bytes())
         t_in_flight = tg.create_task(mongo_client.count_in_flight())
+        t_stuck = tg.create_task(mongo_client.count_stuck(stuck_cutoff))
         t_metakg = tg.create_task(redis_client.metakg_freshness())
         t_subclass = tg.create_task(redis_client.subclass_freshness())
 
@@ -311,6 +314,7 @@ async def status_root() -> StatusSnapshot:
     redis_connected = t_redis_ping.result()
     redis_memory = t_redis_mem.result()
     active_job_count = t_in_flight.result()
+    stuck_job_count = t_stuck.result()
     metakg = t_metakg.result()
     subclass = t_subclass.result()
 
@@ -338,6 +342,7 @@ async def status_root() -> StatusSnapshot:
         version=_get_version(),
         processes=StatusProcesses(main=main, background=background, workers=workers),
         active_job_count=active_job_count,
+        stuck_job_count=stuck_job_count,
         mongo=StatusMongo(
             connected=mongo_connected,
             storage_mb=mongo_storage / _BYTES_PER_MB,
@@ -398,27 +403,38 @@ async def status_job(request: Request, job_id: str) -> JobDetail:
 
 @router.get(
     "/active",
-    response_model=list[ActiveJobRow],
+    response_model=ActivePage,
     response_description=STATUS_DESCRIPTIONS.get("active", ""),
 )
-async def status_active(request: Request) -> list[ActiveJobRow]:
-    """All currently-in-flight jobs, newest first."""
-    page = await MongoClient().get_job_statuses(
+async def status_active(
+    request: Request,
+    cursor: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
+) -> ActivePage:
+    """Paged scan of currently-in-flight jobs, newest first."""
+    page = await _paged_jobs(
         identity=JobIdentityFilter(status=sorted(NON_TERMINAL)),
+        times=None,
         sort={"field": "created", "direction": "desc"},
-        limit=MAX_LIMIT,
+        limit=limit,
+        cursor=cursor,
     )
     now = _now_aware()
-    return [_enrich_active(row, now, request) for row in page["items"]]
+    return ActivePage(
+        items=[_enrich_active(row, now, request) for row in page["items"]],
+        next_cursor=page["next_cursor"],
+    )
 
 
 @router.get(
     "/stuck",
-    response_model=list[ActiveJobRow],
+    response_model=ActivePage,
     response_description=STATUS_DESCRIPTIONS.get("stuck", ""),
 )
 async def status_stuck(
     request: Request,
+    cursor: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
     min_age: Annotated[
         float | None,
         Query(
@@ -426,18 +442,22 @@ async def status_stuck(
             description="Hours; jobs running longer than this are returned.",
         ),
     ] = None,
-) -> list[ActiveJobRow]:
-    """Active jobs older than `min_age` (default 1h)."""
+) -> ActivePage:
+    """Paged scan of active jobs older than `min_age` (default 1h)."""
     effective_min_age = min_age if min_age is not None else STUCK_DEFAULT_HOURS
     cutoff = _now_aware() - timedelta(hours=effective_min_age)
-    page = await MongoClient().get_job_statuses(
+    page = await _paged_jobs(
         identity=JobIdentityFilter(status=sorted(NON_TERMINAL)),
         times=JobTimeFilter(created={"before": cutoff}),
         sort={"field": "created", "direction": "desc"},
-        limit=MAX_LIMIT,
+        limit=limit,
+        cursor=cursor,
     )
     now = _now_aware()
-    return [_enrich_active(row, now, request) for row in page["items"]]
+    return ActivePage(
+        items=[_enrich_active(row, now, request) for row in page["items"]],
+        next_cursor=page["next_cursor"],
+    )
 
 
 # === Dashboard headlines ==================================================

--- a/src/retriever/status.py
+++ b/src/retriever/status.py
@@ -533,6 +533,7 @@ async def status_job(request: Request, job_id: str) -> JobDetail:
     return JobDetail(
         job_id=row["job_id"],
         status=row["status"],
+        description=row.get("description"),
         submitter=row.get("submitter"),
         data_tier=row.get("data_tier"),
         is_async=row.get("is_async"),
@@ -552,11 +553,11 @@ async def status_job(request: Request, job_id: str) -> JobDetail:
 
 
 @router.get(
-    "/active",
+    "/running",
     response_model=ActivePage,
     response_description=STATUS_DESCRIPTIONS.get("active", ""),
 )
-async def status_active(
+async def status_running(
     request: Request,
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=MAX_LIMIT)] = DEFAULT_LIMIT,
@@ -657,7 +658,12 @@ async def status_timeline(  # noqa: PLR0913 Each arg is a query knob
     ] = 24.0,
     status: Annotated[
         str | None,
-        Query(description="Specific status or alias 'failed'."),
+        Query(
+            description=(
+                "AsyncQueryStatusResponse lifecycle code "
+                "(Running, Completed, Failed); maps to stored outcome internally."
+            ),
+        ),
     ] = None,
     data_tier: Annotated[
         int | None,
@@ -703,8 +709,13 @@ async def status_durations(
     ] = 24.0,
     status: Annotated[
         str | None,
-        Query(description="Specific status or alias 'failed'."),
-    ] = "Complete",
+        Query(
+            description=(
+                "AsyncQueryStatusResponse lifecycle code "
+                "(Running, Completed, Failed); maps to stored outcome internally."
+            ),
+        ),
+    ] = "Completed",
 ) -> DurationsResponse:
     """Aggregate runtime stats over terminal jobs in the window."""
     service_health.require_mongo(

--- a/src/retriever/status.py
+++ b/src/retriever/status.py
@@ -146,7 +146,7 @@ def _enrich_active(row: JobStatus, now: datetime, request: Request) -> ActiveJob
         job_id=row["job_id"],
         created=created,
         submitter=row.get("submitter", ""),
-        data_tiers=list(row.get("data_tiers", [])),
+        data_tier=row.get("data_tier"),
         age_seconds=int((now - created).total_seconds()),
         links=_build_links(request, row["job_id"]),
     )
@@ -162,7 +162,7 @@ def _enrich_completed(row: JobStatus, request: Request) -> CompletedJobRow:
         created=created,
         completed=completed,
         duration_seconds=float((completed - created).total_seconds()),
-        data_tiers=list(row.get("data_tiers", [])),
+        data_tier=row.get("data_tier"),
         results=int(row.get("results", 0)),
         links=_build_links(request, row["job_id"]),
     )
@@ -178,7 +178,7 @@ def _enrich_failed(row: JobStatus, request: Request) -> FailedJobRow:
         created=created,
         completed=completed,
         duration_seconds=float((completed - created).total_seconds()),
-        data_tiers=list(row.get("data_tiers", [])),
+        data_tier=row.get("data_tier"),
         status=row["status"],
         links=_build_links(request, row["job_id"]),
     )
@@ -534,8 +534,9 @@ async def status_job(request: Request, job_id: str) -> JobDetail:
         job_id=row["job_id"],
         status=row["status"],
         submitter=row.get("submitter"),
-        data_tiers=list(row.get("data_tiers", [])),
+        data_tier=row.get("data_tier"),
         is_async=row.get("is_async"),
+        job_timeout=row.get("job_timeout"),
         created=created,
         completed=completed,
         duration_seconds=duration,
@@ -677,7 +678,7 @@ async def status_timeline(  # noqa: PLR0913 Each arg is a query knob
         if resolved is not None:
             identity["status"] = resolved
         if data_tier is not None:
-            identity["data_tiers"] = [data_tier]  # pyright: ignore[reportGeneralTypeIssues]
+            identity["data_tier"] = data_tier  # pyright: ignore[reportGeneralTypeIssues]
 
     buckets = await MongoClient().bucket_jobs_over_time(
         field=field, granularity=granularity, identity=identity, times=times
@@ -858,7 +859,7 @@ def _identity_with(
     if submitter is not None:
         identity["submitter"] = submitter
     if data_tier is not None:
-        identity["data_tiers"] = [data_tier]  # pyright: ignore[reportGeneralTypeIssues]
+        identity["data_tier"] = data_tier  # pyright: ignore[reportGeneralTypeIssues]
     return identity
 
 

--- a/src/retriever/types/general.py
+++ b/src/retriever/types/general.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal, NamedTuple, TypedDict
+from collections.abc import Mapping
+from typing import Annotated, Any, Literal, NamedTuple, NotRequired, TypedDict
 
 from fastapi import BackgroundTasks, Request, Response
 from pydantic import BeforeValidator
@@ -26,6 +27,7 @@ class ErrorDetail(TypedDict):
     """Basic FastAPI error response body."""
 
     detail: str
+    additional_info: NotRequired[dict[str, Any]]
 
 
 LogLevel = Annotated[
@@ -92,4 +94,4 @@ QEdgeIDMap = dict[int, QEdgeID]
 QNodeCURIEPair = tuple[QNodeID, CURIE]
 
 
-EntityToEntityMapping = dict[CURIE, list[CURIE]]
+EntityToEntityMapping = Mapping[CURIE, list[CURIE]]

--- a/src/retriever/types/general.py
+++ b/src/retriever/types/general.py
@@ -81,7 +81,7 @@ class LookupArtifacts(NamedTuple):
     kgraph: KnowledgeGraphDict
     aux_graphs: dict[AuxGraphID, AuxiliaryGraphDict]
     logs: list[LogEntryDict]
-    error: bool | None = None
+    status: str = "Success"
 
 
 AdjacencyGraph = dict[QNodeID, dict[QNodeID, list[QEdgeDict]]]

--- a/src/retriever/types/status.py
+++ b/src/retriever/types/status.py
@@ -1,0 +1,272 @@
+"""Response shapes for the `/status/*` dashboard API.
+
+These are plain TypedDicts — the dashboard endpoints build responses from
+trusted internal data, so there's nothing to validate. FastAPI uses the
+return-type annotations to generate the OpenAPI schema.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, NotRequired, TypedDict
+
+
+class Links(TypedDict):
+    """Drill-down URLs into the existing per-job endpoints."""
+
+    logs: str
+    response: str
+
+
+class ActiveJobRow(TypedDict):
+    """A single currently-in-flight job."""
+
+    job_id: str
+    created: datetime
+    submitter: str
+    data_tiers: list[int]
+    age_seconds: int
+    links: Links
+
+
+class CompletedJobRow(TypedDict):
+    """A single terminal-success job row."""
+
+    job_id: str
+    submitter: str
+    created: datetime
+    completed: datetime
+    duration_seconds: float
+    data_tiers: list[int]
+    results: int
+    links: Links
+
+
+class FailedJobRow(TypedDict):
+    """A single terminal-failure job row.
+
+    Same as `CompletedJobRow` but with `status` carrying the specific
+    failure flavor (Failed / QueryNotTraversable / UnsupportedConstraint).
+    """
+
+    job_id: str
+    submitter: str
+    created: datetime
+    completed: datetime
+    duration_seconds: float
+    data_tiers: list[int]
+    status: str
+    links: Links
+
+
+class CompletedPage(TypedDict):
+    """A page of completed job rows."""
+
+    items: list[CompletedJobRow]
+    next_cursor: str | None
+
+
+class FailedPage(TypedDict):
+    """A page of failed job rows."""
+
+    items: list[FailedJobRow]
+    next_cursor: str | None
+
+
+class JobDetail(TypedDict):
+    """Full per-job status for the dashboard's drill-down modal."""
+
+    job_id: str
+    status: str
+    submitter: NotRequired[str | None]
+    data_tiers: list[int]
+    is_async: NotRequired[bool | None]
+    created: NotRequired[datetime | None]
+    completed: NotRequired[datetime | None]
+    duration_seconds: NotRequired[float | None]
+    # Query-graph geometry (set at enqueue)
+    qnodes: NotRequired[int | None]
+    qedges: NotRequired[int | None]
+    qpaths: NotRequired[int | None]
+    # Response-graph geometry (set on completion)
+    knodes: NotRequired[int | None]
+    kedges: NotRequired[int | None]
+    aux_graphs: NotRequired[int | None]
+    results: NotRequired[int | None]
+    links: Links
+
+
+class TimelineBucket(TypedDict):
+    """A single time-bucketed throughput count."""
+
+    bucket_start: datetime
+    count: int
+
+
+class DurationsResponse(TypedDict):
+    """Aggregate runtime stats over terminal jobs in the window."""
+
+    sample_size: int
+    min_seconds: float
+    max_seconds: float
+    avg_seconds: float
+    p50_seconds: NotRequired[float | None]
+    p95_seconds: NotRequired[float | None]
+    p99_seconds: NotRequired[float | None]
+
+
+class SubmitterRow(TypedDict):
+    """A single submitter leaderboard row."""
+
+    submitter: str
+    count: int
+    completed: int
+    failed: int
+    success_rate: float | None
+    p95_duration_seconds: float | None
+    last_seen: datetime
+
+
+class TierDurations(TypedDict):
+    """Per-tier duration stats; all `None` when no completions."""
+
+    avg_seconds: float | None
+    min_seconds: float | None
+    max_seconds: float | None
+    p50_seconds: float | None
+    p95_seconds: float | None
+    p99_seconds: float | None
+
+
+class TierRow(TypedDict):
+    """A single tier-activity row."""
+
+    tier: int
+    active: int
+    completed: int
+    failed: int
+    durations: TierDurations
+    last_activity: datetime | None
+
+
+class SubmitterTierRow(TypedDict):
+    """A single (submitter, tier) cell."""
+
+    submitter: str
+    tier: int
+    count: int
+    completed: int
+    failed: int
+    avg_seconds: float | None
+    p95_seconds: float | None
+    last_seen: datetime | None
+
+
+class FailureBreakdownCell(TypedDict):
+    """One {key, status} cell from `/status/failure_breakdown`.
+
+    `key` is the submitter name or the tier index stringified, depending
+    on the `by` query param.
+    """
+
+    key: str
+    status: str
+    count: int
+
+
+class FailureBreakdownResponse(TypedDict):
+    """`/status/failure_breakdown` response."""
+
+    by: Literal["submitter", "tier"]
+    rows: list[FailureBreakdownCell]
+
+
+class CountsLinks(TypedDict):
+    """Per-window drill-down links to /completed and /failed."""
+
+    completed: str
+    failed: str
+
+
+class CountsWindow(TypedDict):
+    """One window's status breakdown + drill-down links.
+
+    `counts` maps status string -> count for shallow JSON access:
+    `counts.Failed` rather than walking a list.
+    """
+
+    total: int
+    counts: dict[str, int]
+    links: CountsLinks
+
+
+class CountsSnapshot(TypedDict):
+    """`/counts` response — three fixed windows (last_24h, last_week, all_time)."""
+
+    windows: dict[str, CountsWindow]
+
+
+class StatusVersion(TypedDict):
+    """Running-build provenance."""
+
+    git_commit: str
+    git_branch: str | None
+
+
+class StatusProcess(TypedDict):
+    """A registered Retriever process."""
+
+    pid: int
+    uptime_seconds: float
+    rss_mb: float | None
+
+
+class StatusMongo(TypedDict):
+    """MongoDB liveness + capacity."""
+
+    connected: bool
+    storage_mb: float
+    queue_depth: int
+
+
+class StatusRedis(TypedDict):
+    """Dragonfly liveness + capacity."""
+
+    connected: bool
+    used_memory_mb: float
+
+
+class StatusTier(TypedDict):
+    """One configured tier's connection state."""
+
+    tier: int
+    backend: str
+    connected: bool
+
+
+class StatusFreshness(TypedDict):
+    """Sidecar freshness for a Redis-published artifact."""
+
+    refreshed_at: datetime
+    count: int
+
+
+class StatusProcesses(TypedDict):
+    """Process tree for the running Retriever instance."""
+
+    main: StatusProcess | None
+    background: StatusProcess | None
+    workers: list[StatusProcess]
+
+
+class StatusSnapshot(TypedDict):
+    """Bare `/status` health snapshot."""
+
+    version: StatusVersion
+    processes: StatusProcesses
+    active_job_count: int
+    mongo: StatusMongo
+    redis: StatusRedis
+    tiers: list[StatusTier]
+    metakg: StatusFreshness | None
+    subclass_map: StatusFreshness | None

--- a/src/retriever/types/status.py
+++ b/src/retriever/types/status.py
@@ -59,6 +59,13 @@ class FailedJobRow(TypedDict):
     links: Links
 
 
+class ActivePage(TypedDict):
+    """A page of in-flight job rows."""
+
+    items: list[ActiveJobRow]
+    next_cursor: str | None
+
+
 class CompletedPage(TypedDict):
     """A page of completed job rows."""
 
@@ -265,6 +272,7 @@ class StatusSnapshot(TypedDict):
     version: StatusVersion
     processes: StatusProcesses
     active_job_count: int
+    stuck_job_count: int
     mongo: StatusMongo
     redis: StatusRedis
     tiers: list[StatusTier]

--- a/src/retriever/types/status.py
+++ b/src/retriever/types/status.py
@@ -85,6 +85,7 @@ class JobDetail(TypedDict):
 
     job_id: str
     status: str
+    description: NotRequired[str | None]
     submitter: NotRequired[str | None]
     data_tier: int | None
     is_async: NotRequired[bool | None]

--- a/src/retriever/types/status.py
+++ b/src/retriever/types/status.py
@@ -1,6 +1,6 @@
 """Response shapes for the `/status/*` dashboard API.
 
-These are plain TypedDicts — the dashboard endpoints build responses from
+These are plain TypedDicts - the dashboard endpoints build responses from
 trusted internal data, so there's nothing to validate. FastAPI uses the
 return-type annotations to generate the OpenAPI schema.
 """
@@ -208,7 +208,7 @@ class CountsWindow(TypedDict):
 
 
 class CountsSnapshot(TypedDict):
-    """`/counts` response — three fixed windows (last_24h, last_week, all_time)."""
+    """`/counts` response - three fixed windows (last_24h, last_week, all_time)."""
 
     windows: dict[str, CountsWindow]
 
@@ -228,34 +228,52 @@ class StatusProcess(TypedDict):
     rss_mb: float | None
 
 
-class StatusMongo(TypedDict):
+class BackendHealth(TypedDict):
+    """Uniform health projection emitted by every BackendClient."""
+
+    up: bool
+    last_outage: datetime | None
+    last_recovery: datetime | None
+    error: str | None
+
+
+class StatusMongo(BackendHealth):
     """MongoDB liveness + capacity."""
 
-    connected: bool
-    storage_mb: float
+    storage_mb: float | None
     queue_depth: int
 
 
-class StatusRedis(TypedDict):
+class StatusRedis(BackendHealth):
     """Dragonfly liveness + capacity."""
 
-    connected: bool
-    used_memory_mb: float
+    used_memory_mb: float | None
 
 
-class StatusTier(TypedDict):
-    """One configured tier's connection state."""
+class StatusTier(BackendHealth):
+    """One configured tier's health + identity."""
 
     tier: int
     backend: str
-    connected: bool
 
 
-class StatusFreshness(TypedDict):
-    """Sidecar freshness for a Redis-published artifact."""
+class StatusMetaKG(TypedDict):
+    """Freshness of the published MetaKG plus per-worker caveats."""
 
-    refreshed_at: datetime
-    count: int
+    refreshed_at: datetime | None
+    count: int | None
+    self_reported: bool
+    """True if the answering worker served its in-memory copy instead of the Redis sidecar."""
+    stale: bool
+    """True past roughly twice the refresh cadence; signals instance-0 not refreshing."""
+
+
+class StatusSubclassMap(TypedDict):
+    """Subclass mapping freshness; `available` flips false when no map can be served."""
+
+    refreshed_at: datetime | None
+    count: int | None
+    available: bool
 
 
 class StatusProcesses(TypedDict):
@@ -264,17 +282,28 @@ class StatusProcesses(TypedDict):
     main: StatusProcess | None
     background: StatusProcess | None
     workers: list[StatusProcess]
+    """Just the answering worker if the registry isn't available."""
+    registry_available: bool
+    """False when the worker registry couldn't be read (typically a Redis outage)."""
+
+
+class StatusServedBy(TypedDict):
+    """Identity of the worker that answered this `/status` request."""
+
+    pid: int
+    started_at: datetime
 
 
 class StatusSnapshot(TypedDict):
     """Bare `/status` health snapshot."""
 
     version: StatusVersion
+    served_by: StatusServedBy
     processes: StatusProcesses
-    active_job_count: int
-    stuck_job_count: int
+    active_job_count: int | None
+    stuck_job_count: int | None
     mongo: StatusMongo
     redis: StatusRedis
     tiers: list[StatusTier]
-    metakg: StatusFreshness | None
-    subclass_map: StatusFreshness | None
+    metakg: StatusMetaKG
+    subclass_map: StatusSubclassMap

--- a/src/retriever/types/status.py
+++ b/src/retriever/types/status.py
@@ -24,7 +24,7 @@ class ActiveJobRow(TypedDict):
     job_id: str
     created: datetime
     submitter: str
-    data_tiers: list[int]
+    data_tier: int | None
     age_seconds: int
     links: Links
 
@@ -37,7 +37,7 @@ class CompletedJobRow(TypedDict):
     created: datetime
     completed: datetime
     duration_seconds: float
-    data_tiers: list[int]
+    data_tier: int | None
     results: int
     links: Links
 
@@ -54,7 +54,7 @@ class FailedJobRow(TypedDict):
     created: datetime
     completed: datetime
     duration_seconds: float
-    data_tiers: list[int]
+    data_tier: int | None
     status: str
     links: Links
 
@@ -86,8 +86,9 @@ class JobDetail(TypedDict):
     job_id: str
     status: str
     submitter: NotRequired[str | None]
-    data_tiers: list[int]
+    data_tier: int | None
     is_async: NotRequired[bool | None]
+    job_timeout: NotRequired[float | None]
     created: NotRequired[datetime | None]
     completed: NotRequired[datetime | None]
     duration_seconds: NotRequired[float | None]

--- a/src/retriever/types/trapi_pydantic.py
+++ b/src/retriever/types/trapi_pydantic.py
@@ -34,6 +34,12 @@ class Parameters(BaseModel):
         | None
     ) = None
     tier: TierNumber | None = None
+    tier_fallback: Annotated[
+        bool,
+        Field(
+            description="When the requested tier is down, fall back to the other implemented tier (T0 ↔ T1). Set False to require the requested tier and 424 if it's unavailable. Default True. Has no effect on T2 (no fallback peer)."
+        ),
+    ] = True
     dehydrated: Annotated[
         bool | None,
         Field(

--- a/src/retriever/utils/backend_client.py
+++ b/src/retriever/utils/backend_client.py
@@ -123,7 +123,7 @@ class BackendClient(AsyncDaemon, ABC):
         with contextlib.suppress(ValueError):
             {
                 "outage": self._outage_callbacks,
-                "recovery": self._recovery_callbacks,
+                "recover": self._recovery_callbacks,
             }[event].remove(callback)
 
     def on_outage(self, callback: Callable[[], Awaitable[None]]) -> None:

--- a/src/retriever/utils/backend_client.py
+++ b/src/retriever/utils/backend_client.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import random
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Coroutine
+from datetime import datetime
+from typing import Literal, TypedDict, override
+
+from loguru import logger
+
+from retriever.utils.general import AsyncDaemon
+
+
+class StatusDict(TypedDict):
+    """Dict of core status info for a BackendClient."""
+
+    up: bool
+    last_outage: datetime | None
+    last_recovery: datetime | None
+    error: str | None
+
+
+class BackendClient(AsyncDaemon, ABC):
+    """Base for clients of external dependencies.
+
+    Provides lifecycle, periodic healthchecks, error classification, and subclass
+    method requirements.
+    """
+
+    healthcheck_interval: float | None = 30.0
+    """How often to check health, None to disable periodic checks."""
+
+    retry_backoff_start: float = 1.0
+    """Starting backoff for reconnecting."""
+
+    retry_backoff_max: float = 60.0
+    """Maximum backoff for reconnecting."""
+
+    retry_backoff_jitter: float = 0.2
+    """Proportion of jitter in backoff."""
+
+    up: bool = True
+    """Status of the service."""
+
+    last_outage: datetime | None
+    """Timestamp of last outage, if occurred."""
+
+    last_recovery: datetime | None
+    """Timestamp of last outage recovery, if occurred."""
+
+    last_error: str | None
+    _recovery_callbacks: list[Callable[[], Awaitable[None]]]
+    _outage_callbacks: list[Callable[[], Awaitable[None]]]
+
+    _check_event: asyncio.Event
+    """Used to request a background healthcheck."""
+
+    _up_event: asyncio.Event
+    """Set while `up` is True; consumers `await` it to park during outages."""
+
+    _callback_tasks: set[asyncio.Task[None]]
+    """Callback task storage to prevent early GC."""
+
+    def __init__(self) -> None:
+        """Initialize state. Assume up until failure."""
+        super().__init__()
+        self.up = True
+        self.last_outage = None
+        self.last_recovery = None
+        self.last_error = None
+        self._recovery_callbacks = []
+        self._outage_callbacks = []
+        self._check_event = asyncio.Event()
+        self._up_event = asyncio.Event()
+        self._up_event.set()
+        self._callback_tasks = set()
+
+    @abstractmethod
+    async def ping(self) -> None:
+        """Probe the backend. Raise on failure; return on success.
+
+        Called by the health loop at `healthcheck_interval` and after
+        every `request_health_check()`.
+        Implementations should be cheap and idempotent.
+        """
+
+    def is_outage_error(self, exc: BaseException) -> bool:
+        """Classify whether an exception indicates this backend is down.
+
+        Default biases toward True so callers don't miss real outages.
+        `CancelledError` is always treated as a non-outage signal so
+        shutdown cancellation isn't mistaken for a backend failure.
+        Subclasses override to add more known-benign carve-outs.
+        """
+        return not isinstance(exc, asyncio.CancelledError)
+
+    def request_health_check(self) -> None:
+        """Schedule a one-shot ping ASAP.
+
+        Used for quick status checking by client callers.
+        No-op if a check is already pending
+        """
+        self._check_event.set()
+
+    def on_recover(self, callback: Callable[[], Awaitable[None]]) -> None:
+        """Register a coroutine fired on every recovery; duplicate registrations are ignored.
+
+        Implementers MUST guard the callback body with an `asyncio.Lock`
+        (or equivalent) so multiple callbacks do not overlap.
+        The base catches and logs callback exceptions but does not serialize them.
+        """
+        if callback not in self._recovery_callbacks:
+            self._recovery_callbacks.append(callback)
+
+    def deregister_callback(
+        self,
+        event: Literal["outage", "recover"],
+        callback: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Deregister a previously-registered callback. Idempotent."""
+        with contextlib.suppress(ValueError):
+            {
+                "outage": self._outage_callbacks,
+                "recovery": self._recovery_callbacks,
+            }[event].remove(callback)
+
+    def on_outage(self, callback: Callable[[], Awaitable[None]]) -> None:
+        """Register a coroutine fired on every outage; duplicate registrations are ignored.
+
+        Same self-serialization contract as `on_recover`.
+        """
+        if callback not in self._outage_callbacks:
+            self._outage_callbacks.append(callback)
+
+    def status(self) -> StatusDict:
+        """Dict of relevant status fields."""
+        return StatusDict(
+            up=self.up,
+            last_outage=self.last_outage,
+            last_recovery=self.last_recovery,
+            error=self.last_error,
+        )
+
+    # Integrate with AsyncDaemon for Lifecycle
+    @override
+    def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:
+        """Append the health loop to whatever the parent class returns."""
+        return [*super().get_task_funcs(), self._health_loop]
+
+    async def _health_loop(self) -> None:
+        """Driver loop maintaining the health flag.
+
+        Pings periodically (or on demand) while up; jittered
+        exponential backoff while down. Transitions update timestamps,
+        clear/record `last_error`, and fire callbacks. Failures the
+        driver classifies as non-outage (via `is_outage_error`) are
+        treated as successful probes.
+        """
+        backoff = self.retry_backoff_start
+        try:
+            while True:
+                nudged = await self._await_next_tick(backoff)
+                self._check_event.clear()
+                try:
+                    await self.ping()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    if not self.is_outage_error(exc):
+                        self._handle_ping_success()
+                        backoff = self.retry_backoff_start
+                        continue
+                    was_up = self.up
+                    self._handle_ping_failure(exc)
+                    if was_up:
+                        backoff = self.retry_backoff_start
+                    elif not nudged:
+                        backoff = min(backoff * 2, self.retry_backoff_max)
+                else:
+                    self._handle_ping_success()
+                    backoff = self.retry_backoff_start
+        except asyncio.CancelledError:
+            return
+
+    async def _await_next_tick(self, backoff: float) -> bool:
+        """Sleep until the next ping; returns True if a nudge interrupted the sleep.
+
+        While up: wait for either the steady interval to elapse or
+        `request_health_check()` to fire, whichever comes first. If
+        polling is disabled, block on the event indefinitely.
+
+        While down: sleep an uninterruptible floor (one
+        `retry_backoff_start`) and then a nudge-interruptible tail up
+        to the current backoff. The floor caps nudge-driven ping
+        frequency under high-traffic nudge sources.
+        """
+        if self.up:
+            if self.healthcheck_interval is None:
+                await self._check_event.wait()
+                return True
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(
+                    self._check_event.wait(),
+                    timeout=self.healthcheck_interval,
+                )
+                return True
+            return False
+
+        jitter = 1.0 + random.uniform(
+            -self.retry_backoff_jitter, self.retry_backoff_jitter
+        )
+        sleep_time = backoff * jitter
+        floor = self.retry_backoff_start
+        if sleep_time <= floor:
+            await asyncio.sleep(sleep_time)
+            return False
+        await asyncio.sleep(floor)
+        try:
+            await asyncio.wait_for(
+                self._check_event.wait(),
+                timeout=sleep_time - floor,
+            )
+        except TimeoutError:
+            return False
+        return True
+
+    def _handle_ping_failure(self, exc: BaseException) -> None:
+        """Record the failure; on first outage fire callbacks."""
+        self.last_error = f"{type(exc).__name__}: {exc}"
+        if self.up:
+            self.up = False
+            self._up_event.clear()
+            self.last_outage = datetime.now().astimezone()
+            logger.warning(f"{type(self).__name__} down: {self.last_error}")
+            self._fire_callbacks(self._outage_callbacks, "outage")
+
+    def _handle_ping_success(self) -> None:
+        """Record recovery and fire on_recover callbacks. Idempotent."""
+        if self.up:
+            return
+        self.up = True
+        self._up_event.set()
+        self.last_recovery = datetime.now().astimezone()
+        self.last_error = None
+        logger.success(f"{type(self).__name__} up: ping succeeded.")
+        self._fire_callbacks(self._recovery_callbacks, "recovery")
+
+    def _fire_callbacks(
+        self,
+        callbacks: list[Callable[[], Awaitable[None]]],
+        kind: Literal["outage", "recovery"],
+    ) -> None:
+        """Spawn each callback as a fire-and-forget task.
+
+        Tasks are kept in `_callback_tasks` as strong refs until they
+        complete (they remove themselves via `add_done_callback`).
+        Callbacks don't delay health loop. Callbacks must self-manage protection
+        against parallel races.
+        """
+        for cb in callbacks:
+            task = asyncio.create_task(self._safe_callback(cb, kind))
+            self._callback_tasks.add(task)
+            _ = task.add_done_callback(self._callback_tasks.discard)
+
+    async def _safe_callback(
+        self,
+        callback: Callable[[], Awaitable[None]],
+        kind: Literal["outage", "recovery"],
+    ) -> None:
+        """Run a callback, swallowing exceptions so the health loop is unaffected."""
+        try:
+            await callback()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(f"{type(self).__name__} {kind} callback failed.")

--- a/src/retriever/utils/exception_handlers.py
+++ b/src/retriever/utils/exception_handlers.py
@@ -1,11 +1,14 @@
 import traceback
 from datetime import datetime
 from functools import lru_cache
+from http import HTTPStatus
 from typing import cast
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
+from fastapi.utils import is_body_allowed_for_status_code
 
 from retriever.config.general import CONFIG
 
@@ -22,6 +25,19 @@ def get_cors(app: FastAPI) -> CORSMiddleware:
         allow_methods=CONFIG.cors.allow_methods,
         allow_headers=CONFIG.cors.allow_headers,
     )
+
+
+async def http_exception_handler(_request: Request, exc: HTTPException) -> Response:
+    """Like FastAPI's handler but emits a dict `detail` as the body directly, not nested."""
+    headers = getattr(exc, "headers", None)
+    if not is_body_allowed_for_status_code(exc.status_code):
+        return Response(status_code=exc.status_code, headers=headers)
+    body = (
+        jsonable_encoder(exc.detail)
+        if isinstance(exc.detail, dict)
+        else {"detail": exc.detail}
+    )
+    return JSONResponse(body, status_code=exc.status_code, headers=headers)
 
 
 async def ensure_cors(app: FastAPI, request: Request, exc: Exception) -> Response:
@@ -43,7 +59,7 @@ async def ensure_cors(app: FastAPI, request: Request, exc: Exception) -> Respons
                 },
             ],
         },
-        status_code=500,
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
     )
 
     # Since the CORSMiddleware is not executed when an unhandled server exception

--- a/src/retriever/utils/general.py
+++ b/src/retriever/utils/general.py
@@ -185,6 +185,18 @@ class BatchedAction(AsyncDaemon, metaclass=Singleton):
             except asyncio.CancelledError:
                 break
 
+    async def flush(self) -> None:
+        """Drain all pending queue items and run their batch handlers directly."""
+        for target, queue in self.action_queues.items():
+            batch: list[Any] = []
+            while not queue.empty():
+                try:
+                    batch.append(queue.get_nowait())
+                except asyncio.QueueEmpty:
+                    break
+            if batch:
+                await getattr(self, target)(batch)
+
     def put(self, target: str, payload: Any) -> None:
         """Put a payload in the target action queue."""
         if not hasattr(self, target):

--- a/src/retriever/utils/general.py
+++ b/src/retriever/utils/general.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, ABCMeta
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Coroutine
 from typing import Any, ClassVar, override
 
@@ -12,11 +13,15 @@ from loguru import logger
 class Singleton(ABCMeta):
     """Singleton metaclass that ensures classes using it have only one instance."""
 
-    _instances: ClassVar[dict[Singleton, Singleton]] = {}
+    _instances: ClassVar[dict[Singleton, Any]] = {}
 
     @override
-    def __call__(cls, *args: Any, **kwargs: Any) -> Singleton:
-        """Ensure calls go to one instance."""
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        """Ensure calls go to one instance.
+
+        Return type is `Any` so callers infer the subclass
+        rather than the metaclass itself.
+        """
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)  # noqa:UP008
         return cls._instances[cls]
@@ -30,6 +35,14 @@ async def await_next[T](iterator: AsyncIterator[T]) -> T:
 def as_task[T](iterator: AsyncIterator[T]) -> asyncio.Task[T]:
     """Create a task which resolves to the iterator's next result."""
     return asyncio.create_task(await_next(iterator))
+
+
+async def tolerate_init(label: str, coro: Coroutine[None, None, Any]) -> None:
+    """Run an init step; log and swallow failures so startup proceeds."""
+    try:
+        await coro
+    except Exception:
+        logger.exception(f"{label} failed at startup; continuing in degraded mode.")
 
 
 class EmptyIteratorError(Exception):
@@ -103,14 +116,22 @@ class AsyncDaemon(ABC, metaclass=Singleton):
         self.initialized = True
 
     async def wrapup(self) -> None:
-        """Cancel all long-running tasks."""
+        """Cancel all long-running tasks and await their termination."""
         logger.info(f"{self.__class__.__name__} wrapping up.")
         for task in self.tasks:
-            task.cancel()
+            _ = task.cancel()
+        for task in self.tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
-    @abstractmethod
     def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:
-        """Return a list of long-running task functions."""
+        """Return long-running task functions to spawn on initialize.
+
+        Default is an empty list. Override to contribute tasks. Subclasses
+        composing with intermediate base classes should chain
+        `super().get_task_funcs()` so contributions aren't lost.
+        """
+        return []
 
 
 class BatchedAction(AsyncDaemon, metaclass=Singleton):

--- a/src/retriever/utils/job_status.py
+++ b/src/retriever/utils/job_status.py
@@ -15,7 +15,7 @@ Retriever doesn't queue async jobs so `Queued` never appears in our
 storage.
 """
 
-TERMINAL_SUCCESS: frozenset[str] = frozenset({"Success"})
+TERMINAL_SUCCESS: frozenset[str] = frozenset({"Success", "Complete"})
 """Statuses for successfully-terminated jobs."""
 
 TERMINAL_FAILURE: frozenset[str] = frozenset(

--- a/src/retriever/utils/job_status.py
+++ b/src/retriever/utils/job_status.py
@@ -1,0 +1,34 @@
+"""Job-status vocabulary shared across the /status API surface.
+
+Centralizes the canonical sets of status strings that Retriever's lookup
+path actually writes, plus the "failed" alias used at the API boundary.
+Imported by MongoClient query helpers and (eventually) FastAPI route
+handlers so the vocabulary stays in one place.
+"""
+
+from __future__ import annotations
+
+NON_TERMINAL: frozenset[str] = frozenset({"Running", "Accepted"})
+"""Statuses for jobs that have not reached a terminal state."""
+
+TERMINAL_SUCCESS: frozenset[str] = frozenset({"Complete"})
+"""Statuses for successfully-terminated jobs."""
+
+TERMINAL_FAILURE: frozenset[str] = frozenset(
+    {"Failed", "QueryNotTraversable", "UnsupportedConstraint"}
+)
+"""Statuses for failed-or-errored terminal jobs."""
+
+
+def resolve_status_filter(status: str | None) -> str | list[str] | None:
+    """Expand the "failed" alias to the failure union; pass other values through.
+
+    Output shape matches `JobIdentityFilter["status"]` so callers can drop
+    the result straight into `_build_filter_query` without further
+    massaging.
+    """
+    if status is None:
+        return None
+    if status == "failed":
+        return sorted(TERMINAL_FAILURE)
+    return status

--- a/src/retriever/utils/job_status.py
+++ b/src/retriever/utils/job_status.py
@@ -8,10 +8,14 @@ handlers so the vocabulary stays in one place.
 
 from __future__ import annotations
 
-NON_TERMINAL: frozenset[str] = frozenset({"Running", "Accepted"})
-"""Statuses for jobs that have not reached a terminal state."""
+NON_TERMINAL: frozenset[str] = frozenset({"Running"})
+"""Statuses for jobs that have not reached a terminal state.
 
-TERMINAL_SUCCESS: frozenset[str] = frozenset({"Complete"})
+Retriever doesn't queue async jobs so `Queued` never appears in our
+storage.
+"""
+
+TERMINAL_SUCCESS: frozenset[str] = frozenset({"Success"})
 """Statuses for successfully-terminated jobs."""
 
 TERMINAL_FAILURE: frozenset[str] = frozenset(
@@ -20,15 +24,44 @@ TERMINAL_FAILURE: frozenset[str] = frozenset(
 """Statuses for failed-or-errored terminal jobs."""
 
 
-def resolve_status_filter(status: str | None) -> str | list[str] | None:
-    """Expand the "failed" alias to the failure union; pass other values through.
+# TRAPI 1.6 splits status vocabularies: Response uses outcome shortcodes
+# (Success, QueryNotTraversable, KPsNotAvailable, ...) while
+# AsyncQueryStatusResponse uses lifecycle shortcodes (Queued, Running,
+# Completed, Failed). We store outcomes (the more specific value) and
+# collapse to lifecycle only when filling an AsyncQueryStatusResponse.
+_ASYNC_LIFECYCLE_MAP: dict[str, str] = {
+    "Success": "Completed",
+    "Complete": "Completed",  # legacy stored value
+    "QueryNotTraversable": "Failed",
+    "UnsupportedConstraint": "Failed",
+}
 
-    Output shape matches `JobIdentityFilter["status"]` so callers can drop
-    the result straight into `_build_filter_query` without further
+
+def to_async_lifecycle(status: str) -> str:
+    """Map a stored outcome status to the TRAPI AsyncQueryStatusResponse vocabulary.
+
+    Unknown values pass through so we never lose information for statuses
+    we haven't classified (e.g. future Retriever-specific failure flavors).
+    """
+    return _ASYNC_LIFECYCLE_MAP.get(status, status)
+
+
+def resolve_status_filter(status: str | None) -> str | list[str] | None:
+    """Map a lifecycle status to the stored outcome code(s) MongoDB indexes against.
+
+    `Completed` -> `Success`. `Failed` (and legacy lowercase `failed`)
+    expand to the failure union so all failure flavors match. `Running`
+    passes through unchanged. Unknown values pass through too so a
+    caller can still filter by a Retriever-specific code directly.
+
+    Output shape matches `JobIdentityFilter["status"]` so callers can
+    drop the result straight into `_build_filter_query` without further
     massaging.
     """
     if status is None:
         return None
-    if status == "failed":
+    if status in {"Failed", "failed"}:
         return sorted(TERMINAL_FAILURE)
+    if status == "Completed":
+        return "Success"
     return status

--- a/src/retriever/utils/logs.py
+++ b/src/retriever/utils/logs.py
@@ -15,7 +15,7 @@ from retriever.config.general import CONFIG
 from retriever.types.general import LogLevel
 from retriever.types.trapi import LogEntryDict
 from retriever.types.trapi import LogLevel as TRAPILogLevel
-from retriever.utils.mongo import MongoQueue
+from retriever.utils.mongo import MongoOutage, MongoQueue
 
 MONGO_QUEUE = MongoQueue()
 
@@ -218,7 +218,7 @@ def add_mongo_sink() -> None:
 
         try:
             MONGO_QUEUE.put("log_dump", log)
-        except ValueError:
+        except (ValueError, MongoOutage):
             return
 
     # Allow an out via no_mongo_log to avoid feedback loops

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any, ClassVar, Literal, NotRequired, TypedDict, cast
+from typing import Any, ClassVar, Literal, NotRequired, TypedDict, cast, override
 
 from bson import ObjectId
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
@@ -49,6 +50,8 @@ class QueryState(TypedDict):
     qedges: int
     qpaths: int
     status: str
+    worker_pid: int | None
+    worker_started_at: datetime | None
 
 
 class ResponseState(TypedDict):
@@ -63,7 +66,7 @@ class ResponseState(TypedDict):
     status: str
 
 
-class JobDocs(TypedDict):
+class JobDoc(TypedDict):
     """Job documents and some lifetime metadata."""
 
     job_id: str
@@ -73,6 +76,11 @@ class JobDocs(TypedDict):
     created: NotRequired[datetime]
     completed: NotRequired[datetime]
     touched: NotRequired[datetime]
+
+    # Set by the orphan sweep — tells `get_job_response` that `doc`, if
+    # present, still holds the original query bytes rather than a real
+    # response (the ResponseState write never landed).
+    abandoned: NotRequired[bool]
 
 
 class JobStatus(TypedDict):
@@ -100,6 +108,14 @@ class JobStatus(TypedDict):
     created: NotRequired[datetime]
     completed: NotRequired[datetime]
     touched: NotRequired[datetime]
+
+    # Worker identity (absent on pre-feature documents)
+    worker_pid: NotRequired[int | None]
+    worker_started_at: NotRequired[datetime | None]
+
+    # Set by the orphan sweep — distinguishes a Failed-from-orphan job
+    # from a Failed-from-lookup one.
+    abandoned: NotRequired[bool]
 
 
 class IntRange(TypedDict, total=False):
@@ -704,7 +720,7 @@ class MongoClient(metaclass=Singleton):
             status_data["$set"]["completed"] = update_time
 
         doc = job.get(doc_type)
-        doc_inner: JobDocs = {
+        doc_inner: JobDoc = {
             "job_id": job["job_id"],
             "touched": update_time,
         }
@@ -738,7 +754,7 @@ class MongoClient(metaclass=Singleton):
         """Create a write operation for a given log."""
         return InsertOne(log)
 
-    async def get_job_doc(self, job_id: str) -> JobDocs | None:
+    async def get_job_doc(self, job_id: str) -> JobDoc | None:
         """Retrieve a job from the database."""
         status_collection, docs_collection = self.get_job_collection()
 
@@ -758,19 +774,32 @@ class MongoClient(metaclass=Singleton):
         )
 
         del job["_id"]
-        return JobDocs(**job)
+        return JobDoc(**job)
 
-    async def get_job_status(self, job_id: str) -> JobStatus | None:
+    async def get_job_status(
+        self, job_id: str, *, touch: bool = False
+    ) -> JobStatus | None:
         """Return a single job_status doc by job_id, or None if not found.
 
-        Unlike `get_job_doc`, this only reads from the status collection
-        and does NOT update the `touched` timestamp — it's intended for
-        the dashboard, not for deliberate TRAPI interactions.
+        Reads only the status collection (no doc bytes). Pass `touch=True`
+        to bump the `touched` timestamp on both collections, extending
+        TTL — required for TRAPI interactions. Leave it `False` for
+        read-only dashboard queries.
         """
-        status_collection, _ = self.get_job_collection()
+        status_collection, docs_collection = self.get_job_collection()
         doc = await status_collection.find_one({"job_id": job_id})
         if doc is None:
             return None
+        if touch:
+            touch_time = datetime.now().astimezone()
+            await status_collection.update_one(
+                {"_id": doc["_id"]},
+                {"$set": {"touched": touch_time}},
+            )
+            await docs_collection.update_one(
+                {"job_id": job_id},
+                {"$set": {"touched": touch_time}},
+            )
         del doc["_id"]
         return JobStatus(**doc)
 
@@ -1465,6 +1494,52 @@ class MongoClient(metaclass=Singleton):
         async for line in _format_flat(self.get_server_logs(start, end, level)):
             yield line
 
+    async def get_non_terminal_with_worker_info(
+        self,
+    ) -> list[tuple[str, int | None, datetime | None]]:
+        """Return (job_id, worker_pid, worker_started_at) for all non-terminal jobs.
+
+        Jobs created before worker tracking was added will have None for both worker fields.
+        """
+        status_collection, _ = self.get_job_collection()
+        projection = {"_id": 0, "job_id": 1, "worker_pid": 1, "worker_started_at": 1}
+        cursor = status_collection.find(
+            {"status": {"$in": sorted(NON_TERMINAL)}}, projection
+        )
+        return [
+            (doc["job_id"], doc.get("worker_pid"), doc.get("worker_started_at"))
+            async for doc in cursor
+        ]
+
+    async def mark_jobs_abandoned(self, job_ids: list[str]) -> int:
+        """Mark non-terminal jobs whose worker died as Failed/abandoned.
+
+        Updates both collections so they stay in sync for TTL purposes,
+        and sets an `abandoned` flag so `get_job_response` can tell that
+        `docs.doc` (if any) still holds the original query bytes rather
+        than a response.
+
+        Each side has its own guard against the race where a job
+        completed between the orphan-detection snapshot and this write:
+        the status side checks status is still non-terminal; the docs
+        side checks `completed` hasn't been set by a ResponseState
+        write. Returns the count of status rows updated.
+        """
+        if not job_ids:
+            return 0
+        status_collection, docs_collection = self.get_job_collection()
+        now = datetime.now().astimezone()
+        fields = {"completed": now, "touched": now, "abandoned": True}
+        result = await status_collection.update_many(
+            {"job_id": {"$in": job_ids}, "status": {"$in": sorted(NON_TERMINAL)}},
+            {"$set": {"status": "Failed", **fields}},
+        )
+        await docs_collection.update_many(
+            {"job_id": {"$in": job_ids}, "completed": None},
+            {"$set": fields},
+        )
+        return result.modified_count
+
     async def close(self) -> None:
         """Clean up and close MongoDB client threads/connections."""
         self.client.close()
@@ -1478,6 +1553,27 @@ class MongoQueue(BatchedAction):
     flush_time: float = 0
 
     client: ClassVar[MongoClient] = MongoClient()
+
+    @override
+    async def wrapup(self) -> None:
+        """Flush pending writes during graceful shutdown.
+
+        The polling loop is cancelled and awaited *before* the flush, so it
+        can't race the flush by pulling items off the queue concurrently.
+        """
+        log.info(f"{type(self).__name__} wrapping up.")
+        for task in self.tasks:
+            _ = task.cancel()
+        for task in self.tasks:
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        try:
+            async with asyncio.timeout(CONFIG.mongo.shutdown_timeout):
+                await self.flush()
+        except TimeoutError:
+            log.warning(
+                f"MongoQueue flush timed out after {CONFIG.mongo.shutdown_timeout}s; some queued writes may be lost."
+            )
 
     async def job_state(self, batch: list[QueryState | ResponseState]) -> None:
         """Send a batch of job states to MongoDB."""

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Any, ClassVar, Literal, NotRequired, TypedDict
+from typing import Any, ClassVar, Literal, NotRequired, TypedDict, cast
 
+from bson import ObjectId
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from loguru import logger as log
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
@@ -14,8 +17,23 @@ from pymongo.server_api import ServerApi
 from retriever.config.general import CONFIG
 from retriever.types.general import LogLevel
 from retriever.utils.general import BatchedAction, Singleton
+from retriever.utils.job_status import NON_TERMINAL, TERMINAL_FAILURE, TERMINAL_SUCCESS
 
 CODEC_OPTIONS = DEFAULT_CODEC_OPTIONS.with_options(tz_aware=True)
+
+_PERCENTILE_MIN_MAJOR = 7
+"""Mongo major version where `$percentile` became available."""
+
+_LOG_LEVEL_THRESHOLD: dict[str, int] = {
+    "TRACE": 5,
+    "DEBUG": 10,
+    "INFO": 20,
+    "SUCCESS": 25,
+    "WARNING": 30,
+    "ERROR": 40,
+    "CRITICAL": 50,
+}
+"""Numeric thresholds for loguru levels — used to build `{level.no: {$gte}}` clauses."""
 
 
 class QueryState(TypedDict):
@@ -84,6 +102,444 @@ class JobStatus(TypedDict):
     touched: NotRequired[datetime]
 
 
+class IntRange(TypedDict, total=False):
+    """Inclusive integer bounds. Omit a side for an open-ended range."""
+
+    min: int
+    max: int
+
+
+class TimeRange(TypedDict, total=False):
+    """Inclusive datetime bounds. Omit a side for an open-ended range."""
+
+    after: datetime
+    before: datetime
+
+
+class JobIdentityFilter(TypedDict, total=False):
+    """Filter on identity / classification fields set at enqueue.
+
+    `job_id` is matched as a regex (mirroring `get_logs`). `status` and
+    `submitter` accept either a single value or a list (matched as any-of).
+    `data_tiers` matches jobs whose tier list intersects the given tiers.
+    """
+
+    job_id: str
+    status: str | list[str]
+    submitter: str | list[str]
+    data_tiers: list[Literal[0, 1, 2]]
+    is_async: bool
+
+
+class JobTimeFilter(TypedDict, total=False):
+    """Filter on lifetime timestamps. Each range is independent and ANDed."""
+
+    created: TimeRange
+    completed: TimeRange
+
+
+class QueryGeometryFilter(TypedDict, total=False):
+    """Filter on query-graph shape (set at enqueue)."""
+
+    qnodes: IntRange
+    qedges: IntRange
+    qpaths: IntRange
+
+
+class ResponseGeometryFilter(TypedDict, total=False):
+    """Filter on response-graph shape (set on completion).
+
+    Filtering on any of these implicitly restricts results to completed jobs.
+    """
+
+    knodes: IntRange
+    kedges: IntRange
+    aux_graphs: IntRange
+    results: IntRange
+
+
+class JobSortSpec(TypedDict):
+    """How to order job-status results.
+
+    `duration` is a computed field — `completed - created` in seconds —
+    and forces the underlying query through an aggregation pipeline.
+    All other fields are stored on the document directly.
+    """
+
+    field: Literal[
+        "created",
+        "completed",
+        "duration",
+        "results",
+        "submitter",
+        "status",
+    ]
+    direction: NotRequired[Literal["asc", "desc"]]
+
+
+class JobStatusPage(TypedDict):
+    """A page of job-status results plus an optional continuation cursor.
+
+    `next_cursor` is None when the page is the last one. Otherwise it's an
+    opaque token to pass back as the `cursor` arg to fetch the next page.
+    Callers must use the same filter and sort args across pages.
+    """
+
+    items: list[JobStatus]
+    next_cursor: str | None
+
+
+class JobGroupCount(TypedDict):
+    """A single (group-key, count) row from a group-by aggregation."""
+
+    key: Any
+    count: int
+
+
+class JobTimeBucket(TypedDict):
+    """A single (bucket-start, count) row from a time-bucketed aggregation."""
+
+    bucket_start: datetime
+    count: int
+
+
+class DurationStats(TypedDict):
+    """Aggregate runtime stats (completed - created) over a set of jobs.
+
+    Percentile fields are `NotRequired` so they can be omitted on Mongo
+    versions older than 7.0 (which lack `$percentile`). All-zero values
+    are returned when the sample is empty.
+    """
+
+    sample_size: int
+    min_seconds: float
+    max_seconds: float
+    avg_seconds: float
+    p50_seconds: NotRequired[float]
+    p95_seconds: NotRequired[float]
+    p99_seconds: NotRequired[float]
+
+
+class SubmitterStats(TypedDict):
+    """Per-submitter activity row produced by `submitter_stats`."""
+
+    submitter: str
+    count: int
+    completed: int
+    failed: int
+    success_rate: float | None
+    p95_duration_seconds: float | None
+    last_seen: datetime
+
+
+class TierDurationStats(TypedDict):
+    """Per-tier duration stats; all `None` when no completions in window."""
+
+    avg_seconds: float | None
+    min_seconds: float | None
+    max_seconds: float | None
+    p50_seconds: float | None
+    p95_seconds: float | None
+    p99_seconds: float | None
+
+
+class TierStats(TypedDict):
+    """Per-tier activity row produced by `tier_stats`."""
+
+    tier: int
+    active: int
+    completed: int
+    failed: int
+    durations: TierDurationStats
+    last_activity: datetime | None
+
+
+class SubmitterTierStats(TypedDict):
+    """One (submitter, tier) cell produced by `submitter_tier_stats`."""
+
+    submitter: str
+    tier: int
+    count: int
+    completed: int
+    failed: int
+    avg_seconds: float | None
+    p95_seconds: float | None
+    last_seen: datetime | None
+
+
+class FailureBreakdownRow(TypedDict):
+    """One {key, status} cell produced by `failure_breakdown_by_*`.
+
+    `key` is the submitter name or the tier index stringified, depending
+    on which breakdown was requested. Counts are over jobs whose status
+    is in `TERMINAL_FAILURE`.
+    """
+
+    key: str
+    status: str
+    count: int
+
+
+_DURATION_EXPR: dict[str, Any] = {
+    "$divide": [{"$subtract": ["$completed", "$created"]}, 1000]
+}
+"""Shared aggregation fragment: (completed - created) in seconds."""
+
+
+def _count_if_status_in(status_list: list[str]) -> dict[str, Any]:
+    """Aggregation `$sum` fragment: count of docs whose status matches."""
+    return {"$sum": {"$cond": [{"$in": ["$status", status_list]}, 1, 0]}}
+
+
+def _require_nonnull(query: dict[str, Any], field: str) -> None:
+    """Merge `$ne: None` into `query[field]`, preserving any existing clauses."""
+    query[field] = {**query.get(field, {}), "$ne": None}
+
+
+def _push_success_durations(success_list: list[str]) -> dict[str, Any]:
+    """`$push` fragment: durations only for success-status docs with both timestamps."""
+    return {
+        "$push": {
+            "$cond": [
+                {
+                    "$and": [
+                        {"$in": ["$status", success_list]},
+                        {"$ne": ["$completed", None]},
+                        {"$ne": ["$created", None]},
+                    ]
+                },
+                _DURATION_EXPR,
+                None,
+            ]
+        }
+    }
+
+
+def _percentile_first_of(input_field: str, p: float) -> dict[str, Any]:
+    """Single approximate percentile over a pushed-duration array, nulls filtered out.
+
+    Used in `$project` stages whose group stage pushed durations via
+    `_push_success_durations` (where non-matching docs landed as `None`).
+    """
+    return {
+        "$let": {
+            "vars": {
+                "filtered": {
+                    "$filter": {
+                        "input": f"${input_field}",
+                        "as": "d",
+                        "cond": {"$ne": ["$$d", None]},
+                    }
+                }
+            },
+            "in": {
+                "$cond": [
+                    {"$gt": [{"$size": "$$filtered"}, 0]},
+                    {
+                        "$first": {
+                            "$percentile": {
+                                "input": "$$filtered",
+                                "p": [p],
+                                "method": "approximate",
+                            }
+                        }
+                    },
+                    None,
+                ]
+            },
+        }
+    }
+
+
+SortValue = float | int | datetime | str | None
+"""All sort dimensions exposed via JobSortSpec resolve to one of these."""
+
+
+def _encode_cursor(sort_value: SortValue, object_id: ObjectId) -> str:
+    """Encode the trailing sort value + _id of a page as an opaque cursor.
+
+    The sort value carries a `t` tag (`null`/`datetime`/`int`/`float`/`bool`/
+    `str`) so the decode side can reconstitute the correct Python type
+    regardless of which underlying field drove the sort.
+    """
+    v_part: dict[str, Any]
+    if sort_value is None:
+        v_part = {"t": "null"}
+    elif isinstance(sort_value, datetime):
+        v_part = {"t": "datetime", "v": sort_value.isoformat()}
+    elif isinstance(sort_value, bool):
+        # bool is a subclass of int — check it first.
+        v_part = {"t": "bool", "v": sort_value}
+    elif isinstance(sort_value, int):
+        v_part = {"t": "int", "v": int(sort_value)}
+    elif isinstance(sort_value, float):
+        v_part = {"t": "float", "v": float(sort_value)}
+    else:
+        v_part = {"t": "str", "v": str(sort_value)}
+    payload: dict[str, Any] = {**v_part, "id": str(object_id)}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+
+
+class CursorDecodeError(ValueError):
+    """Raised when an opaque pagination cursor can't be parsed.
+
+    Callers (FastAPI route handlers) should translate this to HTTP 400
+    rather than letting it propagate as 500 — bad cursors are a client
+    fault, not a server fault.
+    """
+
+
+def _decode_cursor(cursor: str) -> tuple[SortValue, ObjectId]:
+    """Decode a cursor into the trailing sort value + _id it represents.
+
+    Raises:
+        CursorDecodeError: if the cursor is malformed (bad base64, bad
+            JSON, missing keys, or an ObjectId that won't parse).
+    """
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(cursor + padding))
+        kind = payload.get("t")
+        sort_value: SortValue
+        if kind == "null":
+            sort_value = None
+        elif kind == "datetime":
+            sort_value = datetime.fromisoformat(payload["v"])
+        elif kind == "int":
+            sort_value = int(payload["v"])
+        elif kind == "float":
+            sort_value = float(payload["v"])
+        elif kind == "bool":
+            sort_value = bool(payload["v"])
+        elif kind == "str":
+            sort_value = str(payload["v"])
+        else:
+            # Backward-compat with cursors emitted before the typed payload —
+            # those used `{"v": <iso>|null, "id": ...}` with datetime
+            # semantics.
+            raw = payload.get("v")
+            sort_value = datetime.fromisoformat(raw) if raw is not None else None
+        return sort_value, ObjectId(payload["id"])
+    except Exception as e:
+        raise CursorDecodeError(f"invalid cursor: {e}") from e
+
+
+def _apply_time_ranges(query: dict[str, Any], spec: JobTimeFilter | None) -> None:
+    """Apply TimeRange-typed fields from a filter spec onto a Mongo query dict."""
+    if spec is None:
+        return
+    for field, range_ in spec.items():
+        range_ = cast(TimeRange, range_)
+        clauses: dict[str, datetime] = {}
+        if "after" in range_:
+            clauses["$gte"] = range_["after"]
+        if "before" in range_:
+            clauses["$lte"] = range_["before"]
+        if clauses:
+            query[field] = clauses
+
+
+def _apply_int_ranges(
+    query: dict[str, Any],
+    spec: QueryGeometryFilter | ResponseGeometryFilter | None,
+) -> None:
+    """Apply IntRange-typed fields from a filter spec onto a Mongo query dict."""
+    if spec is None:
+        return
+    for field, range_ in spec.items():
+        range_ = cast(IntRange, range_)
+        clauses: dict[str, int] = {}
+        if "min" in range_:
+            clauses["$gte"] = range_["min"]
+        if "max" in range_:
+            clauses["$lte"] = range_["max"]
+        if clauses:
+            query[field] = clauses
+
+
+async def _format_flat(
+    log_stream: AsyncGenerator[dict[str, Any]],
+) -> AsyncGenerator[str]:
+    """Render a stream of log docs as stdout-style flat lines."""
+    first = True
+    async for log_doc in log_stream:
+        message = log_doc["message"]
+        if log_doc.get("exception"):
+            exception = log_doc["exception"]
+            message = (
+                f"{message}\n{exception.get('traceback')}\n"
+                f"{exception.get('type')}: {exception.get('value')}"
+            )
+        yield "{}{} {:4} {:7} {:80} {}".format(
+            "\n" if not first else "",
+            log_doc["time"],
+            log_doc["process"]["id"],
+            log_doc["level"]["name"],
+            (
+                f"{log_doc['extra']['job_id'][:8]} "
+                if "job_id" in log_doc["extra"]
+                else ""
+            )
+            + message,
+            f"{log_doc['name']}.{log_doc['function']}:{log_doc['line']}",
+        )
+        first = False
+
+
+def _build_log_query(
+    start: datetime | None,
+    end: datetime | None,
+    level: LogLevel,
+) -> dict[str, Any]:
+    """Build the common time/level clause for log queries."""
+    query: dict[str, Any] = {"level.no": {"$gte": _LOG_LEVEL_THRESHOLD[level.upper()]}}
+    if start or end:
+        time_clause: dict[str, datetime] = {}
+        if start:
+            time_clause["$gte"] = start
+        if end:
+            time_clause["$lte"] = end
+        query["time"] = time_clause
+    return query
+
+
+def _build_filter_query(
+    identity: JobIdentityFilter | None = None,
+    times: JobTimeFilter | None = None,
+    query_geometry: QueryGeometryFilter | None = None,
+    response_geometry: ResponseGeometryFilter | None = None,
+) -> dict[str, Any]:
+    """Translate job-status filter TypedDicts into a Mongo query dict.
+
+    Each group is optional and ANDed into the resulting query. Used by both
+    paged retrieval and the count/aggregation methods so the filter
+    vocabulary stays in sync across call sites.
+    """
+    query: dict[str, Any] = {}
+
+    if identity is not None:
+        if "job_id" in identity:
+            query["job_id"] = {"$regex": identity["job_id"]}
+        if "status" in identity:
+            status = identity["status"]
+            query["status"] = {"$in": status} if isinstance(status, list) else status
+        if "submitter" in identity:
+            submitter = identity["submitter"]
+            query["submitter"] = (
+                {"$in": submitter} if isinstance(submitter, list) else submitter
+            )
+        if "data_tiers" in identity:
+            query["data_tiers"] = {"$in": identity["data_tiers"]}
+        if "is_async" in identity:
+            query["is_async"] = identity["is_async"]
+
+    _apply_time_ranges(query, times)
+    _apply_int_ranges(query, query_geometry)
+    _apply_int_ranges(query, response_geometry)
+
+    return query
+
+
 class MongoClient(metaclass=Singleton):
     """A client abstraction layer for basic operations."""
 
@@ -117,6 +573,7 @@ class MongoClient(metaclass=Singleton):
             )
         # Patch client to get the current asyncio loop
         self.client.get_io_loop = asyncio.get_running_loop
+        self._supports_percentile: bool = False
 
     def get_job_collection(
         self,
@@ -150,6 +607,21 @@ class MongoClient(metaclass=Singleton):
             )
             raise error
 
+        # Detect $percentile support once. Branch in aggregation methods on
+        # this flag rather than catching MongoCommandError mid-pipeline.
+        # buildInfo can be denied on locked-down clusters or return a
+        # version string we can't parse; in either case fall back to the
+        # no-percentile branch rather than blocking startup.
+        try:
+            build_info = await self.client.admin.command("buildInfo")
+            major = int(str(build_info["version"]).split(".", 1)[0])
+            self._supports_percentile = major >= _PERCENTILE_MIN_MAJOR
+        except Exception:
+            log.warning(
+                "Could not read MongoDB buildInfo; assuming no $percentile support."
+            )
+            self._supports_percentile = False
+
         job_collections = self.get_job_collection()
         for collection in job_collections:
             await collection.create_index("job_id", unique=True, background=True)
@@ -159,10 +631,31 @@ class MongoClient(metaclass=Singleton):
             await collection.create_index(
                 "completed", background=True, expireAfterSeconds=CONFIG.job.ttl_max
             )
+            await collection.create_index("created", background=True)
 
         log_collection = self.get_log_collection()
         await log_collection.create_index(
             {"time": 1}, background=True, expireAfterSeconds=CONFIG.log.mongo_ttl
+        )
+
+    async def ping(self) -> bool:
+        """Post-init liveness check. Returns True iff the server responds."""
+        try:
+            _ = await self.client.admin.command("ping")
+        except Exception:
+            return False
+        return True
+
+    async def db_storage_bytes(self) -> int:
+        """Return the on-disk storage size of the retriever_persist database."""
+        stats = await self.client.retriever_persist.command("dbStats")
+        return int(stats["storageSize"])
+
+    async def count_in_flight(self) -> int:
+        """Count jobs whose status is non-terminal (Running / Accepted)."""
+        status_collection, _ = self.get_job_collection()
+        return await status_collection.count_documents(
+            {"status": {"$in": sorted(NON_TERMINAL)}}
         )
 
     async def batch_write(
@@ -196,7 +689,9 @@ class MongoClient(metaclass=Singleton):
 
     def job_state(self, job: QueryState | ResponseState) -> tuple[UpdateOne, UpdateOne]:
         """Create an operation for upserting a job state doc."""
-        update_time = datetime.now()
+        # Tz-aware. Naive datetime.now() would be treated as already-UTC by
+        # pymongo and shift readers by the local offset.
+        update_time = datetime.now().astimezone()
         status_data = {
             "$set": JobStatus(
                 **{k: v for k, v in job.items() if k not in ("query", "response")},  # pyright:ignore[reportArgumentType] We know it's valid
@@ -252,7 +747,7 @@ class MongoClient(metaclass=Singleton):
         )
         if job is None:
             return
-        touch_time = datetime.now()
+        touch_time = datetime.now().astimezone()
         await status_collection.update_one(
             {"_id": job["_id"]},
             {"$set": {"touched": touch_time}},
@@ -265,6 +760,644 @@ class MongoClient(metaclass=Singleton):
         del job["_id"]
         return JobDocs(**job)
 
+    async def get_job_status(self, job_id: str) -> JobStatus | None:
+        """Return a single job_status doc by job_id, or None if not found.
+
+        Unlike `get_job_doc`, this only reads from the status collection
+        and does NOT update the `touched` timestamp — it's intended for
+        the dashboard, not for deliberate TRAPI interactions.
+        """
+        status_collection, _ = self.get_job_collection()
+        doc = await status_collection.find_one({"job_id": job_id})
+        if doc is None:
+            return None
+        del doc["_id"]
+        return JobStatus(**doc)
+
+    async def get_job_statuses(  # noqa: PLR0913 Each arg is a deliberate filter group
+        self,
+        *,
+        identity: JobIdentityFilter | None = None,
+        times: JobTimeFilter | None = None,
+        query_geometry: QueryGeometryFilter | None = None,
+        response_geometry: ResponseGeometryFilter | None = None,
+        sort: JobSortSpec | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> JobStatusPage:
+        """Return a filtered page of job status docs from the job_status collection.
+
+        Each parameter group is optional and ANDed together. Filtering on
+        `response_geometry` implicitly restricts results to completed jobs,
+        since those fields are only populated on response upsert.
+
+        Sort defaults to `created` descending. `_id` is always used as a
+        tie-breaker so paging is stable across duplicate sort values.
+        `sort.field = "duration"` is the one computed dimension and runs
+        the query through an aggregation pipeline; every other field is a
+        plain `find().sort()`.
+        """
+        query = _build_filter_query(identity, times, query_geometry, response_geometry)
+
+        sort_field: str = "created"
+        sort_direction = -1
+        if sort is not None:
+            sort_field = sort["field"]
+            if sort.get("direction") == "asc":
+                sort_direction = 1
+
+        if sort_field == "duration":
+            return await self._page_by_duration(query, sort_direction, limit, cursor)
+
+        if cursor is not None:
+            cursor_value, cursor_id = _decode_cursor(cursor)
+            op = "$gt" if sort_direction == 1 else "$lt"
+            cursor_clause: dict[str, Any] = {
+                "$or": [
+                    {sort_field: {op: cursor_value}},
+                    {sort_field: cursor_value, "_id": {op: cursor_id}},
+                ]
+            }
+            query = {"$and": [query, cursor_clause]} if query else cursor_clause
+
+        status_collection, _ = self.get_job_collection()
+        found = (
+            status_collection.find(query)
+            .sort([(sort_field, sort_direction), ("_id", sort_direction)])
+            .limit(limit + 1)
+        )
+        docs = [doc async for doc in found]
+
+        next_cursor: str | None = None
+        if len(docs) > limit:
+            last = docs[limit - 1]
+            next_cursor = _encode_cursor(last.get(sort_field), last["_id"])
+            docs = docs[:limit]
+
+        items: list[JobStatus] = [JobStatus(**doc) for doc in docs]
+
+        return JobStatusPage(items=items, next_cursor=next_cursor)
+
+    async def _page_by_duration(
+        self,
+        match_query: dict[str, Any],
+        sort_direction: int,
+        limit: int,
+        cursor: str | None,
+    ) -> JobStatusPage:
+        """Aggregation-pipeline branch for sort_field='duration'.
+
+        Computes `duration_seconds = (completed - created) / 1000` via
+        `$addFields`, then sorts + paginates on it. Implicitly restricts
+        to terminal jobs (both timestamps non-null).
+        """
+        match_query = dict(match_query)
+        _require_nonnull(match_query, "completed")
+        _require_nonnull(match_query, "created")
+
+        post_match: dict[str, Any] = {}
+        if cursor is not None:
+            cursor_value, cursor_id = _decode_cursor(cursor)
+            op = "$gt" if sort_direction == 1 else "$lt"
+            post_match["$or"] = [
+                {"duration_seconds": {op: cursor_value}},
+                {"duration_seconds": cursor_value, "_id": {op: cursor_id}},
+            ]
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {"$addFields": {"duration_seconds": _DURATION_EXPR}},
+        ]
+        if post_match:
+            pipeline.append({"$match": post_match})
+        pipeline.extend(
+            [
+                {"$sort": {"duration_seconds": sort_direction, "_id": sort_direction}},
+                {"$limit": limit + 1},
+            ]
+        )
+
+        status_collection, _ = self.get_job_collection()
+        docs = [doc async for doc in status_collection.aggregate(pipeline)]
+
+        next_cursor: str | None = None
+        if len(docs) > limit:
+            last = docs[limit - 1]
+            next_cursor = _encode_cursor(last.get("duration_seconds"), last["_id"])
+            docs = docs[:limit]
+
+        items: list[JobStatus] = [JobStatus(**doc) for doc in docs]
+        return JobStatusPage(items=items, next_cursor=next_cursor)
+
+    async def count_jobs(
+        self,
+        *,
+        identity: JobIdentityFilter | None = None,
+        times: JobTimeFilter | None = None,
+        query_geometry: QueryGeometryFilter | None = None,
+        response_geometry: ResponseGeometryFilter | None = None,
+    ) -> int:
+        """Return the count of job_status docs matching the given filters."""
+        query = _build_filter_query(identity, times, query_geometry, response_geometry)
+        status_collection, _ = self.get_job_collection()
+        return await status_collection.count_documents(query)
+
+    async def group_jobs(  # noqa: PLR0913 Each arg is a deliberate filter group
+        self,
+        *,
+        group_by: Literal["status", "submitter", "is_async", "data_tiers"],
+        identity: JobIdentityFilter | None = None,
+        times: JobTimeFilter | None = None,
+        query_geometry: QueryGeometryFilter | None = None,
+        response_geometry: ResponseGeometryFilter | None = None,
+        sort_by: Literal["count", "key"] = "count",
+        top: int | None = None,
+    ) -> list[JobGroupCount]:
+        """Return per-value counts of job_status docs grouped by `group_by`.
+
+        For list-valued fields (currently `data_tiers`), the field is
+        `$unwind`ed before grouping — a job that spans multiple tiers
+        contributes one to each tier's count.
+        """
+        match_query = _build_filter_query(
+            identity, times, query_geometry, response_geometry
+        )
+        pipeline: list[dict[str, Any]] = []
+        if match_query:
+            pipeline.append({"$match": match_query})
+        if group_by == "data_tiers":
+            pipeline.append({"$unwind": "$data_tiers"})
+        pipeline.append({"$group": {"_id": f"${group_by}", "count": {"$sum": 1}}})
+        sort_key = "count" if sort_by == "count" else "_id"
+        sort_dir = -1 if sort_by == "count" else 1
+        pipeline.append({"$sort": {sort_key: sort_dir}})
+        if top is not None:
+            pipeline.append({"$limit": top})
+
+        status_collection, _ = self.get_job_collection()
+        return [
+            JobGroupCount(key=doc["_id"], count=doc["count"])
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
+    async def bucket_jobs_over_time(  # noqa: PLR0913 Each arg is a deliberate filter group
+        self,
+        *,
+        field: Literal["created", "completed"],
+        granularity: Literal["hour", "day", "week", "month"],
+        identity: JobIdentityFilter | None = None,
+        times: JobTimeFilter | None = None,
+        query_geometry: QueryGeometryFilter | None = None,
+        response_geometry: ResponseGeometryFilter | None = None,
+    ) -> list[JobTimeBucket]:
+        """Return counts of job_status docs bucketed by a timestamp field.
+
+        Docs missing the bucketed `field` (e.g. running jobs when bucketing on
+        `completed`) are excluded. Empty buckets between populated ones are
+        not back-filled — callers that want a continuous series can pad.
+        """
+        match_query = _build_filter_query(
+            identity, times, query_geometry, response_geometry
+        )
+        _require_nonnull(match_query, field)
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {
+                "$group": {
+                    "_id": {"$dateTrunc": {"date": f"${field}", "unit": granularity}},
+                    "count": {"$sum": 1},
+                }
+            },
+            {"$sort": {"_id": 1}},
+        ]
+
+        status_collection, _ = self.get_job_collection()
+        return [
+            JobTimeBucket(bucket_start=doc["_id"], count=doc["count"])
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
+    async def compute_durations(
+        self,
+        *,
+        identity: JobIdentityFilter | None = None,
+        times: JobTimeFilter | None = None,
+    ) -> DurationStats:
+        """Aggregate runtime stats over terminal jobs in the filter window.
+
+        Returns min/max/avg seconds; on Mongo 7+ also returns p50/p95/p99
+        (approximate). When no docs match, all numeric fields are 0 and
+        percentile fields are omitted regardless of Mongo version.
+
+        `identity` accepts a `resolve_status_filter` output so callers can
+        pass `?status=failed` straight through.
+        """
+        match_query = _build_filter_query(identity, times)
+        _require_nonnull(match_query, "completed")
+        _require_nonnull(match_query, "created")
+
+        group_stage: dict[str, Any] = {
+            "_id": None,
+            "sample_size": {"$sum": 1},
+            "min_seconds": {"$min": _DURATION_EXPR},
+            "max_seconds": {"$max": _DURATION_EXPR},
+            "avg_seconds": {"$avg": _DURATION_EXPR},
+        }
+        if self._supports_percentile:
+            group_stage["percentiles"] = {
+                "$percentile": {
+                    "input": _DURATION_EXPR,
+                    "p": [0.5, 0.95, 0.99],
+                    "method": "approximate",
+                }
+            }
+
+        status_collection, _ = self.get_job_collection()
+        cursor = status_collection.aggregate(
+            [{"$match": match_query}, {"$group": group_stage}]
+        )
+        doc = await cursor.to_list(length=1)
+        if not doc:
+            return DurationStats(
+                sample_size=0, min_seconds=0.0, max_seconds=0.0, avg_seconds=0.0
+            )
+
+        row = doc[0]
+        stats: DurationStats = {
+            "sample_size": int(row["sample_size"]),
+            "min_seconds": float(row["min_seconds"] or 0.0),
+            "max_seconds": float(row["max_seconds"] or 0.0),
+            "avg_seconds": float(row["avg_seconds"] or 0.0),
+        }
+        percentiles = row.get("percentiles")
+        if percentiles:
+            p50, p95, p99 = percentiles
+            stats["p50_seconds"] = float(p50)
+            stats["p95_seconds"] = float(p95)
+            stats["p99_seconds"] = float(p99)
+        return stats
+
+    async def submitter_stats(
+        self,
+        *,
+        times: JobTimeFilter | None = None,
+        top: int = 50,
+    ) -> list[SubmitterStats]:
+        """Per-submitter activity rows for the leaderboard view.
+
+        `times` filters by `created` if supplied. Each row includes raw
+        count + completed/failed breakdown, derived `success_rate`, p95
+        completion-duration (Mongo 7+ only; `None` otherwise), and the
+        most-recent `created` timestamp as `last_seen`.
+        """
+        match_query = _build_filter_query(times=times)
+        match_query["submitter"] = {"$exists": True}
+
+        failure_list = sorted(TERMINAL_FAILURE)
+        success_list = sorted(TERMINAL_SUCCESS)
+
+        group_stage: dict[str, Any] = {
+            "_id": "$submitter",
+            "count": {"$sum": 1},
+            "completed_count": _count_if_status_in(success_list),
+            "failed_count": _count_if_status_in(failure_list),
+            "last_seen": {"$max": "$created"},
+        }
+        if self._supports_percentile:
+            group_stage["completed_durations"] = _push_success_durations(success_list)
+
+        terminal_count_expr = {"$add": ["$completed_count", "$failed_count"]}
+        project_stage: dict[str, Any] = {
+            "_id": 0,
+            "submitter": "$_id",
+            "count": 1,
+            "completed": "$completed_count",
+            "failed": "$failed_count",
+            "last_seen": 1,
+            "success_rate": {
+                "$cond": [
+                    {"$gt": [terminal_count_expr, 0]},
+                    {"$divide": ["$completed_count", terminal_count_expr]},
+                    None,
+                ]
+            },
+        }
+        if self._supports_percentile:
+            project_stage["p95_duration_seconds"] = _percentile_first_of(
+                "completed_durations", 0.95
+            )
+        else:
+            project_stage["p95_duration_seconds"] = {"$literal": None}
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {"$group": group_stage},
+            {"$project": project_stage},
+            {"$sort": {"count": -1}},
+            {"$limit": top},
+        ]
+
+        status_collection, _ = self.get_job_collection()
+        return [
+            SubmitterStats(
+                submitter=doc["submitter"],
+                count=int(doc["count"]),
+                completed=int(doc["completed"]),
+                failed=int(doc["failed"]),
+                success_rate=(
+                    float(doc["success_rate"])
+                    if doc["success_rate"] is not None
+                    else None
+                ),
+                p95_duration_seconds=(
+                    float(doc["p95_duration_seconds"])
+                    if doc["p95_duration_seconds"] is not None
+                    else None
+                ),
+                last_seen=doc["last_seen"],
+            )
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
+    async def tier_stats(
+        self,
+        *,
+        times: JobTimeFilter | None = None,
+    ) -> list[TierStats]:
+        """Per-tier activity rows.
+
+        `active` counts in-flight jobs on a tier (no time filter applies).
+        `completed` / `failed` / `durations` / `last_activity` reflect
+        terminal jobs within the supplied `times` window (filters on
+        `completed` if present; otherwise no time bound).
+
+        Duration percentiles are populated only on Mongo 7+; otherwise
+        their fields are `None`. Returned tiers are those that appear in
+        the data; callers that want a fixed set of tier rows can pad with
+        zeros.
+        """
+        window_match = _build_filter_query(times=times)
+        # Window-pipeline only sees terminal jobs with both timestamps so
+        # duration math is meaningful.
+        _require_nonnull(window_match, "completed")
+        _require_nonnull(window_match, "created")
+
+        failure_list = sorted(TERMINAL_FAILURE)
+        success_list = sorted(TERMINAL_SUCCESS)
+        non_terminal_list = sorted(NON_TERMINAL)
+
+        window_group: dict[str, Any] = {
+            "_id": "$data_tiers",
+            "completed": _count_if_status_in(success_list),
+            "failed": _count_if_status_in(failure_list),
+            "last_activity": {"$max": "$completed"},
+            "avg_seconds": {"$avg": _DURATION_EXPR},
+            "min_seconds": {"$min": _DURATION_EXPR},
+            "max_seconds": {"$max": _DURATION_EXPR},
+        }
+        if self._supports_percentile:
+            # Percentile input matches avg/min/max — all terminal jobs in
+            # window, success and failure alike. window_match has already
+            # filtered to docs with non-null timestamps.
+            window_group["percentiles"] = {
+                "$percentile": {
+                    "input": _DURATION_EXPR,
+                    "p": [0.5, 0.95, 0.99],
+                    "method": "approximate",
+                }
+            }
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": {"data_tiers": {"$exists": True, "$ne": []}}},
+            {"$unwind": "$data_tiers"},
+            {
+                "$facet": {
+                    "active": [
+                        {"$match": {"status": {"$in": non_terminal_list}}},
+                        {"$group": {"_id": "$data_tiers", "count": {"$sum": 1}}},
+                    ],
+                    "in_window": [
+                        {"$match": window_match},
+                        {"$group": window_group},
+                    ],
+                }
+            },
+        ]
+
+        status_collection, _ = self.get_job_collection()
+        facet_docs = await status_collection.aggregate(pipeline).to_list(length=1)
+        if not facet_docs:
+            return []
+
+        facet = facet_docs[0]
+        active_by_tier: dict[int, int] = {
+            int(row["_id"]): int(row["count"]) for row in facet.get("active", [])
+        }
+        window_by_tier: dict[int, dict[str, Any]] = {
+            int(row["_id"]): row for row in facet.get("in_window", [])
+        }
+
+        tiers = sorted(set(active_by_tier) | set(window_by_tier))
+        return [
+            self._tier_stats_row(tier, active_by_tier, window_by_tier) for tier in tiers
+        ]
+
+    @staticmethod
+    def _tier_stats_row(
+        tier: int,
+        active_by_tier: dict[int, int],
+        window_by_tier: dict[int, dict[str, Any]],
+    ) -> TierStats:
+        """Merge a single tier's active + window rows into a TierStats."""
+        window = window_by_tier.get(tier, {})
+        percentiles = window.get("percentiles")
+        durations: TierDurationStats = {
+            "avg_seconds": (
+                float(window["avg_seconds"])
+                if window.get("avg_seconds") is not None
+                else None
+            ),
+            "min_seconds": (
+                float(window["min_seconds"])
+                if window.get("min_seconds") is not None
+                else None
+            ),
+            "max_seconds": (
+                float(window["max_seconds"])
+                if window.get("max_seconds") is not None
+                else None
+            ),
+            "p50_seconds": float(percentiles[0]) if percentiles else None,
+            "p95_seconds": float(percentiles[1]) if percentiles else None,
+            "p99_seconds": float(percentiles[2]) if percentiles else None,
+        }
+        return TierStats(
+            tier=tier,
+            active=active_by_tier.get(tier, 0),
+            completed=int(window.get("completed", 0)),
+            failed=int(window.get("failed", 0)),
+            durations=durations,
+            last_activity=window.get("last_activity"),
+        )
+
+    async def submitter_tier_stats(
+        self,
+        *,
+        times: JobTimeFilter | None = None,
+    ) -> list[SubmitterTierStats]:
+        """Per-(submitter, tier) cells for the heatmaps view.
+
+        Returns one row per non-empty (submitter, tier) pair in the
+        window. A job whose `data_tiers` list spans both tiers
+        contributes to BOTH cells (mirrors `tier_stats` semantics).
+        Duration percentiles populate on Mongo 7+; otherwise `None`.
+        """
+        match_query = _build_filter_query(times=times)
+        match_query["submitter"] = {"$exists": True}
+        match_query["data_tiers"] = {"$exists": True, "$ne": []}
+
+        failure_list = sorted(TERMINAL_FAILURE)
+        success_list = sorted(TERMINAL_SUCCESS)
+
+        group_stage: dict[str, Any] = {
+            "_id": {"submitter": "$submitter", "tier": "$data_tiers"},
+            "count": {"$sum": 1},
+            "completed_count": _count_if_status_in(success_list),
+            "failed_count": _count_if_status_in(failure_list),
+            # `last_seen` = latest submission (created), matching submitter_stats
+            # semantics. Using `completed` would yield None for cells whose
+            # most recent job is still running.
+            "last_seen": {"$max": "$created"},
+            "avg_seconds": {"$avg": _DURATION_EXPR},
+        }
+        if self._supports_percentile:
+            group_stage["completed_durations"] = _push_success_durations(success_list)
+
+        project_stage: dict[str, Any] = {
+            "_id": 0,
+            "submitter": "$_id.submitter",
+            "tier": "$_id.tier",
+            "count": 1,
+            "completed": "$completed_count",
+            "failed": "$failed_count",
+            "last_seen": 1,
+            "avg_seconds": 1,
+        }
+        if self._supports_percentile:
+            project_stage["p95_seconds"] = _percentile_first_of(
+                "completed_durations", 0.95
+            )
+        else:
+            project_stage["p95_seconds"] = {"$literal": None}
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {"$unwind": "$data_tiers"},
+            {"$group": group_stage},
+            {"$project": project_stage},
+            {"$sort": {"submitter": 1, "tier": 1}},
+        ]
+
+        status_collection, _ = self.get_job_collection()
+        return [
+            SubmitterTierStats(
+                submitter=doc["submitter"],
+                tier=int(doc["tier"]),
+                count=int(doc["count"]),
+                completed=int(doc["completed"]),
+                failed=int(doc["failed"]),
+                avg_seconds=(
+                    float(doc["avg_seconds"])
+                    if doc.get("avg_seconds") is not None
+                    else None
+                ),
+                p95_seconds=(
+                    float(doc["p95_seconds"])
+                    if doc.get("p95_seconds") is not None
+                    else None
+                ),
+                last_seen=doc.get("last_seen"),
+            )
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
+    async def failure_breakdown_by_submitter(
+        self,
+        *,
+        times: JobTimeFilter | None = None,
+    ) -> list[FailureBreakdownRow]:
+        """One row per (submitter, failure-status) pair with counts."""
+        match_query = _build_filter_query(times=times)
+        match_query["submitter"] = {"$exists": True}
+        match_query["status"] = {"$in": sorted(TERMINAL_FAILURE)}
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {
+                "$group": {
+                    "_id": {"submitter": "$submitter", "status": "$status"},
+                    "count": {"$sum": 1},
+                }
+            },
+            {
+                "$project": {
+                    "_id": 0,
+                    "key": "$_id.submitter",
+                    "status": "$_id.status",
+                    "count": 1,
+                }
+            },
+            {"$sort": {"key": 1, "status": 1}},
+        ]
+        status_collection, _ = self.get_job_collection()
+        return [
+            FailureBreakdownRow(
+                key=doc["key"], status=doc["status"], count=int(doc["count"])
+            )
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
+    async def failure_breakdown_by_tier(
+        self,
+        *,
+        times: JobTimeFilter | None = None,
+    ) -> list[FailureBreakdownRow]:
+        """One row per (tier, failure-status) pair with counts.
+
+        `data_tiers` is `$unwind`ed so a multi-tier job contributes to
+        each of its tiers (same semantics as `tier_stats`).
+        """
+        match_query = _build_filter_query(times=times)
+        match_query["data_tiers"] = {"$exists": True, "$ne": []}
+        match_query["status"] = {"$in": sorted(TERMINAL_FAILURE)}
+
+        pipeline: list[dict[str, Any]] = [
+            {"$match": match_query},
+            {"$unwind": "$data_tiers"},
+            {
+                "$group": {
+                    "_id": {"tier": "$data_tiers", "status": "$status"},
+                    "count": {"$sum": 1},
+                }
+            },
+            {
+                "$project": {
+                    "_id": 0,
+                    "key": {"$toString": "$_id.tier"},
+                    "status": "$_id.status",
+                    "count": 1,
+                }
+            },
+            {"$sort": {"key": 1, "status": 1}},
+        ]
+        status_collection, _ = self.get_job_collection()
+        return [
+            FailureBreakdownRow(
+                key=doc["key"], status=doc["status"], count=int(doc["count"])
+            )
+            async for doc in status_collection.aggregate(pipeline)
+        ]
+
     async def get_logs(
         self,
         start: datetime | None = None,
@@ -273,26 +1406,35 @@ class MongoClient(metaclass=Singleton):
         job_id: str | None = None,
     ) -> AsyncGenerator[dict[str, Any]]:
         """Return a generator of a filtered set of logs."""
-        # Set up query
-        levels = {
-            "TRACE": 5,
-            "DEBUG": 10,
-            "INFO": 20,
-            "SUCCESS": 25,
-            "WARNING": 30,
-            "ERROR": 40,
-            "CRITICAL": 50,
-        }
-        query: dict[str, Any] = {"level.no": {"$gte": levels[level.upper()]}}
-        if start or end:
-            query["time"] = {}
-        if start:
-            query["time"]["$gte"] = start
-        if end:
-            query["time"]["$lte"] = end
+        query = _build_log_query(start, end, level)
         if job_id is not None:
             query["extra.job_id"] = {"$regex": job_id}
 
+        async for document in self._yield_logs(query):
+            yield document
+
+    async def get_server_logs(
+        self,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        level: LogLevel = "DEBUG",
+    ) -> AsyncGenerator[dict[str, Any]]:
+        """Return a generator of logs not associated with any job.
+
+        Matches docs where `extra.job_id` is absent — the logs Retriever
+        itself emits (lifecycle, background refreshes, tier drivers,
+        cache activity). Sibling to `get_logs`.
+        """
+        query = _build_log_query(start, end, level)
+        query["extra.job_id"] = {"$exists": False}
+
+        async for document in self._yield_logs(query):
+            yield document
+
+    async def _yield_logs(
+        self, query: dict[str, Any]
+    ) -> AsyncGenerator[dict[str, Any]]:
+        """Run the log query and yield decoded log documents (oldest first)."""
         logs = self.get_log_collection()
         cursor = logs.find(query).sort("time", 1)
         async for document in cursor:
@@ -310,26 +1452,18 @@ class MongoClient(metaclass=Singleton):
         job_id: str | None = None,
     ) -> AsyncGenerator[str]:
         """Return a generator of logs as flat strings, as they would appear in stdout."""
-        first = True
-        async for log_doc in self.get_logs(start, end, level, job_id):
-            message = log_doc["message"]
-            if log_doc.get("exception"):
-                exception = log_doc["exception"]
-                message = f"{message}\n{exception.get('traceback')}\n{exception.get('type')}: {exception.get('value')}"
-            yield "{}{} {:4} {:7} {:80} {}".format(
-                "\n" if not first else "",
-                log_doc["time"],
-                log_doc["process"]["id"],
-                log_doc["level"]["name"],
-                (
-                    f"{log_doc['extra']['job_id'][:8]} "
-                    if "job_id" in log_doc["extra"]
-                    else ""
-                )
-                + message,
-                f"{log_doc['name']}.{log_doc['function']}:{log_doc['line']}",
-            )
-            first = False
+        async for line in _format_flat(self.get_logs(start, end, level, job_id)):
+            yield line
+
+    async def get_flat_server_logs(
+        self,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        level: LogLevel = "DEBUG",
+    ) -> AsyncGenerator[str]:
+        """Return flat-formatted logs that aren't associated with a job."""
+        async for line in _format_flat(self.get_server_logs(start, end, level)):
+            yield line
 
     async def close(self) -> None:
         """Clean up and close MongoDB client threads/connections."""
@@ -357,3 +1491,7 @@ class MongoQueue(BatchedAction):
     async def log_dump(self, batch: list[dict[str, Any]]) -> None:
         """Send a batch of logs to MongoDB."""
         await self.client.batch_log_dump([self.client.log_dump(log) for log in batch])
+
+    def qsize(self) -> int:
+        """Return the total number of pending items across all action queues."""
+        return sum(q.qsize() for q in self.action_queues.values())

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -674,6 +674,16 @@ class MongoClient(metaclass=Singleton):
             {"status": {"$in": sorted(NON_TERMINAL)}}
         )
 
+    async def count_stuck(self, older_than: datetime) -> int:
+        """Count non-terminal jobs created before `older_than`."""
+        status_collection, _ = self.get_job_collection()
+        return await status_collection.count_documents(
+            {
+                "status": {"$in": sorted(NON_TERMINAL)},
+                "created": {"$lt": older_than},
+            }
+        )
+
     async def batch_write(
         self,
         operations: list[InsertOne[dict[str, Any]]] | list[UpdateOne],

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -64,6 +64,7 @@ class ResponseState(TypedDict):
     aux_graphs: int
     results: int
     status: str
+    description: NotRequired[str | None]
 
 
 class JobDoc(TypedDict):
@@ -88,6 +89,7 @@ class JobStatus(TypedDict):
 
     job_id: str
     status: str
+    description: NotRequired[str | None]
 
     # Query info
     job_timeout: NotRequired[float | None]

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -42,9 +42,9 @@ class QueryState(TypedDict):
 
     job_id: str
     query: bytes
-    job_timeout: dict[int, float]
+    job_timeout: float
     submitter: str
-    data_tiers: list[Literal[0, 1, 2]]
+    data_tier: Literal[0, 1, 2] | None
     is_async: bool
     qnodes: int
     qedges: int
@@ -90,9 +90,9 @@ class JobStatus(TypedDict):
     status: str
 
     # Query info
-    job_timeout: NotRequired[dict[int, float]]
+    job_timeout: NotRequired[float | None]
     submitter: NotRequired[str]
-    data_tiers: NotRequired[list[Literal[0, 1, 2]]]
+    data_tier: NotRequired[Literal[0, 1, 2] | None]
     is_async: NotRequired[bool]
     qnodes: NotRequired[int]
     qedges: NotRequired[int]
@@ -137,13 +137,13 @@ class JobIdentityFilter(TypedDict, total=False):
 
     `job_id` is matched as a regex (mirroring `get_logs`). `status` and
     `submitter` accept either a single value or a list (matched as any-of).
-    `data_tiers` matches jobs whose tier list intersects the given tiers.
+    `data_tier` matches jobs assigned to that tier.
     """
 
     job_id: str
     status: str | list[str]
     submitter: str | list[str]
-    data_tiers: list[Literal[0, 1, 2]]
+    data_tier: Literal[0, 1, 2]
     is_async: bool
 
 
@@ -544,8 +544,8 @@ def _build_filter_query(
             query["submitter"] = (
                 {"$in": submitter} if isinstance(submitter, list) else submitter
             )
-        if "data_tiers" in identity:
-            query["data_tiers"] = {"$in": identity["data_tiers"]}
+        if "data_tier" in identity:
+            query["data_tier"] = identity["data_tier"]
         if "is_async" in identity:
             query["is_async"] = identity["is_async"]
 
@@ -966,7 +966,7 @@ class MongoClient(BackendClient):
     async def group_jobs(  # noqa: PLR0913 Each arg is a deliberate filter group
         self,
         *,
-        group_by: Literal["status", "submitter", "is_async", "data_tiers"],
+        group_by: Literal["status", "submitter", "is_async", "data_tier"],
         identity: JobIdentityFilter | None = None,
         times: JobTimeFilter | None = None,
         query_geometry: QueryGeometryFilter | None = None,
@@ -974,20 +974,13 @@ class MongoClient(BackendClient):
         sort_by: Literal["count", "key"] = "count",
         top: int | None = None,
     ) -> list[JobGroupCount]:
-        """Return per-value counts of job_status docs grouped by `group_by`.
-
-        For list-valued fields (currently `data_tiers`), the field is
-        `$unwind`ed before grouping - a job that spans multiple tiers
-        contributes one to each tier's count.
-        """
+        """Return per-value counts of job_status docs grouped by `group_by`."""
         match_query = _build_filter_query(
             identity, times, query_geometry, response_geometry
         )
         pipeline: list[dict[str, Any]] = []
         if match_query:
             pipeline.append({"$match": match_query})
-        if group_by == "data_tiers":
-            pipeline.append({"$unwind": "$data_tiers"})
         pipeline.append({"$group": {"_id": f"${group_by}", "count": {"$sum": 1}}})
         sort_key = "count" if sort_by == "count" else "_id"
         sort_dir = -1 if sort_by == "count" else 1
@@ -1208,7 +1201,7 @@ class MongoClient(BackendClient):
         non_terminal_list = sorted(NON_TERMINAL)
 
         window_group: dict[str, Any] = {
-            "_id": "$data_tiers",
+            "_id": "$data_tier",
             "completed": _count_if_status_in(success_list),
             "failed": _count_if_status_in(failure_list),
             "last_activity": {"$max": "$completed"},
@@ -1229,13 +1222,12 @@ class MongoClient(BackendClient):
             }
 
         pipeline: list[dict[str, Any]] = [
-            {"$match": {"data_tiers": {"$exists": True, "$ne": []}}},
-            {"$unwind": "$data_tiers"},
+            {"$match": {"data_tier": {"$exists": True, "$ne": None}}},
             {
                 "$facet": {
                     "active": [
                         {"$match": {"status": {"$in": non_terminal_list}}},
-                        {"$group": {"_id": "$data_tiers", "count": {"$sum": 1}}},
+                        {"$group": {"_id": "$data_tier", "count": {"$sum": 1}}},
                     ],
                     "in_window": [
                         {"$match": window_match},
@@ -1309,19 +1301,17 @@ class MongoClient(BackendClient):
         """Per-(submitter, tier) cells for the heatmaps view.
 
         Returns one row per non-empty (submitter, tier) pair in the
-        window. A job whose `data_tiers` list spans both tiers
-        contributes to BOTH cells (mirrors `tier_stats` semantics).
-        Duration percentiles populate on Mongo 7+; otherwise `None`.
+        window. Duration percentiles populate on Mongo 7+; otherwise `None`.
         """
         match_query = _build_filter_query(times=times)
         match_query["submitter"] = {"$exists": True}
-        match_query["data_tiers"] = {"$exists": True, "$ne": []}
+        match_query["data_tier"] = {"$exists": True, "$ne": None}
 
         failure_list = sorted(TERMINAL_FAILURE)
         success_list = sorted(TERMINAL_SUCCESS)
 
         group_stage: dict[str, Any] = {
-            "_id": {"submitter": "$submitter", "tier": "$data_tiers"},
+            "_id": {"submitter": "$submitter", "tier": "$data_tier"},
             "count": {"$sum": 1},
             "completed_count": _count_if_status_in(success_list),
             "failed_count": _count_if_status_in(failure_list),
@@ -1353,7 +1343,6 @@ class MongoClient(BackendClient):
 
         pipeline: list[dict[str, Any]] = [
             {"$match": match_query},
-            {"$unwind": "$data_tiers"},
             {"$group": group_stage},
             {"$project": project_stage},
             {"$sort": {"submitter": 1, "tier": 1}},
@@ -1423,21 +1412,16 @@ class MongoClient(BackendClient):
         *,
         times: JobTimeFilter | None = None,
     ) -> list[FailureBreakdownRow]:
-        """One row per (tier, failure-status) pair with counts.
-
-        `data_tiers` is `$unwind`ed so a multi-tier job contributes to
-        each of its tiers (same semantics as `tier_stats`).
-        """
+        """One row per (tier, failure-status) pair with counts."""
         match_query = _build_filter_query(times=times)
-        match_query["data_tiers"] = {"$exists": True, "$ne": []}
+        match_query["data_tier"] = {"$exists": True, "$ne": None}
         match_query["status"] = {"$in": sorted(TERMINAL_FAILURE)}
 
         pipeline: list[dict[str, Any]] = [
             {"$match": match_query},
-            {"$unwind": "$data_tiers"},
             {
                 "$group": {
-                    "_id": {"tier": "$data_tiers", "status": "$status"},
+                    "_id": {"tier": "$data_tier", "status": "$status"},
                     "count": {"$sum": 1},
                 }
             },

--- a/src/retriever/utils/mongo.py
+++ b/src/retriever/utils/mongo.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import contextlib
 import json
 from collections.abc import AsyncGenerator
 from datetime import datetime
@@ -17,7 +16,8 @@ from pymongo.server_api import ServerApi
 
 from retriever.config.general import CONFIG
 from retriever.types.general import LogLevel
-from retriever.utils.general import BatchedAction, Singleton
+from retriever.utils.backend_client import BackendClient
+from retriever.utils.general import BatchedAction
 from retriever.utils.job_status import NON_TERMINAL, TERMINAL_FAILURE, TERMINAL_SUCCESS
 
 CODEC_OPTIONS = DEFAULT_CODEC_OPTIONS.with_options(tz_aware=True)
@@ -34,7 +34,7 @@ _LOG_LEVEL_THRESHOLD: dict[str, int] = {
     "ERROR": 40,
     "CRITICAL": 50,
 }
-"""Numeric thresholds for loguru levels — used to build `{level.no: {$gte}}` clauses."""
+"""Numeric thresholds for loguru levels - used to build `{level.no: {$gte}}` clauses."""
 
 
 class QueryState(TypedDict):
@@ -77,7 +77,7 @@ class JobDoc(TypedDict):
     completed: NotRequired[datetime]
     touched: NotRequired[datetime]
 
-    # Set by the orphan sweep — tells `get_job_response` that `doc`, if
+    # Set by the orphan sweep - tells `get_job_response` that `doc`, if
     # present, still holds the original query bytes rather than a real
     # response (the ResponseState write never landed).
     abandoned: NotRequired[bool]
@@ -113,7 +113,7 @@ class JobStatus(TypedDict):
     worker_pid: NotRequired[int | None]
     worker_started_at: NotRequired[datetime | None]
 
-    # Set by the orphan sweep — distinguishes a Failed-from-orphan job
+    # Set by the orphan sweep - distinguishes a Failed-from-orphan job
     # from a Failed-from-lookup one.
     abandoned: NotRequired[bool]
 
@@ -177,7 +177,7 @@ class ResponseGeometryFilter(TypedDict, total=False):
 class JobSortSpec(TypedDict):
     """How to order job-status results.
 
-    `duration` is a computed field — `completed - created` in seconds —
+    `duration` is a computed field - `completed - created` in seconds -
     and forces the underlying query through an aggregation pipeline.
     All other fields are stored on the document directly.
     """
@@ -384,7 +384,7 @@ def _encode_cursor(sort_value: SortValue, object_id: ObjectId) -> str:
     elif isinstance(sort_value, datetime):
         v_part = {"t": "datetime", "v": sort_value.isoformat()}
     elif isinstance(sort_value, bool):
-        # bool is a subclass of int — check it first.
+        # bool is a subclass of int - check it first.
         v_part = {"t": "bool", "v": sort_value}
     elif isinstance(sort_value, int):
         v_part = {"t": "int", "v": int(sort_value)}
@@ -400,7 +400,7 @@ class CursorDecodeError(ValueError):
     """Raised when an opaque pagination cursor can't be parsed.
 
     Callers (FastAPI route handlers) should translate this to HTTP 400
-    rather than letting it propagate as 500 — bad cursors are a client
+    rather than letting it propagate as 500 - bad cursors are a client
     fault, not a server fault.
     """
 
@@ -430,7 +430,7 @@ def _decode_cursor(cursor: str) -> tuple[SortValue, ObjectId]:
         elif kind == "str":
             sort_value = str(payload["v"])
         else:
-            # Backward-compat with cursors emitted before the typed payload —
+            # Backward-compat with cursors emitted before the typed payload -
             # those used `{"v": <iso>|null, "id": ...}` with datetime
             # semantics.
             raw = payload.get("v")
@@ -556,12 +556,15 @@ def _build_filter_query(
     return query
 
 
-class MongoClient(metaclass=Singleton):
+class MongoClient(BackendClient):
     """A client abstraction layer for basic operations."""
+
+    client: AsyncIOMotorClient[dict[str, Any]]
+    _supports_percentile: bool = False
 
     def __init__(self) -> None:
         """Set up the client."""
-        self.client: AsyncIOMotorClient[dict[str, Any]]
+        super().__init__()
         if CONFIG.mongo.authsource is None:
             self.client = AsyncIOMotorClient(
                 host=CONFIG.mongo.host,
@@ -589,7 +592,12 @@ class MongoClient(metaclass=Singleton):
             )
         # Patch client to get the current asyncio loop
         self.client.get_io_loop = asyncio.get_running_loop
-        self._supports_percentile: bool = False
+        self._supports_percentile = False
+
+    @override
+    async def ping(self) -> None:
+        """Probe MongoDB. Raises on failure."""
+        _ = await self.client.admin.command("ping")
 
     def get_job_collection(
         self,
@@ -608,26 +616,40 @@ class MongoClient(metaclass=Singleton):
         db = self.client.retriever_persist
         return db.get_collection("log_dump", codec_options=CODEC_OPTIONS)
 
+    @override
     async def initialize(self) -> None:
-        """Check and prepare mongo client.
-
-        Pings to check connection, then sets up collection indices.
-        """
+        """Check and prepare mongo client; idempotent on repeat invocation."""
+        if self.initialized:
+            return
         log.info("Checking mongodb connection...")
         try:
-            await self.client.admin.command("ping")
-            log.success("Mongodb connection successful!")
+            await self.ping()
         except Exception as error:
-            log.critical(
-                "Connection to MongoDB failed. Ensure an instance is running and the connection config is correct."
+            log.warning(
+                f"MongoDB unreachable at startup; continuing in degraded mode. Index setup deferred to first recovery. Error: {error}"
             )
-            raise error
+            self._handle_ping_failure(error)
+        else:
+            log.success("Mongodb connection successful!")
+            await self._setup_after_connection()
 
-        # Detect $percentile support once. Branch in aggregation methods on
-        # this flag rather than catching MongoCommandError mid-pipeline.
-        # buildInfo can be denied on locked-down clusters or return a
-        # version string we can't parse; in either case fall back to the
-        # no-percentile branch rather than blocking startup.
+        # Re-run the post-connection setup on every recovery. Index
+        # creation is idempotent in Mongo, so a startup-then-flap
+        # scenario will retry the work without harm.
+        self.on_recover(self._setup_after_connection)
+
+        await super().initialize()
+
+    async def _setup_after_connection(self) -> None:
+        """Detect `$percentile` support and create collection indexes.
+
+        Run after a successful connection (initial or recovered). Each
+        step is independently guarded so a single failure doesn't abort
+        the others; what survives is what gets re-attempted on the next
+        recovery.
+        """
+        # Detect $percentile support once. Branch in aggregation methods
+        # on this flag rather than catching MongoCommandError mid-pipeline.
         try:
             build_info = await self.client.admin.command("buildInfo")
             major = int(str(build_info["version"]).split(".", 1)[0])
@@ -638,29 +660,26 @@ class MongoClient(metaclass=Singleton):
             )
             self._supports_percentile = False
 
-        job_collections = self.get_job_collection()
-        for collection in job_collections:
-            await collection.create_index("job_id", unique=True, background=True)
-            await collection.create_index(
-                "touched", background=True, expireAfterSeconds=CONFIG.job.ttl
-            )
-            await collection.create_index(
-                "completed", background=True, expireAfterSeconds=CONFIG.job.ttl_max
-            )
-            await collection.create_index("created", background=True)
-
-        log_collection = self.get_log_collection()
-        await log_collection.create_index(
-            {"time": 1}, background=True, expireAfterSeconds=CONFIG.log.mongo_ttl
-        )
-
-    async def ping(self) -> bool:
-        """Post-init liveness check. Returns True iff the server responds."""
         try:
-            _ = await self.client.admin.command("ping")
-        except Exception:
-            return False
-        return True
+            job_collections = self.get_job_collection()
+            for collection in job_collections:
+                await collection.create_index("job_id", unique=True, background=True)
+                await collection.create_index(
+                    "touched", background=True, expireAfterSeconds=CONFIG.job.ttl
+                )
+                await collection.create_index(
+                    "completed", background=True, expireAfterSeconds=CONFIG.job.ttl_max
+                )
+                await collection.create_index("created", background=True)
+
+            log_collection = self.get_log_collection()
+            await log_collection.create_index(
+                {"time": 1}, background=True, expireAfterSeconds=CONFIG.log.mongo_ttl
+            )
+        except Exception as exc:
+            log.warning(
+                f"MongoDB index setup failed; will retry on next recovery. Error: {exc}"
+            )
 
     async def db_storage_bytes(self) -> int:
         """Return the on-disk storage size of the retriever_persist database."""
@@ -704,6 +723,9 @@ class MongoClient(metaclass=Singleton):
                     f"Failed to write batch after {CONFIG.mongo.attempts} attempts.",
                     no_mongo_log=True,
                 )
+                # Nudge the health loop so the flag flips faster than
+                # the next steady-ping cycle would on its own.
+                self.request_health_check()
 
     async def batch_job_state(
         self, job_status_ops: list[UpdateOne], job_doc_ops: list[UpdateOne]
@@ -793,7 +815,7 @@ class MongoClient(metaclass=Singleton):
 
         Reads only the status collection (no doc bytes). Pass `touch=True`
         to bump the `touched` timestamp on both collections, extending
-        TTL — required for TRAPI interactions. Leave it `False` for
+        TTL - required for TRAPI interactions. Leave it `False` for
         read-only dashboard queries.
         """
         status_collection, docs_collection = self.get_job_collection()
@@ -955,7 +977,7 @@ class MongoClient(metaclass=Singleton):
         """Return per-value counts of job_status docs grouped by `group_by`.
 
         For list-valued fields (currently `data_tiers`), the field is
-        `$unwind`ed before grouping — a job that spans multiple tiers
+        `$unwind`ed before grouping - a job that spans multiple tiers
         contributes one to each tier's count.
         """
         match_query = _build_filter_query(
@@ -993,7 +1015,7 @@ class MongoClient(metaclass=Singleton):
 
         Docs missing the bucketed `field` (e.g. running jobs when bucketing on
         `completed`) are excluded. Empty buckets between populated ones are
-        not back-filled — callers that want a continuous series can pad.
+        not back-filled - callers that want a continuous series can pad.
         """
         match_query = _build_filter_query(
             identity, times, query_geometry, response_geometry
@@ -1195,7 +1217,7 @@ class MongoClient(metaclass=Singleton):
             "max_seconds": {"$max": _DURATION_EXPR},
         }
         if self._supports_percentile:
-            # Percentile input matches avg/min/max — all terminal jobs in
+            # Percentile input matches avg/min/max - all terminal jobs in
             # window, success and failure alike. window_match has already
             # filtered to docs with non-null timestamps.
             window_group["percentiles"] = {
@@ -1460,7 +1482,7 @@ class MongoClient(metaclass=Singleton):
     ) -> AsyncGenerator[dict[str, Any]]:
         """Return a generator of logs not associated with any job.
 
-        Matches docs where `extra.job_id` is absent — the logs Retriever
+        Matches docs where `extra.job_id` is absent - the logs Retriever
         itself emits (lifecycle, background refreshes, tier drivers,
         cache activity). Sibling to `get_logs`.
         """
@@ -1550,9 +1572,15 @@ class MongoClient(metaclass=Singleton):
         )
         return result.modified_count
 
-    async def close(self) -> None:
-        """Clean up and close MongoDB client threads/connections."""
+    @override
+    async def wrapup(self) -> None:
+        """Cancel background tasks and close MongoDB client connections."""
+        await super().wrapup()
         self.client.close()
+
+
+class MongoOutage(Exception):
+    """Raised by `MongoQueue.put` when MongoClient is down; callers attach a warning."""
 
 
 class MongoQueue(BatchedAction):
@@ -1565,18 +1593,16 @@ class MongoQueue(BatchedAction):
     client: ClassVar[MongoClient] = MongoClient()
 
     @override
-    async def wrapup(self) -> None:
-        """Flush pending writes during graceful shutdown.
+    def put(self, target: str, payload: Any) -> None:
+        """Enqueue `payload` for `target`; raises `MongoOutage` if Mongo is down."""
+        if not self.client.up:
+            raise MongoOutage("MongoDB is unavailable; queued write dropped.")
+        super().put(target, payload)
 
-        The polling loop is cancelled and awaited *before* the flush, so it
-        can't race the flush by pulling items off the queue concurrently.
-        """
-        log.info(f"{type(self).__name__} wrapping up.")
-        for task in self.tasks:
-            _ = task.cancel()
-        for task in self.tasks:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
+    @override
+    async def wrapup(self) -> None:
+        """Cancel the polling loop, then flush pending writes during graceful shutdown."""
+        await super().wrapup()
         try:
             async with asyncio.timeout(CONFIG.mongo.shutdown_timeout):
                 await self.flush()

--- a/src/retriever/utils/orphan_detection.py
+++ b/src/retriever/utils/orphan_detection.py
@@ -1,0 +1,92 @@
+"""Orphan-job detection: mark jobs whose worker is gone as Failed.
+
+The background process drives `periodically_mark_orphans` on the interval
+configured by `CONFIG.job.orphan_check_interval`. A job is considered
+orphaned when its `worker_pid` is no longer in the Redis worker registry,
+or when the registered start time at that PID differs from the one
+recorded on the job (PID reuse).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from loguru import logger
+
+from retriever.config.general import CONFIG
+from retriever.utils.mongo import MongoClient
+from retriever.utils.redis import RedisClient
+
+
+def _ms_since_epoch(dt: datetime) -> int:
+    """Truncate to integer ms since epoch — matches BSON datetime resolution.
+
+    MongoDB stores datetimes at ms precision; Redis preserves the original
+    microseconds via ISO-string round-trip. Comparing at ms precision lets
+    the two round-trip representations of the same instant match.
+    """
+    return int(dt.timestamp() * 1000)
+
+
+async def _mark_orphaned_jobs() -> None:
+    """One sweep: find non-terminal jobs whose worker is gone and mark them Failed."""
+    try:
+        # Read Mongo *before* Redis: workers register in Redis before they
+        # serve any request, so any job present in the Mongo snapshot was
+        # created by a worker that must also be in the later Redis snapshot
+        # if it's still alive. Reading the other way around would risk
+        # marking a freshly-created job orphaned because its worker
+        # registered between the two reads.
+        non_terminal = await MongoClient().get_non_terminal_with_worker_info()
+        live_workers = await RedisClient().list_workers()
+    except Exception:
+        logger.exception("Orphan sweep failed to read state; skipping.")
+        return
+
+    orphaned_ids: list[str] = []
+    for job_id, wpid, wstarted in non_terminal:
+        if wpid is None:
+            continue  # pre-feature doc; no worker info to check
+        live_started = live_workers.get(wpid)
+        if live_started is None:
+            # Worker PID is no longer in the registry → worker died.
+            orphaned_ids.append(job_id)
+            continue
+        if wstarted is None:
+            # Inconsistent state (wpid set but wstarted missing); trust the
+            # live PID match rather than orphan based on partial data.
+            continue
+        if _ms_since_epoch(live_started) != _ms_since_epoch(wstarted):
+            # Same PID, different start time → PID was reused by a new worker.
+            orphaned_ids.append(job_id)
+
+    if orphaned_ids:
+        try:
+            count = await MongoClient().mark_jobs_abandoned(orphaned_ids)
+            if count:
+                logger.warning(
+                    f"Orphan sweep: marked {count} job(s) as Failed.",
+                    no_mongo_log=True,
+                )
+        except Exception:
+            logger.exception("Orphan sweep failed to write Failed status.")
+
+
+async def periodically_mark_orphans() -> None:
+    """Periodic driver for orphan detection.
+
+    Runs immediately on startup so jobs left behind by a previous run get
+    cleaned up without waiting a full interval. There's no startup race:
+    workers register in Redis before their lifespan yields, so they cannot
+    have unregistered jobs in MongoDB.
+    """
+    try:
+        interval = CONFIG.job.orphan_check_interval
+        if interval < 0:
+            return
+        while True:
+            await _mark_orphaned_jobs()
+            await asyncio.sleep(interval)
+    except asyncio.CancelledError:
+        return

--- a/src/retriever/utils/orphan_detection.py
+++ b/src/retriever/utils/orphan_detection.py
@@ -20,7 +20,7 @@ from retriever.utils.redis import RedisClient
 
 
 def _ms_since_epoch(dt: datetime) -> int:
-    """Truncate to integer ms since epoch — matches BSON datetime resolution.
+    """Truncate to integer ms since epoch - matches BSON datetime resolution.
 
     MongoDB stores datetimes at ms precision; Redis preserves the original
     microseconds via ISO-string round-trip. Comparing at ms precision lets
@@ -31,6 +31,12 @@ def _ms_since_epoch(dt: datetime) -> int:
 
 async def _mark_orphaned_jobs() -> None:
     """One sweep: find non-terminal jobs whose worker is gone and mark them Failed."""
+    if not RedisClient().up:
+        logger.debug(
+            "Orphan sweep skipped; Redis is down.",
+            no_mongo_log=True,
+        )
+        return
     try:
         # Read Mongo *before* Redis: workers register in Redis before they
         # serve any request, so any job present in the Mongo snapshot was

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 from abc import ABCMeta, abstractmethod
 from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from datetime import datetime
 from types import CoroutineType, TracebackType
 from typing import (
     Any,
@@ -32,9 +34,64 @@ PREFIX = "{Retriever}:"
 OP_TABLE_KEY = f"{PREFIX}op_table"
 OP_TABLE_UPDATE_CHANNEL = f"{OP_TABLE_KEY}:update"
 
+# Sidecar timestamp keys — written alongside published artifacts so /status
+# can show freshness without inferring from TTL. Defined here (rather than
+# next to the artifact owners) so both publishers and consumers share one
+# import path and to avoid an artifact-module ↔ redis-client import cycle.
+OP_TABLE_META_KEY = f"{OP_TABLE_KEY}:meta"
+SUBCLASS_META_KEY = f"{PREFIX}SubclassHashMap:meta"
+
+# Process-registry hashes — workers / background self-report PID + start
+# time on lifespan startup and refresh on a heartbeat. Field TTL via
+# HEXPIRE so a dead process drops out automatically.
+WORKER_REGISTRY_KEY = f"{PREFIX}workers"
+BACKGROUND_REGISTRY_KEY = f"{PREFIX}background"
+MAIN_REGISTRY_KEY = f"{PREFIX}main"
+
+# Heartbeat cadence + TTL for process self-report. TTL is set to several
+# heartbeat intervals so a single missed refresh doesn't drop the entry.
+PROCESS_HEARTBEAT_INTERVAL_SECONDS = 60
+PROCESS_TTL_SECONDS = 300
+
+
+async def heartbeat(
+    on_tick: Callable[[], Awaitable[None]],
+    role_label: str,
+    interval_seconds: int = PROCESS_HEARTBEAT_INTERVAL_SECONDS,
+) -> None:
+    """Run `on_tick` on an interval, swallowing per-tick failures.
+
+    Used to drive process-registry refresh loops from the lifespan hooks.
+    Cancellation of the surrounding task exits cleanly.
+    """
+    try:
+        while True:
+            await asyncio.sleep(interval_seconds)
+            try:
+                await on_tick()
+            except Exception:
+                logger.warning(
+                    f"{role_label} heartbeat refresh failed; will retry next interval.",
+                    no_mongo_log=True,
+                )
+    except asyncio.CancelledError:
+        return
+
+
 # For better performance
 ZSTD_COMPRESSOR = zstandard.ZstdCompressor()
 ZSTD_DECOMPRESSOR = zstandard.ZstdDecompressor()
+
+
+class FreshnessRecord(TypedDict):
+    """Sidecar metadata for a Redis-published artifact.
+
+    `count` semantics vary by artifact: `op_count` for the MetaKG op
+    table, map `size` for the subclass mapping.
+    """
+
+    refreshed_at: datetime
+    count: int
 
 
 class PubSubMessage(TypedDict):
@@ -266,6 +323,20 @@ class AsyncRedis(Protocol, metaclass=ABCMeta):
         """
 
     @abstractmethod
+    async def hgetall(self, name: str) -> dict[bytes, bytes]:
+        """Return a Python dict of the hash's name/value pairs.
+
+        For more information, see https://redis.io/commands/hgetall
+        """
+
+    @abstractmethod
+    async def info(self, section: str | None = None) -> dict[str, Any]:
+        """Return server INFO (optionally restricted to a section).
+
+        For more information, see https://redis.io/commands/info
+        """
+
+    @abstractmethod
     async def hexpire(  # noqa:PLR0913
         self,
         name: KeyT,
@@ -314,6 +385,17 @@ class RedisClient(AsyncDaemon):
     def __init__(self) -> None:
         """Instantiate a client class without initializing the Redis connection."""
         super().__init__()
+        self._build_client()
+        self.subscriptions: dict[str, list[Callable[[str], Awaitable[None]]]] = {}
+
+    def _build_client(self) -> None:
+        """(Re)build the internal redis-py async client.
+
+        Called from __init__ and again from initialize() when the existing
+        client is bound to a now-closed asyncio loop. This keeps the
+        RedisClient Singleton usable across event loops (e.g. across
+        pytest-asyncio tests, where each test gets a fresh loop).
+        """
         retry = Retry(ExponentialBackoff(), CONFIG.redis.attempts)
         self._client = redis.Redis(
             host=CONFIG.redis.host,
@@ -329,7 +411,6 @@ class RedisClient(AsyncDaemon):
             AsyncRedis,
             cast(object, self._client),
         )
-        self.subscriptions: dict[str, list[Callable[[str], Awaitable[None]]]] = {}
 
     @override
     def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:
@@ -338,16 +419,26 @@ class RedisClient(AsyncDaemon):
     @override
     async def initialize(self) -> None:
         """Initialize a connection to the redis server."""
+        log.info("Checking redis connection...")
         try:
-            log.info("Checking redis connection...")
             await self.client.initialize()
             await self.client.ping()
-            log.success("Redis connection successful!")
+        except RuntimeError as error:
+            # redis-py binds connections to the asyncio loop they were
+            # created on. If the Singleton survives a loop closure
+            # (Python test runners, in particular), rebuild and retry.
+            if "Event loop is closed" not in str(error):
+                raise
+            log.debug("Rebuilding Redis client on current event loop.")
+            self._build_client()
+            await self.client.initialize()
+            await self.client.ping()
         except RedisConnectionError as error:
             log.critical(
                 "Connection to Redis failed. Ensure an instance is running and the connection config is correct."
             )
             raise error
+        log.success("Redis connection successful!")
         return await super().initialize()
 
     @override
@@ -453,6 +544,103 @@ class RedisClient(AsyncDaemon):
         response = await self.client.delete(f"{PREFIX}{key}")
         return response > 0
 
+    async def ping(self) -> bool:
+        """Post-init liveness check. Returns True iff the server responds."""
+        try:
+            return bool(await self.client.ping())
+        except Exception:
+            return False
+
+    async def used_memory_bytes(self) -> int:
+        """Return the Dragonfly/Redis `used_memory` field from INFO MEMORY."""
+        info = await self.client.info("memory")
+        return int(info["used_memory"])
+
+    async def _read_freshness(self, key: str) -> FreshnessRecord | None:
+        """Read a JSON sidecar `{refreshed_at, count}` from the given key."""
+        data = await self.client.get(key)
+        if data is None:
+            return None
+        try:
+            payload = json.loads(data)
+            return FreshnessRecord(
+                refreshed_at=datetime.fromisoformat(payload["refreshed_at"]),
+                count=int(payload["count"]),
+            )
+        except (KeyError, ValueError, json.JSONDecodeError):
+            return None
+
+    async def write_freshness(self, key: str, count: int, ttl: int) -> None:
+        """Write a JSON sidecar `{refreshed_at, count}` with the given TTL."""
+        payload = json.dumps(
+            {"refreshed_at": datetime.now().astimezone().isoformat(), "count": count}
+        )
+        await self.client.set(key, payload, ex=ttl if ttl > 0 else None)
+
+    async def metakg_freshness(self) -> FreshnessRecord | None:
+        """Return the last-refreshed timestamp + op count for the MetaKG."""
+        return await self._read_freshness(OP_TABLE_META_KEY)
+
+    async def subclass_freshness(self) -> FreshnessRecord | None:
+        """Return the last-refreshed timestamp + map size for the subclass map."""
+        return await self._read_freshness(SUBCLASS_META_KEY)
+
+    async def _register_process(
+        self,
+        registry_key: str,
+        pid: int,
+        started_at: datetime,
+        ttl_seconds: int,
+    ) -> None:
+        """Write the JSON started-at payload to a hash field with TTL."""
+        payload = json.dumps({"started_at": started_at.astimezone().isoformat()})
+        _ = await self.client.hset(registry_key, str(pid), payload.encode())
+        _ = await self.client.hexpire(registry_key, ttl_seconds, str(pid))
+
+    async def register_worker(
+        self, pid: int, started_at: datetime, ttl_seconds: int
+    ) -> None:
+        """Register this worker's PID + start time with a TTL."""
+        await self._register_process(WORKER_REGISTRY_KEY, pid, started_at, ttl_seconds)
+
+    async def register_background(
+        self, pid: int, started_at: datetime, ttl_seconds: int
+    ) -> None:
+        """Register the background process's PID + start time with a TTL."""
+        await self._register_process(
+            BACKGROUND_REGISTRY_KEY, pid, started_at, ttl_seconds
+        )
+
+    async def register_main(
+        self, pid: int, started_at: datetime, ttl_seconds: int
+    ) -> None:
+        """Register the main entry-point process's PID + start time with a TTL."""
+        await self._register_process(MAIN_REGISTRY_KEY, pid, started_at, ttl_seconds)
+
+    async def _list_processes(self, registry_key: str) -> dict[int, datetime]:
+        """Return a mapping of pid -> started_at for the given registry hash."""
+        entries = await self.client.hgetall(registry_key)
+        out: dict[int, datetime] = {}
+        for raw_pid, raw_value in entries.items():
+            try:
+                payload = json.loads(raw_value)
+                out[int(raw_pid)] = datetime.fromisoformat(payload["started_at"])
+            except (KeyError, ValueError, json.JSONDecodeError):
+                continue
+        return out
+
+    async def list_workers(self) -> dict[int, datetime]:
+        """Return all currently-registered worker PIDs and their start times."""
+        return await self._list_processes(WORKER_REGISTRY_KEY)
+
+    async def list_background(self) -> dict[int, datetime]:
+        """Return the registered background process PID + start time (0 or 1 entries)."""
+        return await self._list_processes(BACKGROUND_REGISTRY_KEY)
+
+    async def list_main(self) -> dict[int, datetime]:
+        """Return the registered main process PID + start time (0 or 1 entries)."""
+        return await self._list_processes(MAIN_REGISTRY_KEY)
+
     @overload
     async def hset(self, key: str, field: str, value: bytes) -> None: ...
 
@@ -526,7 +714,7 @@ class RedisClient(AsyncDaemon):
                 await self.client.hexpire(f"{PREFIX}{key}", ttl, field)
         else:
             await self.client.hset(
-                key,
+                f"{PREFIX}{key}",
                 mapping=value_to_set,
             )
             if ttl > 0:
@@ -536,7 +724,7 @@ class RedisClient(AsyncDaemon):
         self, key: str, *field: str, compressed: bool = False
     ) -> list[bytes | None]:
         """Generically get a field of a mapping."""
-        values = await self.client.hmget(key, field)
+        values = await self.client.hmget(f"{PREFIX}{key}", field)
         if compressed:
             return [
                 ZSTD_DECOMPRESSOR.decompress(val) if val is not None else val

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
+import random
 from abc import ABCMeta, abstractmethod
-from collections.abc import Awaitable, Callable, Coroutine, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime
 from types import CoroutineType, TracebackType
 from typing import (
@@ -20,62 +21,31 @@ from loguru import logger
 from loguru import logger as log
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
-from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.typing import AbsExpiryT, ChannelT, EncodableT, ExpiryT, KeyT, ResponseT
 
 from retriever.config.general import CONFIG
-from retriever.utils.general import AsyncDaemon
+from retriever.utils.backend_client import BackendClient
 
 # Required to avoid CROSSSLOT errors: https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags
 # Technically not needed as cluster is not supported, but worth keeping in case we need to re-add cluster support
 PREFIX = "{Retriever}:"
 
-# For consistency
-OP_TABLE_KEY = f"{PREFIX}op_table"
-OP_TABLE_UPDATE_CHANNEL = f"{OP_TABLE_KEY}:update"
+# Bare names - `RedisClient.set/get/publish/subscribe` add `PREFIX`.
+OP_TABLE_KEY = "op_table"
+OP_TABLE_UPDATE_CHANNEL = "op_table:update"
 
-# Sidecar timestamp keys — written alongside published artifacts so /status
-# can show freshness without inferring from TTL. Defined here (rather than
-# next to the artifact owners) so both publishers and consumers share one
-# import path and to avoid an artifact-module ↔ redis-client import cycle.
-OP_TABLE_META_KEY = f"{OP_TABLE_KEY}:meta"
+# Worker -> leader signal for a tier recovery; payload is the tier index as a string.
+TIER_RECOVERED_CHANNEL = "tier:recovered"
+
+# Timestamp keys written alongside published artifacts so /status
+# can show freshness without inferring from TTL.
+OP_TABLE_META_KEY = f"{PREFIX}op_table:meta"
 SUBCLASS_META_KEY = f"{PREFIX}SubclassHashMap:meta"
 
-# Process-registry hashes — workers / background self-report PID + start
-# time on lifespan startup and refresh on a heartbeat. Field TTL via
-# HEXPIRE so a dead process drops out automatically.
+# Process-registry hashes.
 WORKER_REGISTRY_KEY = f"{PREFIX}workers"
 BACKGROUND_REGISTRY_KEY = f"{PREFIX}background"
 MAIN_REGISTRY_KEY = f"{PREFIX}main"
-
-# Heartbeat cadence + TTL for process self-report. TTL is set to several
-# heartbeat intervals so a single missed refresh doesn't drop the entry.
-PROCESS_HEARTBEAT_INTERVAL_SECONDS = 60
-PROCESS_TTL_SECONDS = 300
-
-
-async def heartbeat(
-    on_tick: Callable[[], Awaitable[None]],
-    role_label: str,
-    interval_seconds: int = PROCESS_HEARTBEAT_INTERVAL_SECONDS,
-) -> None:
-    """Run `on_tick` on an interval, swallowing per-tick failures.
-
-    Used to drive process-registry refresh loops from the lifespan hooks.
-    Cancellation of the surrounding task exits cleanly.
-    """
-    try:
-        while True:
-            await asyncio.sleep(interval_seconds)
-            try:
-                await on_tick()
-            except Exception:
-                logger.warning(
-                    f"{role_label} heartbeat refresh failed; will retry next interval.",
-                    no_mongo_log=True,
-                )
-    except asyncio.CancelledError:
-        return
 
 
 # For better performance
@@ -383,7 +353,7 @@ class AsyncRedis(Protocol, metaclass=ABCMeta):
         """
 
 
-class RedisClient(AsyncDaemon):
+class RedisClient(BackendClient):
     """A client abstraction layer for basic operations."""
 
     _client: redis.Redis
@@ -394,6 +364,11 @@ class RedisClient(AsyncDaemon):
         super().__init__()
         self._build_client()
         self.subscriptions: dict[str, list[Callable[[str], Awaitable[None]]]] = {}
+
+    @override
+    async def ping(self) -> None:
+        """Probe Redis. Raises on failure."""
+        _ = await self.client.ping()
 
     def _build_client(self) -> None:
         """(Re)build the internal redis-py async client.
@@ -420,38 +395,110 @@ class RedisClient(AsyncDaemon):
         )
 
     @override
-    def get_task_funcs(self) -> list[Callable[[], Coroutine[None, None, None]]]:
-        return []
-
-    @override
     async def initialize(self) -> None:
-        """Initialize a connection to the redis server."""
+        """Initialize a connection to the redis server; degraded mode on any startup failure."""
         log.info("Checking redis connection...")
+        try:
+            await self._connect_with_loop_rebuild()
+        except Exception as error:
+            log.warning(
+                f"Redis startup failed; continuing in degraded mode. Health loop will retry. Error: {error}"
+            )
+            self._handle_ping_failure(error)
+        else:
+            log.success("Redis connection successful!")
+        return await super().initialize()
+
+    async def _connect_with_loop_rebuild(self) -> None:
+        """Run the initial connect, rebuilding once if bound to a closed loop.
+
+        redis-py binds connections to the asyncio loop they were created
+        on. When the Singleton survives a loop closure (Python test
+        runners, in particular), the first connect raises and we rebuild
+        against the current loop.
+        """
         try:
             await self.client.initialize()
             await self.client.ping()
         except RuntimeError as error:
-            # redis-py binds connections to the asyncio loop they were
-            # created on. If the Singleton survives a loop closure
-            # (Python test runners, in particular), rebuild and retry.
             if "Event loop is closed" not in str(error):
                 raise
             log.debug("Rebuilding Redis client on current event loop.")
             self._build_client()
             await self.client.initialize()
             await self.client.ping()
-        except RedisConnectionError as error:
-            log.critical(
-                "Connection to Redis failed. Ensure an instance is running and the connection config is correct."
-            )
-            raise error
-        log.success("Redis connection successful!")
-        return await super().initialize()
 
     @override
     async def wrapup(self) -> None:
         await super().wrapup()
         await self.client.aclose()
+
+    def start_heartbeat(
+        self,
+        on_tick: Callable[[], Awaitable[None]],
+        role_label: str,
+        interval_seconds: int | None = None,
+    ) -> None:
+        """Spawn a heartbeat task tracked by `self.tasks`; cancelled at wrapup."""
+        task = asyncio.create_task(
+            self._heartbeat(on_tick, role_label, interval_seconds),
+            name=f"{role_label.lower()}-heartbeat",
+        )
+        self.tasks.append(task)
+
+    async def _heartbeat(
+        self,
+        on_tick: Callable[[], Awaitable[None]],
+        role_label: str,
+        interval_seconds: int | None,
+    ) -> None:
+        """Run `on_tick` on an interval; skip ticks while Redis is down and re-fire on recovery."""
+        if interval_seconds is None:
+            interval_seconds = CONFIG.redis.heartbeat_interval_seconds
+        armed = False
+
+        async def _on_recover_fire() -> None:
+            nonlocal armed
+            try:
+                await on_tick()
+            except Exception:
+                logger.warning(
+                    f"{role_label} heartbeat refresh on recovery failed; will retry next interval.",
+                    no_mongo_log=True,
+                )
+            finally:
+                self.deregister_callback("recover", _on_recover_fire)
+                armed = False
+
+        def _arm_recovery() -> None:
+            nonlocal armed
+            if armed:
+                return
+            self.on_recover(_on_recover_fire)
+            armed = True
+
+        try:
+            while True:
+                await asyncio.sleep(interval_seconds)
+                if not self.up:
+                    logger.debug(
+                        f"{role_label} heartbeat skipped; Redis is down.",
+                        no_mongo_log=True,
+                    )
+                    _arm_recovery()
+                    continue
+                try:
+                    await on_tick()
+                except Exception:
+                    logger.warning(
+                        f"{role_label} heartbeat refresh failed; will retry next interval.",
+                        no_mongo_log=True,
+                    )
+                    self.request_health_check()
+                    _arm_recovery()
+        except asyncio.CancelledError:
+            self.deregister_callback("recover", _on_recover_fire)
+            return
 
     async def publish(self, channel: str, message: Any) -> None:
         """Publish a message to a given channel."""
@@ -487,36 +534,90 @@ class RedisClient(AsyncDaemon):
                 return False
         return True
 
-    async def subscriber(self, channel_key: str) -> None:
-        """A subscriber function that should be wrapped in an asyncio task.
+    async def _pump_messages(self, pubsub: PubSub, channel_key: str) -> None:
+        """Dispatch incoming pubsub messages on `channel_key` to its callbacks.
 
-        We wrap in an asyncio task rather than using redis-py's built in handling
-        specifically so that we can unsubscribe method-wise instead of channel-wise.
+        A callback raising non-cancellation is isolated and logged so one
+        misbehaving subscriber can't tear down the connection.
         """
-        async with self.client.pubsub() as pubsub:
-            await pubsub.subscribe(channel_key)
-            logger.trace(f"Subscribed to channel {channel_key}")
-            while True:
-                # if len(self.subscriptions[channel_key]) == 0:
-                #     break
+        while True:
+            message = await pubsub.get_message(
+                ignore_subscribe_messages=True, timeout=1.0
+            )
+            if message is None:
+                continue
+            if isinstance(message["data"], str):
+                data = message["data"]
+            elif isinstance(message["data"], bytes):
+                data = message["data"].decode()
+            else:
+                data = str(message["data"])
+            # Snapshot - a callback awaiting can yield to subscribe()/
+            # unsubscribe() mutating the underlying list mid-iteration.
+            # `.get(..., [])` defends against a future cleanup that
+            # `del`s an empty subscriptions list.
+            for callback in list(self.subscriptions.get(channel_key, [])):
                 try:
-                    message = await pubsub.get_message(
-                        ignore_subscribe_messages=True, timeout=0.01
+                    await callback(data)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        f"Pubsub callback for {channel_key} raised; continuing."
                     )
-                    if message is not None:
-                        if isinstance(message["data"], str):
-                            data = message["data"]
-                        elif isinstance(message["data"], bytes):
-                            data = message["data"].decode()
-                        else:
-                            data = str(message["data"])
 
-                        for callback in self.subscriptions[channel_key]:
-                            await callback(data)
+    async def subscriber(self, channel_key: str) -> None:
+        """Self-healing subscriber task for a single Redis pub/sub channel.
 
-                except (ValueError, asyncio.CancelledError):
-                    await pubsub.unsubscribe(channel_key)
-                    break
+        Wrapped in an asyncio task (rather than using redis-py's built-in
+        handling) so we can unsubscribe per-callback instead of per-channel.
+
+        Resilience model: park on `_up_event` while the client believes
+        Redis is down so we don't busy-fail. On a classified outage
+        exception, nudge `request_health_check()` and retry with jittered
+        exponential backoff using a fresh `pubsub()` (its own connection -
+        distinct from the main client's). Non-outage exceptions log and
+        continue. `CancelledError` exits cleanly even if cleanup of the
+        old `pubsub()` masks it.
+        """
+        backoff = self.retry_backoff_start
+        try:
+            while True:
+                if not self.up:
+                    backoff = self.retry_backoff_start
+                    await self._up_event.wait()
+                try:
+                    async with self.client.pubsub() as pubsub:
+                        await pubsub.subscribe(channel_key)
+                        logger.trace(f"Subscribed to channel {channel_key}")
+                        backoff = self.retry_backoff_start
+                        await self._pump_messages(pubsub, channel_key)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    # PubSub.__aexit__ can raise a ConnectionError during
+                    # cleanup of a dead connection, masking an in-flight
+                    # cancellation. Detect that and re-raise so shutdown
+                    # exits immediately instead of waiting out the backoff.
+                    task = asyncio.current_task()
+                    if task is not None and task.cancelling():
+                        raise asyncio.CancelledError from exc
+                    if self.is_outage_error(exc):
+                        self.request_health_check()
+                        jitter = 1.0 + random.uniform(
+                            -self.retry_backoff_jitter, self.retry_backoff_jitter
+                        )
+                        await asyncio.sleep(backoff * jitter)
+                        backoff = min(backoff * 2, self.retry_backoff_max)
+                    else:
+                        logger.exception(
+                            f"Pubsub non-outage error on {channel_key}; continuing."
+                        )
+                        # Short pause to avoid a tight reconnect loop if a
+                        # misclassified or transient error keeps recurring.
+                        await asyncio.sleep(self.retry_backoff_start)
+        except asyncio.CancelledError:
+            return
 
     async def set(
         self,
@@ -551,13 +652,6 @@ class RedisClient(AsyncDaemon):
         response = await self.client.delete(f"{PREFIX}{key}")
         return response > 0
 
-    async def ping(self) -> bool:
-        """Post-init liveness check. Returns True iff the server responds."""
-        try:
-            return bool(await self.client.ping())
-        except Exception:
-            return False
-
     async def used_memory_bytes(self) -> int:
         """Return the Dragonfly/Redis `used_memory` field from INFO MEMORY."""
         info = await self.client.info("memory")
@@ -577,8 +671,8 @@ class RedisClient(AsyncDaemon):
         except (KeyError, ValueError, json.JSONDecodeError):
             return None
 
-    async def write_freshness(self, key: str, count: int, ttl: int) -> None:
-        """Write a JSON sidecar `{refreshed_at, count}` with the given TTL."""
+    async def write_freshness(self, key: str, count: int, ttl: int = 0) -> None:
+        """Write a JSON sidecar `{refreshed_at, count}`; `ttl=0` for no expire."""
         payload = json.dumps(
             {"refreshed_at": datetime.now().astimezone().isoformat(), "count": count}
         )

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -316,6 +316,13 @@ class AsyncRedis(Protocol, metaclass=ABCMeta):
         """
 
     @abstractmethod
+    async def hdel(self, name: str, *keys: str) -> int:
+        """Delete ``keys`` from hash ``name``. Returns the number of fields removed.
+
+        For more information, see https://redis.io/commands/hdel
+        """
+
+    @abstractmethod
     async def hmget(self, name: str, keys: Iterable[KeyT]) -> list[bytes | None]:
         """Returns a list of values ordered identically to ``keys``.
 
@@ -602,6 +609,14 @@ class RedisClient(AsyncDaemon):
     ) -> None:
         """Register this worker's PID + start time with a TTL."""
         await self._register_process(WORKER_REGISTRY_KEY, pid, started_at, ttl_seconds)
+
+    async def unregister_worker(self, pid: int) -> None:
+        """Remove this worker's registration entry.
+
+        Called on graceful shutdown so orphan detection picks up the
+        worker's leftover jobs immediately rather than waiting on TTL.
+        """
+        _ = await self.client.hdel(WORKER_REGISTRY_KEY, str(pid))
 
     async def register_background(
         self, pid: int, started_at: datetime, ttl_seconds: int

--- a/src/retriever/utils/service_health.py
+++ b/src/retriever/utils/service_health.py
@@ -1,0 +1,230 @@
+"""Service-health snapshot and degradation policy.
+
+`Snapshot()` captures a frozen, process-local view of every backend
+dependency's `up`/`error` state at the moment it's constructed; its
+methods answer the per-request questions that follow from that view
+- what HTTP status to return, which tier to route to, what warning
+text to attach. No cross-process consensus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import Literal
+
+from fastapi import HTTPException
+
+from retriever.data_tiers import tier_manager
+from retriever.types.general import ErrorDetail
+from retriever.types.trapi import LogEntryDict
+from retriever.types.trapi_pydantic import (
+    AsyncQuery as TRAPIAsyncQuery,
+)
+from retriever.types.trapi_pydantic import (
+    Query as TRAPIQuery,
+)
+from retriever.types.trapi_pydantic import (
+    TierNumber,
+)
+from retriever.utils.backend_client import BackendClient, StatusDict
+from retriever.utils.logs import format_trapi_log
+from retriever.utils.mongo import MongoClient
+from retriever.utils.redis import RedisClient
+
+Endpoint = Literal[
+    "/query",
+    "/asyncquery",
+    "/asyncquery_status",
+    "/response",
+    "/logs",
+    "/status/server_logs",
+    "/status/counts",
+    "/metadata",
+    "/meta_knowledge_graph",
+]
+"""Routes whose behavior the policy module decides about."""
+
+_T2: TierNumber = 2
+"""Tier 2 - the one tier without a fallback peer."""
+
+
+_MONGO_OUTAGE_TEXT = (
+    "MongoDB connection failed, job state will not be persisted after this response"
+)
+
+_SUBCLASS_UNAVAILABLE_TEXT = (
+    "Subclass mapping unavailable due to Redis outage; query results "
+    "may omit subclass expansion."
+)
+
+
+def _tier_fallback_text(requested: TierNumber, fallback: TierNumber) -> str:
+    return f"Tier {requested} is down; falling back to Tier {fallback}."
+
+
+def mongo_outage_warning() -> LogEntryDict:
+    """LogEntry attached when a Mongo write fails during request execution."""
+    return format_trapi_log("WARNING", _MONGO_OUTAGE_TEXT)
+
+
+def subclass_unavailable_warning() -> LogEntryDict:
+    """LogEntry attached when subclass expansion fails for outage reasons."""
+    return format_trapi_log("WARNING", _SUBCLASS_UNAVAILABLE_TEXT)
+
+
+def tier_fallback_warning(requested: TierNumber, fallback: TierNumber) -> LogEntryDict:
+    """LogEntry attached when a query was routed to a fallback tier."""
+    return format_trapi_log("WARNING", _tier_fallback_text(requested, fallback))
+
+
+def outage_detail(detail: str, dependency: BackendClient) -> ErrorDetail:
+    """Build an `ErrorDetail` enriched with `dependency`'s outage info.
+
+    `additional_info` carries `outage_time` (the dependency's
+    `last_outage`) and `outage_error` (its `last_error`) so callers
+    handling 424s can correlate the failure with `/status` data.
+    """
+    status = dependency.status()
+    return ErrorDetail(
+        detail=detail,
+        additional_info={
+            "outage_time": status["last_outage"],
+            "outage_error": status["error"],
+        },
+    )
+
+
+def require_mongo(detail: str) -> None:
+    """Fail-fast 424 when MongoDB is unreachable.
+
+    Convenience for read-only endpoints that touch Mongo and have no
+    fallback path. Saves each call site from the Motor 30s server-
+    selection timeout and ensures a uniform `ErrorDetail` body.
+    """
+    mongo = MongoClient()
+    if mongo.up:
+        return
+    raise HTTPException(
+        HTTPStatus.FAILED_DEPENDENCY,
+        detail=outage_detail(detail, mongo),
+    )
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class Snapshot:
+    """Frozen process-local view of backend health, built at construction time.
+
+    Immutable so every decision within a request shares one view, even
+    if a backend's flag flips mid-flight. `tier2` is `None` when that
+    tier isn't implemented in this build.
+    """
+
+    mongo: StatusDict
+    redis: StatusDict
+    tier0: StatusDict
+    tier1: StatusDict
+    tier2: StatusDict | None
+
+    def __init__(self) -> None:
+        """Build a snapshot from the current `BackendClient` singletons."""
+        object.__setattr__(self, "mongo", MongoClient().status())
+        object.__setattr__(self, "redis", RedisClient().status())
+        object.__setattr__(self, "tier0", tier_manager.get_driver(0).status())
+        object.__setattr__(self, "tier1", tier_manager.get_driver(1).status())
+        tier2 = (
+            tier_manager.get_driver(_T2).status()
+            if _T2 in tier_manager.IMPLEMENTED_TIERS
+            else None
+        )
+        object.__setattr__(self, "tier2", tier2)
+
+    def _tier_health(self, tier: TierNumber) -> StatusDict | None:
+        """`StatusDict` for `tier`, or `None` if unimplemented."""
+        if tier == 0:
+            return self.tier0
+        if tier == 1:
+            return self.tier1
+        return self.tier2
+
+    def http_status_for(self, endpoint: Endpoint) -> HTTPStatus | None:
+        """Short-circuit HTTP status for `endpoint`, or `None` to proceed.
+
+        Per-tier endpoints (`/metadata?tier=N`, `/meta_knowledge_graph?tier=N`)
+        can't be decided from the snapshot alone - callers should use
+        `select_tier(..., allow_fallback=False)`. Aggregated
+        `/meta_knowledge_graph` runs as long as at least one implemented
+        tier is up; only 424s when all are down.
+        """
+        if endpoint in (
+            "/asyncquery_status",
+            "/response",
+            "/logs",
+            "/status/server_logs",
+            "/status/counts",
+        ):
+            return None if self.mongo["up"] else HTTPStatus.FAILED_DEPENDENCY
+        if endpoint == "/meta_knowledge_graph":
+            return (
+                None
+                if (self.tier0["up"] or self.tier1["up"])
+                else HTTPStatus.FAILED_DEPENDENCY
+            )
+        return None
+
+    def select_tier(
+        self,
+        body: TRAPIQuery | TRAPIAsyncQuery | None,
+        requested: TierNumber,
+        *,
+        allow_fallback: bool = True,
+    ) -> tuple[TierNumber, list[LogEntryDict]] | tuple[HTTPStatus, ErrorDetail]:
+        """Resolve `requested` into an effective tier, or a 424/501 body to return.
+
+        Success: `(effective_tier, fallback_warnings)`. `fallback_warnings`
+        carries a tier-fallback `LogEntry` when the request was redirected;
+        empty list otherwise.
+
+        Failure: `(status, ErrorDetail)`. Status is `501 Not Implemented`
+        for tier 2, `424 Failed Dependency` otherwise.
+
+        `allow_fallback=False` (per-tier endpoints with no body) disables
+        fallback explicitly; a `tier_fallback=False` parameter on a query
+        body has the same effect.
+        """
+        fallback_enabled = allow_fallback and (
+            body.parameters.tier_fallback
+            if body is not None and body.parameters is not None
+            else True
+        )
+        requested_health = self._tier_health(requested)
+
+        if requested_health is not None and requested_health["up"]:
+            return requested, []
+
+        if requested == _T2 and requested_health is None:
+            return HTTPStatus.NOT_IMPLEMENTED, ErrorDetail(
+                detail="Tier 2 not yet implemented.",
+            )
+
+        if requested == _T2:
+            return HTTPStatus.FAILED_DEPENDENCY, outage_detail(
+                "Tier 2 is unavailable with no fallback.",
+                tier_manager.get_driver(_T2),
+            )
+
+        if not fallback_enabled:
+            return HTTPStatus.FAILED_DEPENDENCY, outage_detail(
+                f"Tier {requested} is unavailable; tier fallback was disabled by the request.",
+                tier_manager.get_driver(requested),
+            )
+
+        other: TierNumber = 1 if requested == 0 else 0
+        other_health = self._tier_health(other)
+        if other_health is not None and other_health["up"]:
+            return other, [tier_fallback_warning(requested, other)]
+
+        return HTTPStatus.FAILED_DEPENDENCY, outage_detail(
+            f"Tier {requested} is unavailable; fallback Tier {other} is also unavailable.",
+            tier_manager.get_driver(requested),
+        )

--- a/src/retriever/utils/version.py
+++ b/src/retriever/utils/version.py
@@ -1,0 +1,78 @@
+"""Shared lookup for the running build's git commit + branch.
+
+Two callers (status.py for /status, server.py for /config) used to each
+spawn their own gitpython lookup on every request. Now both go through
+`get_version()`, which resolves in this order:
+
+  1. `RETRIEVER_GIT_COMMIT` / `RETRIEVER_GIT_BRANCH` env vars — an
+     explicit override for deployments that bake version info via env.
+  2. `_version_commit.txt` / `_version_branch.txt` sitting next to this
+     module — the Dockerfile writes these at build time via `git
+     rev-parse` so shipped images report the real SHA out of the box.
+  3. A runtime gitpython lookup — used for editable / `uv run` dev
+     installs where the source tree's `.git` is reachable.
+  4. Fallback `("unknown", None)`, logged once per worker.
+
+Result is cached so the answer is computed once per process.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from pathlib import Path
+
+import git
+from loguru import logger
+
+_PKG_DIR = Path(__file__).parent.parent
+_COMMIT_FILE = _PKG_DIR / "_version_commit.txt"
+_BRANCH_FILE = _PKG_DIR / "_version_branch.txt"
+
+
+def _read_baked() -> tuple[str, str | None] | None:
+    """Read `(sha, branch)` from the Dockerfile-baked version files.
+
+    Returns None when the commit file is missing or empty (e.g. local
+    `uv run` outside a container, or a build where `git rev-parse`
+    couldn't read the repo).
+    """
+    if not _COMMIT_FILE.exists():
+        return None
+    sha = _COMMIT_FILE.read_text().strip()
+    if not sha:
+        return None
+    branch_raw = _BRANCH_FILE.read_text().strip() if _BRANCH_FILE.exists() else ""
+    # `git rev-parse --abbrev-ref HEAD` returns "HEAD" on detached HEAD;
+    # treat that (and empty) as "no branch".
+    branch = None if branch_raw in ("", "HEAD") else branch_raw
+    return sha, branch
+
+
+@functools.cache
+def get_version() -> tuple[str, str | None]:
+    """Return `(git_commit, git_branch)` for the running build."""
+    env_sha = os.environ.get("RETRIEVER_GIT_COMMIT")
+    if env_sha:
+        env_branch = os.environ.get("RETRIEVER_GIT_BRANCH") or None
+        return env_sha, env_branch
+
+    baked = _read_baked()
+    if baked is not None:
+        return baked
+
+    try:
+        repo = git.Repo(search_parent_directories=True)
+        sha = repo.head.object.hexsha
+        try:
+            branch = repo.active_branch.name
+        except TypeError:
+            # Detached HEAD — no active branch.
+            branch = None
+        return sha, branch
+    except Exception:
+        logger.info(
+            "Git metadata unavailable; reporting version as 'unknown'.",
+            no_mongo_log=True,
+        )
+        return "unknown", None

--- a/src/retriever/utils/version.py
+++ b/src/retriever/utils/version.py
@@ -4,12 +4,12 @@ Two callers (status.py for /status, server.py for /config) used to each
 spawn their own gitpython lookup on every request. Now both go through
 `get_version()`, which resolves in this order:
 
-  1. `RETRIEVER_GIT_COMMIT` / `RETRIEVER_GIT_BRANCH` env vars — an
+  1. `RETRIEVER_GIT_COMMIT` / `RETRIEVER_GIT_BRANCH` env vars - an
      explicit override for deployments that bake version info via env.
   2. `_version_commit.txt` / `_version_branch.txt` sitting next to this
-     module — the Dockerfile writes these at build time via `git
+     module - the Dockerfile writes these at build time via `git
      rev-parse` so shipped images report the real SHA out of the box.
-  3. A runtime gitpython lookup — used for editable / `uv run` dev
+  3. A runtime gitpython lookup - used for editable / `uv run` dev
      installs where the source tree's `.git` is reachable.
   4. Fallback `("unknown", None)`, logged once per worker.
 
@@ -67,7 +67,7 @@ def get_version() -> tuple[str, str | None]:
         try:
             branch = repo.active_branch.name
         except TypeError:
-            # Detached HEAD — no active branch.
+            # Detached HEAD - no active branch.
             branch = None
         return sha, branch
     except Exception:

--- a/src/retriever/utils/worker.py
+++ b/src/retriever/utils/worker.py
@@ -1,0 +1,31 @@
+"""Per-worker process identity, set once at lifespan startup.
+
+Populated by `server.py` lifespan via `init()`. Read by `query.py` at
+job-creation time. A separate module avoids the server → query circular import.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+# Mutable container avoids module-level `global` statements.
+_identity: dict[str, int | datetime | None] = {"pid": None, "started_at": None}
+
+
+def init(started_at: datetime) -> None:
+    """Capture this worker's PID and start time. Called once from lifespan."""
+    _identity["pid"] = os.getpid()
+    _identity["started_at"] = started_at
+
+
+def get_pid() -> int | None:
+    """Return the PID captured at init, or None if init has not been called."""
+    pid = _identity["pid"]
+    return pid if isinstance(pid, int) else None
+
+
+def get_started_at() -> datetime | None:
+    """Return the started_at captured at init, or None if not yet called."""
+    started_at = _identity["started_at"]
+    return started_at if isinstance(started_at, datetime) else None

--- a/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
+++ b/tests/data_tiers/tier_1/elasticsearch_tests/test_tier1_driver.py
@@ -121,7 +121,7 @@ PAYLOAD_2: ESPayload = esp({
 async def test_elasticsearch_driver(payload: ESPayload | list[ESPayload], expected: int | list[int]):
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
@@ -149,7 +149,7 @@ async def test_elasticsearch_driver(payload: ESPayload | list[ESPayload], expect
     else:
         assert_single_result(hits, expected)
 
-    await driver.close()
+    await driver.wrapup()
 
 
 @pytest.mark.parametrize(
@@ -173,7 +173,7 @@ async def test_valid_regex_query():
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
@@ -181,7 +181,7 @@ async def test_valid_regex_query():
     for payload in qgraphs_with_valid_regex:
         hits: list[ESEdge] = await driver.run_query(payload)
 
-    await driver.close()
+    await driver.wrapup()
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
@@ -190,7 +190,7 @@ async def test_metadata_retrieval():
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
@@ -211,7 +211,7 @@ async def test_metadata_retrieval():
 
     # assert len(nodes) == 23
 
-    await driver.close()
+    await driver.wrapup()
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
@@ -220,7 +220,7 @@ async def test_fetch_single_node():
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping fetch_single_node test: cannot connect")
@@ -233,36 +233,38 @@ async def test_fetch_single_node():
     assert len(node.category) > 0
     assert node.name == "N-acyl-L-alpha-amino acid"
 
-    await driver.close()
+    await driver.wrapup()
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "qgraph, expected_hits",
+    "qgraph, min_hits",
     [
+        # Lower-bound floors instead of exact counts so the test survives
+        # data growth in the live ES index.
         (DINGO_QGRAPH, 8),
-        (ID_BYPASS_PAYLOAD, 4176),  # <-- adjust to the real number
+        (ID_BYPASS_PAYLOAD, 4000),
         (EXPANDED_QUALIFIER_QGRAPH, 1),
     ],
 )
-async def test_end_to_end(qgraph, expected_hits):
+async def test_end_to_end(qgraph, min_hits):
     transpiler = ElasticsearchTranspiler()
     payload = _convert_triple(transpiler, qgraph)
 
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
 
     hits: list[ESEdge] = await driver.run_query(payload)
 
-    assert len(hits) == expected_hits
+    assert len(hits) >= min_hits
 
-    await driver.close()
+    await driver.wrapup()
 
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
@@ -279,7 +281,7 @@ async def test_cache_bypass():
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping bypass_cache test: cannot connect to elasticsearch")
@@ -298,7 +300,7 @@ async def test_cache_bypass():
     # (since adding timestamp constraint can only reduce or maintain result count)
     assert len(hits_with_bypass) == len(hits_without_bypass)
 
-    await driver.close()
+    await driver.wrapup()
 
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
@@ -314,7 +316,7 @@ async def test_cache_bypass_batch_query():
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
 
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping batch bypass_cache test: cannot connect to elasticsearch")
@@ -335,7 +337,7 @@ async def test_cache_bypass_batch_query():
     assert len(hits_with_bypass[0]) == len(hits_without_bypass[0])
     assert len(hits_with_bypass[1]) == len(hits_without_bypass[1])
 
-    await driver.close()
+    await driver.wrapup()
 
 
 
@@ -389,9 +391,10 @@ async def test_cache_bypass_timestamp_structure(monkeypatch: pytest.MonkeyPatch)
 
     assert timestamp_filter_found, "Timestamp filter not correctly added to query"
 
-    await driver.close()
+    await driver.wrapup()
 
 
+@pytest.mark.live
 @pytest.mark.usefixtures("mock_elasticsearch_config")
 @pytest.mark.asyncio
 async def test_ubergraph_info_retrieval():
@@ -402,19 +405,16 @@ async def test_ubergraph_info_retrieval():
 
     driver: driver_mod.ElasticSearchDriver = driver_mod.ElasticSearchDriver()
     try:
-        await driver.connect()
+        await driver.initialize()
         assert driver.es_connection is not None
     except Exception:
         pytest.skip("skipping es driver connection test: cannot connect")
 
     info = await driver.get_subclass_mapping(bypass_cache=True)
 
-    # print("total nodes", len(info["nodes"]))
-    # print("adj list sample:")
-    # for k, v in islice(info['mapping'].items(), 5):
-    #     print(k, v)
+    # Lower-bound floor: ubergraph grows over time; verify the load
+    # happened and produced a non-trivial mapping rather than locking
+    # to a moment-in-time count.
+    assert len(info) > 100_000
 
-    # assert "mapping" in info
-    assert len(info) == 122176
-
-    await driver.close()
+    await driver.wrapup()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,8 @@
 """Tests for query dispatch in retriever.query.
 
-Focused on the timeout and tier resolution that make_query performs before
-handing a QueryInfo off to the relevant query function.
+Focused on the timeout and tier resolution that the per-endpoint
+make_*_query functions perform before handing a QueryInfo off to the
+relevant query function.
 """
 
 from types import SimpleNamespace
@@ -34,8 +35,9 @@ def _lookup_body(parameters: Parameters | None = None) -> TRAPIQuery:
 
 
 async def _run(func, ctx, **kwargs) -> QueryInfo:
-    """Run make_query with all query functions mocked, returning the QueryInfo
-    that was dispatched so its resolved timeout/tier can be asserted."""
+    """Run the relevant make_*_query function with all query functions mocked,
+    returning the QueryInfo that was dispatched so its resolved timeout/tier
+    can be asserted."""
     captured: dict[str, QueryInfo] = {}
 
     async def capture(query: QueryInfo):
@@ -49,7 +51,12 @@ async def _run(func, ctx, **kwargs) -> QueryInfo:
         patch.object(query_module, "get_metadata", stub),
         patch.object(query_module.MONGO_QUEUE, "put", Mock()),
     ):
-        await query_module.make_query(func, ctx, **kwargs)
+        if func == "lookup":
+            await query_module.make_lookup_query(ctx, body=kwargs["body"])
+        elif func == "metakg":
+            await query_module.make_metakg_query(ctx, tier=kwargs.get("tier"))
+        else:  # metadata
+            await query_module.make_metadata_query(ctx, tier=kwargs["tier"])
     return captured["query"]
 
 
@@ -62,7 +69,7 @@ async def test_metadata_timeout_uses_metakg_default():
     timeout, not the boolean False (== 0) that caused instant timeouts."""
     query = await _run("metadata", _ctx(), tier=1)
     assert query.timeout == CONFIG.job.metakg.timeout
-    assert query.timeout is not False  # noqa: E712 — guard against the regression
+    assert query.timeout is not False  # noqa: E712 - guard against the regression
 
 
 @pytest.mark.asyncio
@@ -107,13 +114,6 @@ async def test_metadata_tier_passed_through():
 
 
 @pytest.mark.asyncio
-async def test_non_metakg_tier_defaults_to_zero():
-    """A missing tier defaults to 0 for non-metakg requests."""
-    query = await _run("metadata", _ctx(), tier=None)
-    assert query.tier == 0
-
-
-@pytest.mark.asyncio
 async def test_metakg_tier_stays_none():
     """metakg leaves tier unset (None) when none is provided."""
     query = await _run("metakg", _ctx(path="/meta_knowledge_graph"), tier=None)
@@ -123,9 +123,9 @@ async def test_metakg_tier_stays_none():
 @pytest.mark.asyncio
 async def test_custom_tier_param_overrides():
     """parameters.tier overrides the default/path tier."""
-    body = _lookup_body(Parameters(tier=2))
+    body = _lookup_body(Parameters(tier=1))
     query = await _run("lookup", _ctx("POST", "/query"), body=body)
-    assert query.tier == 2
+    assert query.tier == 1
 
 
 @pytest.mark.asyncio
@@ -139,6 +139,6 @@ async def test_deprecated_tiers_param_applied():
 @pytest.mark.asyncio
 async def test_custom_tier_takes_precedence_over_deprecated_tiers():
     """parameters.tier wins over the deprecated parameters.tiers."""
-    body = _lookup_body(Parameters(tiers=[1], tier=2))
+    body = _lookup_body(Parameters(tiers=[0], tier=1))
     query = await _run("lookup", _ctx("POST", "/query"), body=body)
-    assert query.tier == 2
+    assert query.tier == 1

--- a/tests/test_status_live.py
+++ b/tests/test_status_live.py
@@ -41,8 +41,10 @@ async def status_client(test_mongo: MongoClient):  # noqa: F811
 async def test_active_returns_in_flight(status_client: AsyncClient) -> None:
     resp = await status_client.get("/status/active")
     assert resp.status_code == 200
-    rows = resp.json()
+    page = resp.json()
+    rows = page["items"]
     assert len(rows) == 2
+    assert page["next_cursor"] is None
     for row in rows:
         assert row["age_seconds"] >= 0
         # Links should be absolute URLs so they're clickable from a browser.
@@ -236,8 +238,10 @@ async def test_stuck_with_min_age(status_client: AsyncClient) -> None:
     # should include both.
     resp = await status_client.get("/status/stuck", params={"min_age": 0.01})
     assert resp.status_code == 200
-    rows = resp.json()
+    page = resp.json()
+    rows = page["items"]
     assert len(rows) == 2
+    assert page["next_cursor"] is None
     for row in rows:
         assert row["age_seconds"] >= int(0.01 * 3600)
 

--- a/tests/test_status_live.py
+++ b/tests/test_status_live.py
@@ -39,7 +39,7 @@ async def status_client(test_mongo: MongoClient):  # noqa: F811
 
 @pytest.mark.asyncio
 async def test_active_returns_in_flight(status_client: AsyncClient) -> None:
-    resp = await status_client.get("/status/active")
+    resp = await status_client.get("/status/running")
     assert resp.status_code == 200
     page = resp.json()
     rows = page["items"]
@@ -59,8 +59,8 @@ async def test_counts_breakdown(status_client: AsyncClient) -> None:
     body = resp.json()
     all_time = body["windows"]["all_time"]
     counts: dict[str, int] = all_time["counts"]
-    # Seed has 6 Complete, 3 failure-statuses, 2 Running.
-    assert counts.get("Complete") == 6
+    # Seed has 6 Success, 3 failure-statuses, 2 Running.
+    assert counts.get("Success") == 6
     assert counts.get("Failed") == 1
     assert counts.get("QueryNotTraversable") == 1
     assert counts.get("UnsupportedConstraint") == 1
@@ -100,9 +100,10 @@ async def test_failed_with_reason_filter(status_client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_durations_default_complete(status_client: AsyncClient) -> None:
-    # Default status="Complete", default lookback=24h; the older completed
-    # job is outside the window. So expect 5 samples, not 6.
+async def test_durations_default_completed(status_client: AsyncClient) -> None:
+    # Default status="Completed" (mapped to stored "Success"); default
+    # lookback=24h. The older completed job is outside the window, so we
+    # expect 5 samples, not 6.
     resp = await status_client.get("/status/durations")
     assert resp.status_code == 200
     body = resp.json()

--- a/tests/test_status_live.py
+++ b/tests/test_status_live.py
@@ -1,0 +1,251 @@
+"""Live integration tests for the /status/* route handlers.
+
+Run with: `pytest -m live tests/test_status_live.py`. Requires docker
+compose Mongo + Dragonfly. Uses the same seeded test DB pattern as
+tests/test_utils_mongo_live.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from utils.mongo_fixtures import (
+    test_mongo,  # noqa: F401  pyright:ignore[reportImplicitRelativeImport]  # fixture
+)
+
+from retriever.status import router as status_router
+from retriever.utils.mongo import MongoClient
+
+pytestmark = pytest.mark.live
+
+
+@pytest_asyncio.fixture
+async def status_client(test_mongo: MongoClient):  # noqa: F811
+    """Provide an httpx AsyncClient bound to a minimal app mounting just /status.
+
+    The `test_mongo` fixture monkeypatches the MongoClient singleton, so the
+    handlers see the seeded test DB instead of production data.
+    """
+    app = FastAPI()
+    app.include_router(status_router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_active_returns_in_flight(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/active")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 2
+    for row in rows:
+        assert row["age_seconds"] >= 0
+        # Links should be absolute URLs so they're clickable from a browser.
+        assert row["links"]["logs"].startswith("http://test/logs?job_id=")
+        assert row["links"]["response"].startswith("http://test/response/")
+
+
+@pytest.mark.asyncio
+async def test_counts_breakdown(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/counts")
+    assert resp.status_code == 200
+    body = resp.json()
+    all_time = body["windows"]["all_time"]
+    counts: dict[str, int] = all_time["counts"]
+    # Seed has 6 Complete, 3 failure-statuses, 2 Running.
+    assert counts.get("Complete") == 6
+    assert counts.get("Failed") == 1
+    assert counts.get("QueryNotTraversable") == 1
+    assert counts.get("UnsupportedConstraint") == 1
+    assert counts.get("Running") == 2
+    assert all_time["links"]["completed"] == "http://test/status/completed"
+    assert all_time["links"]["failed"] == "http://test/status/failed"
+
+
+@pytest.mark.asyncio
+async def test_completed_pagination(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/completed", params={"limit": 2})
+    assert resp.status_code == 200
+    page1 = resp.json()
+    assert len(page1["items"]) == 2
+    assert page1["next_cursor"] is not None
+
+    resp2 = await status_client.get(
+        "/status/completed", params={"limit": 2, "cursor": page1["next_cursor"]}
+    )
+    assert resp2.status_code == 200
+    page2 = resp2.json()
+    assert len(page2["items"]) <= 2
+
+    # First-page job_ids and second-page job_ids should be disjoint.
+    page1_ids = {row["job_id"] for row in page1["items"]}
+    page2_ids = {row["job_id"] for row in page2["items"]}
+    assert page1_ids.isdisjoint(page2_ids)
+
+
+@pytest.mark.asyncio
+async def test_failed_with_reason_filter(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/failed", params={"reason": "Failed"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["status"] == "Failed"
+
+
+@pytest.mark.asyncio
+async def test_durations_default_complete(status_client: AsyncClient) -> None:
+    # Default status="Complete", default lookback=24h; the older completed
+    # job is outside the window. So expect 5 samples, not 6.
+    resp = await status_client.get("/status/durations")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sample_size"] == 5
+    assert body["min_seconds"] > 0
+    assert body["max_seconds"] >= body["min_seconds"]
+
+
+@pytest.mark.asyncio
+async def test_timeline_default(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/timeline",
+        params={"field": "completed", "granularity": "hour", "lookback": 24.0},
+    )
+    assert resp.status_code == 200
+    buckets = resp.json()
+    assert isinstance(buckets, list)
+    assert len(buckets) >= 1
+    for b in buckets:
+        assert "bucket_start" in b
+        assert b["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_tiers(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/tiers")
+    assert resp.status_code == 200
+    rows = resp.json()
+    by_tier: dict[int, dict[str, Any]] = {row["tier"]: row for row in rows}
+    assert 0 in by_tier
+    assert by_tier[0]["active"] >= 1
+    assert 1 in by_tier
+    assert by_tier[1]["failed"] == 3
+
+
+@pytest.mark.asyncio
+async def test_submitters(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/submitters")
+    assert resp.status_code == 200
+    rows = resp.json()
+    by_submitter: dict[str, dict[str, Any]] = {r["submitter"]: r for r in rows}
+    assert "alice" in by_submitter
+    assert "bob" in by_submitter
+    assert by_submitter["alice"]["success_rate"] == 1.0
+    assert by_submitter["bob"]["success_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_submitter_tier_stats(status_client: AsyncClient) -> None:
+    resp = await status_client.get("/status/submitter_tier_stats")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) > 0
+    by_cell = {(r["submitter"], r["tier"]): r for r in rows}
+    # Seed has alice on tier 0 and bob on tier 1.
+    assert ("alice", 0) in by_cell
+    assert ("bob", 1) in by_cell
+    alice_t0 = by_cell[("alice", 0)]
+    assert alice_t0["count"] >= 1
+    assert alice_t0["completed"] >= 1
+    assert alice_t0["failed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_failure_breakdown_by_submitter(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/failure_breakdown", params={"by": "submitter"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["by"] == "submitter"
+    by_key = {(r["key"], r["status"]): r["count"] for r in body["rows"]}
+    # Bob's failed jobs cover the three terminal-failure statuses in the seed.
+    assert ("bob", "Failed") in by_key
+    assert by_key[("bob", "Failed")] >= 1
+
+
+@pytest.mark.asyncio
+async def test_failure_breakdown_by_tier(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/failure_breakdown", params={"by": "tier"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["by"] == "tier"
+    # Tier keys are stringified ints; failures live on tier 1 in the seed.
+    by_key = {(r["key"], r["status"]): r["count"] for r in body["rows"]}
+    assert any(k[0] == "1" for k in by_key)
+    total_tier_1 = sum(v for k, v in by_key.items() if k[0] == "1")
+    assert total_tier_1 == 3
+
+
+@pytest.mark.asyncio
+async def test_completed_sort_by_duration_desc(status_client: AsyncClient) -> None:
+    # The /slow endpoint was folded into /completed?sort=duration.
+    resp = await status_client.get(
+        "/status/completed",
+        params={"sort": "duration", "direction": "desc"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    durations = [row["duration_seconds"] for row in body["items"]]
+    assert durations == sorted(durations, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_completed_sort_by_submitter_asc(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/completed",
+        params={"sort": "submitter", "direction": "asc"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    submitters = [row["submitter"] for row in body["items"]]
+    assert submitters == sorted(submitters)
+
+
+@pytest.mark.asyncio
+async def test_completed_sort_by_results_desc(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/completed",
+        params={"sort": "results", "direction": "desc"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    results = [row["results"] for row in body["items"]]
+    assert results == sorted(results, reverse=True)
+
+
+@pytest.mark.asyncio
+async def test_stuck_with_min_age(status_client: AsyncClient) -> None:
+    # Seeded "Running" jobs were created ~2 minutes ago; min_age=0.01 (≈36s)
+    # should include both.
+    resp = await status_client.get("/status/stuck", params={"min_age": 0.01})
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 2
+    for row in rows:
+        assert row["age_seconds"] >= int(0.01 * 3600)
+
+
+@pytest.mark.asyncio
+async def test_server_logs_flat(status_client: AsyncClient) -> None:
+    resp = await status_client.get(
+        "/status/server_logs", params={"fmt": "flat", "lookback": 1.0}
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")

--- a/tests/test_utils_job_status.py
+++ b/tests/test_utils_job_status.py
@@ -1,0 +1,35 @@
+"""Unit tests for the job-status vocabulary helpers."""
+
+from retriever.utils.job_status import (
+    NON_TERMINAL,
+    TERMINAL_FAILURE,
+    TERMINAL_SUCCESS,
+    resolve_status_filter,
+)
+
+
+def test_status_sets_are_disjoint() -> None:
+    """No status string should appear in more than one of the three sets."""
+    assert NON_TERMINAL.isdisjoint(TERMINAL_SUCCESS)
+    assert NON_TERMINAL.isdisjoint(TERMINAL_FAILURE)
+    assert TERMINAL_SUCCESS.isdisjoint(TERMINAL_FAILURE)
+
+
+def test_failure_set_excludes_error() -> None:
+    """`Error` is a TRAPI response status, not a persisted job status."""
+    assert "Error" not in TERMINAL_FAILURE
+
+
+def test_resolve_status_filter_none_passthrough() -> None:
+    assert resolve_status_filter(None) is None
+
+
+def test_resolve_status_filter_failed_alias() -> None:
+    resolved = resolve_status_filter("failed")
+    assert isinstance(resolved, list)
+    assert set(resolved) == TERMINAL_FAILURE
+
+
+def test_resolve_status_filter_specific_status_passthrough() -> None:
+    assert resolve_status_filter("Complete") == "Complete"
+    assert resolve_status_filter("Running") == "Running"

--- a/tests/test_utils_mongo_live.py
+++ b/tests/test_utils_mongo_live.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.live
 @pytest.mark.asyncio
 async def test_ping_db_storage_count_in_flight(test_mongo: MongoClient) -> None:  # noqa: F811
     """Smoke-test the three connection/inventory methods."""
-    assert await test_mongo.ping() is True
+    await test_mongo.ping()  # raises on failure; no truthy return to assert on
     assert await test_mongo.db_storage_bytes() >= 0
     # Two in-flight jobs were seeded (one per tier).
     assert await test_mongo.count_in_flight() == 2
@@ -60,7 +60,7 @@ async def test_compute_durations_basic(test_mongo: MongoClient) -> None:  # noqa
     assert stats["avg_seconds"] > 0.0
 
     if test_mongo._supports_percentile:
-        # Approximate percentile — assert it's within the data range, not a
+        # Approximate percentile - assert it's within the data range, not a
         # specific value (Mongo uses an approximation).
         assert "p50_seconds" in stats
         assert "p95_seconds" in stats

--- a/tests/test_utils_mongo_live.py
+++ b/tests/test_utils_mongo_live.py
@@ -1,0 +1,125 @@
+"""Live tests for the MongoClient /status-API additions.
+
+Run with: `pytest -m live tests/test_utils_mongo_live.py`. Requires the
+docker compose Mongo container (or another Mongo reachable at the
+configured host) to be up. Uses an ephemeral test DB and drops it on
+teardown so production data isn't affected.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from retriever.utils.job_status import TERMINAL_FAILURE
+from retriever.utils.mongo import (
+    JobIdentityFilter,
+    JobTimeFilter,
+    MongoClient,
+)
+from utils.mongo_fixtures import test_mongo  # noqa: F401  pyright:ignore[reportImplicitRelativeImport]  # fixture import
+
+pytestmark = pytest.mark.live
+
+
+@pytest.mark.asyncio
+async def test_ping_db_storage_count_in_flight(test_mongo: MongoClient) -> None:  # noqa: F811
+    """Smoke-test the three connection/inventory methods."""
+    assert await test_mongo.ping() is True
+    assert await test_mongo.db_storage_bytes() >= 0
+    # Two in-flight jobs were seeded (one per tier).
+    assert await test_mongo.count_in_flight() == 2
+
+
+@pytest.mark.asyncio
+async def test_count_jobs_with_status_filter(test_mongo: MongoClient) -> None:  # noqa: F811
+    """`count_jobs` respects identity filters built via _build_filter_query."""
+    completed = await test_mongo.count_jobs(
+        identity=JobIdentityFilter(status="Complete")
+    )
+    # Five recent + one old completed.
+    assert completed == 6
+
+    failed = await test_mongo.count_jobs(
+        identity=JobIdentityFilter(status=sorted(TERMINAL_FAILURE))
+    )
+    assert failed == 3
+
+
+@pytest.mark.asyncio
+async def test_compute_durations_basic(test_mongo: MongoClient) -> None:  # noqa: F811
+    """`compute_durations` returns sensible stats; percentile fields only when supported."""
+    stats = await test_mongo.compute_durations(
+        identity=JobIdentityFilter(status="Complete")
+    )
+    # 5 recent (1..5s) + 1 old (30s) = 6 samples; min 1.0, max 30.0.
+    assert stats["sample_size"] == 6
+    assert stats["min_seconds"] == pytest.approx(1.0)
+    assert stats["max_seconds"] == pytest.approx(30.0)
+    assert stats["avg_seconds"] > 0.0
+
+    if test_mongo._supports_percentile:
+        # Approximate percentile — assert it's within the data range, not a
+        # specific value (Mongo uses an approximation).
+        assert "p50_seconds" in stats
+        assert "p95_seconds" in stats
+        assert "p99_seconds" in stats
+        assert stats["min_seconds"] <= stats["p50_seconds"] <= stats["max_seconds"]
+    else:
+        assert "p50_seconds" not in stats
+
+
+@pytest.mark.asyncio
+async def test_submitter_stats(test_mongo: MongoClient) -> None:  # noqa: F811
+    """`submitter_stats` returns per-submitter counts and success_rate."""
+    rows = await test_mongo.submitter_stats(top=10)
+    by_submitter = {row["submitter"]: row for row in rows}
+
+    # alice: 6 Complete + 1 Running = 7 total; 6 terminal (all success); rate = 1.0.
+    assert "alice" in by_submitter
+    alice = by_submitter["alice"]
+    assert alice["count"] == 7
+    assert alice["completed"] == 6
+    assert alice["failed"] == 0
+    assert alice["success_rate"] == pytest.approx(1.0)
+
+    # bob: 3 Failed* + 1 Running = 4 total; 3 terminal (all failure); rate = 0.0.
+    assert "bob" in by_submitter
+    bob = by_submitter["bob"]
+    assert bob["count"] == 4
+    assert bob["completed"] == 0
+    assert bob["failed"] == 3
+    assert bob["success_rate"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_tier_stats(test_mongo: MongoClient) -> None:  # noqa: F811
+    """`tier_stats` aggregates active + completed + failed per tier."""
+    rows = await test_mongo.tier_stats()
+    by_tier = {row["tier"]: row for row in rows}
+
+    # Tier 0: 6 completed (5 + 1 old) + 1 active
+    assert 0 in by_tier
+    assert by_tier[0]["active"] == 1
+    assert by_tier[0]["completed"] == 6
+    assert by_tier[0]["failed"] == 0
+
+    # Tier 1: 0 completed, 3 failed, 1 active
+    assert 1 in by_tier
+    assert by_tier[1]["active"] == 1
+    assert by_tier[1]["completed"] == 0
+    assert by_tier[1]["failed"] == 3
+
+
+@pytest.mark.asyncio
+async def test_compute_durations_empty_window(test_mongo: MongoClient) -> None:  # noqa: F811
+    """Empty windows return all-zero stats without errors."""
+    future = datetime.now().astimezone() + timedelta(days=365)
+    stats = await test_mongo.compute_durations(
+        times=JobTimeFilter(completed={"after": future})
+    )
+    assert stats["sample_size"] == 0
+    assert stats["min_seconds"] == 0.0
+    assert stats["max_seconds"] == 0.0
+    assert stats["avg_seconds"] == 0.0

--- a/tests/test_utils_mongo_live.py
+++ b/tests/test_utils_mongo_live.py
@@ -36,7 +36,7 @@ async def test_ping_db_storage_count_in_flight(test_mongo: MongoClient) -> None:
 async def test_count_jobs_with_status_filter(test_mongo: MongoClient) -> None:  # noqa: F811
     """`count_jobs` respects identity filters built via _build_filter_query."""
     completed = await test_mongo.count_jobs(
-        identity=JobIdentityFilter(status="Complete")
+        identity=JobIdentityFilter(status="Success")
     )
     # Five recent + one old completed.
     assert completed == 6
@@ -51,7 +51,7 @@ async def test_count_jobs_with_status_filter(test_mongo: MongoClient) -> None:  
 async def test_compute_durations_basic(test_mongo: MongoClient) -> None:  # noqa: F811
     """`compute_durations` returns sensible stats; percentile fields only when supported."""
     stats = await test_mongo.compute_durations(
-        identity=JobIdentityFilter(status="Complete")
+        identity=JobIdentityFilter(status="Success")
     )
     # 5 recent (1..5s) + 1 old (30s) = 6 samples; min 1.0, max 30.0.
     assert stats["sample_size"] == 6

--- a/tests/test_utils_redis_live.py
+++ b/tests/test_utils_redis_live.py
@@ -1,0 +1,78 @@
+"""Live tests for the RedisClient /status-API additions.
+
+Run with: `pytest -m live tests/test_utils_redis_live.py`. Requires the
+docker compose Dragonfly container (or another Redis-compatible server)
+to be up. Each test uses a unique key prefix and cleans up via short
+TTLs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+
+from retriever.utils.redis import (
+    PREFIX,
+    WORKER_REGISTRY_KEY,
+    RedisClient,
+)
+
+pytestmark = pytest.mark.live
+
+
+@pytest_asyncio.fixture
+async def redis_client():
+    """Provide an initialized RedisClient, scrubbing any test keys on teardown."""
+    client = RedisClient()
+    await client.initialize()
+    try:
+        yield client
+    finally:
+        # Best-effort teardown — TTLs handle anything we miss.
+        with contextlib.suppress(Exception):
+            await client.client.delete(WORKER_REGISTRY_KEY)
+
+
+@pytest.mark.asyncio
+async def test_ping(redis_client: RedisClient) -> None:
+    """Liveness ping should return True against a healthy server."""
+    assert await redis_client.ping() is True
+
+
+@pytest.mark.asyncio
+async def test_used_memory_bytes(redis_client: RedisClient) -> None:
+    """INFO MEMORY should return a positive used_memory integer."""
+    assert await redis_client.used_memory_bytes() > 0
+
+
+@pytest.mark.asyncio
+async def test_freshness_roundtrip(redis_client: RedisClient) -> None:
+    """write_freshness then _read_freshness should round-trip the payload."""
+    key = f"{PREFIX}test-freshness:{uuid.uuid4().hex[:8]}"
+    try:
+        await redis_client.write_freshness(key, count=42, ttl=60)
+        record = await redis_client._read_freshness(key)
+        assert record is not None
+        assert record["count"] == 42
+        # Refreshed within the last few seconds.
+        delta = datetime.now().astimezone() - record["refreshed_at"]
+        assert delta.total_seconds() < 5
+    finally:
+        await redis_client.client.delete(key)
+
+
+@pytest.mark.asyncio
+async def test_worker_registry_roundtrip(redis_client: RedisClient) -> None:
+    """register_worker → list_workers → presence."""
+    pid = 999999  # unlikely to collide with a real process pid
+    started = datetime.now().astimezone()
+
+    await redis_client.register_worker(pid, started, ttl_seconds=60)
+    workers = await redis_client.list_workers()
+    assert pid in workers
+    # Round-trip within ~1s tolerance.
+    assert abs((workers[pid] - started).total_seconds()) < 1.0

--- a/tests/test_utils_redis_live.py
+++ b/tests/test_utils_redis_live.py
@@ -32,15 +32,15 @@ async def redis_client():
     try:
         yield client
     finally:
-        # Best-effort teardown — TTLs handle anything we miss.
+        # Best-effort teardown - TTLs handle anything we miss.
         with contextlib.suppress(Exception):
             await client.client.delete(WORKER_REGISTRY_KEY)
 
 
 @pytest.mark.asyncio
 async def test_ping(redis_client: RedisClient) -> None:
-    """Liveness ping should return True against a healthy server."""
-    assert await redis_client.ping() is True
+    """ping should return without raising against a healthy server."""
+    await redis_client.ping()
 
 
 @pytest.mark.asyncio

--- a/tests/utils/mongo_fixtures.py
+++ b/tests/utils/mongo_fixtures.py
@@ -74,9 +74,9 @@ async def _seed(collection: AsyncIOMotorCollection[dict[str, Any]]) -> None:
         duration = timedelta(seconds=i + 1)
         docs.append(
             _status_doc(
-                status="Complete",
+                status="Success",
                 submitter="alice",
-                tiers=[0],
+                tier=0,
                 created=created,
                 completed=created + duration,
                 results=10 + i,
@@ -95,7 +95,7 @@ async def _seed(collection: AsyncIOMotorCollection[dict[str, Any]]) -> None:
             _status_doc(
                 status=failure_status,
                 submitter="bob",
-                tiers=[1],
+                tier=1,
                 created=created,
                 completed=created + duration,
                 results=0,
@@ -107,7 +107,7 @@ async def _seed(collection: AsyncIOMotorCollection[dict[str, Any]]) -> None:
         _status_doc(
             status="Running",
             submitter="alice" if tier == 0 else "bob",
-            tiers=[tier],
+            tier=tier,
             created=now - timedelta(minutes=2),
             completed=None,
             results=0,
@@ -119,9 +119,9 @@ async def _seed(collection: AsyncIOMotorCollection[dict[str, Any]]) -> None:
     old = now - timedelta(days=7)
     docs.append(
         _status_doc(
-            status="Complete",
+            status="Success",
             submitter="alice",
-            tiers=[0],
+            tier=0,
             created=old,
             completed=old + timedelta(seconds=30),
             results=100,
@@ -135,7 +135,7 @@ def _status_doc(  # noqa: PLR0913
     *,
     status: str,
     submitter: str,
-    tiers: list[int],
+    tier: int,
     created: datetime,
     completed: datetime | None,
     results: int,
@@ -145,12 +145,12 @@ def _status_doc(  # noqa: PLR0913
         "job_id": uuid.uuid4().hex,
         "status": status,
         "submitter": submitter,
-        "data_tiers": tiers,
+        "data_tier": tier,
         "is_async": False,
         "qnodes": 2,
         "qedges": 1,
         "qpaths": 0,
-        "job_timeout": {"0": 30.0, "1": 60.0},
+        "job_timeout": 30.0,
         "created": created,
         "touched": created,
     }

--- a/tests/utils/mongo_fixtures.py
+++ b/tests/utils/mongo_fixtures.py
@@ -1,0 +1,163 @@
+"""Fixtures + seeding helpers for live MongoClient tests.
+
+Lives under tests/utils/ which is in `norecursedirs` so pytest won't try
+to collect this as test code. Imported from live-marked test modules.
+
+Strategy: keep the MongoClient singleton but redirect its job-collection
+accessor at a uniquely-named test DB for the session, seed it with a
+small varied set of docs, and drop the DB on teardown.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest_asyncio
+from motor.motor_asyncio import AsyncIOMotorCollection
+from pymongo import InsertOne
+
+from retriever.utils.mongo import CODEC_OPTIONS, MongoClient
+
+TEST_DB_PREFIX = "retriever_persist_test_"
+
+
+@pytest_asyncio.fixture
+async def test_mongo(monkeypatch):  # noqa: ANN001
+    """Yield a MongoClient pointed at a seeded, throwaway test database."""
+    client = MongoClient()
+    await client.initialize()
+
+    test_db_name = f"{TEST_DB_PREFIX}{uuid.uuid4().hex[:8]}"
+    test_db = client.client[test_db_name]
+
+    def patched_get_job_collection() -> (
+        tuple[
+            AsyncIOMotorCollection[dict[str, Any]],
+            AsyncIOMotorCollection[dict[str, Any]],
+        ]
+    ):
+        return (
+            test_db.get_collection("job_status", codec_options=CODEC_OPTIONS),
+            test_db.get_collection("job_docs", codec_options=CODEC_OPTIONS),
+        )
+
+    monkeypatch.setattr(client, "get_job_collection", patched_get_job_collection)
+
+    status_collection, _ = patched_get_job_collection()
+    await status_collection.create_index("job_id", unique=True, background=True)
+    await status_collection.create_index("created", background=True)
+    await status_collection.create_index("completed", background=True)
+
+    await _seed(status_collection)
+
+    try:
+        yield client
+    finally:
+        await client.client.drop_database(test_db_name)
+
+
+async def _seed(collection: AsyncIOMotorCollection[dict[str, Any]]) -> None:
+    """Seed a varied set of job_status docs.
+
+    Includes terminal-success / failure / non-terminal jobs across two
+    submitters and two tiers, with varied creation times and durations.
+    """
+    now = datetime.now().astimezone()
+    docs: list[dict[str, Any]] = []
+
+    # Five completed jobs from alice, tier 0, durations 1s..5s, created in
+    # the last hour.
+    for i in range(5):
+        created = now - timedelta(minutes=10 * (i + 1))
+        duration = timedelta(seconds=i + 1)
+        docs.append(
+            _status_doc(
+                status="Complete",
+                submitter="alice",
+                tiers=[0],
+                created=created,
+                completed=created + duration,
+                results=10 + i,
+            )
+        )
+
+    # Three failed jobs from bob, tier 1, mixed failure modes, within window.
+    for failure_status, i in zip(
+        ["Failed", "QueryNotTraversable", "UnsupportedConstraint"],
+        range(3),
+        strict=True,
+    ):
+        created = now - timedelta(minutes=5 * (i + 1))
+        duration = timedelta(seconds=(i + 1) * 2)
+        docs.append(
+            _status_doc(
+                status=failure_status,
+                submitter="bob",
+                tiers=[1],
+                created=created,
+                completed=created + duration,
+                results=0,
+            )
+        )
+
+    # Two in-flight jobs (one each tier).
+    docs.extend(
+        _status_doc(
+            status="Running",
+            submitter="alice" if tier == 0 else "bob",
+            tiers=[tier],
+            created=now - timedelta(minutes=2),
+            completed=None,
+            results=0,
+        )
+        for tier in (0, 1)
+    )
+
+    # One older completed job way outside the typical 1-hour window.
+    old = now - timedelta(days=7)
+    docs.append(
+        _status_doc(
+            status="Complete",
+            submitter="alice",
+            tiers=[0],
+            created=old,
+            completed=old + timedelta(seconds=30),
+            results=100,
+        )
+    )
+
+    await collection.bulk_write([InsertOne(d) for d in docs])  # pyright: ignore[reportUnknownMemberType]
+
+
+def _status_doc(  # noqa: PLR0913
+    *,
+    status: str,
+    submitter: str,
+    tiers: list[int],
+    created: datetime,
+    completed: datetime | None,
+    results: int,
+) -> dict[str, Any]:
+    """Construct a single synthetic job_status document."""
+    doc: dict[str, Any] = {
+        "job_id": uuid.uuid4().hex,
+        "status": status,
+        "submitter": submitter,
+        "data_tiers": tiers,
+        "is_async": False,
+        "qnodes": 2,
+        "qedges": 1,
+        "qpaths": 0,
+        "job_timeout": {"0": 30.0, "1": 60.0},
+        "created": created,
+        "touched": created,
+    }
+    if completed is not None:
+        doc["completed"] = completed
+        doc["knodes"] = 5
+        doc["kedges"] = 3
+        doc["aux_graphs"] = 0
+        doc["results"] = results
+    return doc

--- a/uv.lock
+++ b/uv.lock
@@ -983,7 +983,7 @@ wheels = [
 
 [[package]]
 name = "locust-cloud"
-version = "1.26.3"
+version = "1.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse" },
@@ -992,9 +992,9 @@ dependencies = [
     { name = "python-engineio" },
     { name = "python-socketio", extra = ["client"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/ad/10b299b134068a4250a9156e6832a717406abe1dfea2482a07ae7bdca8f3/locust_cloud-1.26.3.tar.gz", hash = "sha256:587acfd4d2dee715fb5f0c3c2d922770babf0b7cff7b2927afbb693a9cd193cc", size = 456042, upload-time = "2025-07-15T19:51:53.791Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/86/cd6b611f008387ffce5bcb6132ba7431aec7d1b09d8ce27e152e96d94315/locust_cloud-1.30.0.tar.gz", hash = "sha256:324ae23754d49816df96d3f7472357a61cd10e56cebcb26e2def836675cb3c68", size = 457297, upload-time = "2025-12-15T13:35:50.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/6a/276fc50a9d170e7cbb6715735480cb037abb526639bca85491576e6eee4a/locust_cloud-1.26.3-py3-none-any.whl", hash = "sha256:8cb4b8bb9adcd5b99327bc8ed1d98cf67a29d9d29512651e6e94869de6f1faa8", size = 410023, upload-time = "2025-07-15T19:51:52.056Z" },
+    { url = "https://files.pythonhosted.org/packages/85/db/35c1cc8e01dfa570913255c55eb983a7e2e532060b4d1ee5f1fb543a6a0b/locust_cloud-1.30.0-py3-none-any.whl", hash = "sha256:2324b690efa1bfc8d1871340276953cf265328bd6333e07a5ba8ff7dc5e99e6c", size = 413446, upload-time = "2025-12-15T13:35:48.75Z" },
 ]
 
 [[package]]
@@ -1765,15 +1765,15 @@ wheels = [
 
 [[package]]
 name = "python-socketio"
-version = "5.13.0"
+version = "5.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bidict" },
     { name = "python-engineio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/1a/396d50ccf06ee539fa758ce5623b59a9cb27637fc4b2dc07ed08bf495e77/python_socketio-5.13.0.tar.gz", hash = "sha256:ac4e19a0302ae812e23b712ec8b6427ca0521f7c582d6abb096e36e24a263029", size = 121125, upload-time = "2025-04-12T15:46:59.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/81/cf8284f45e32efa18d3848ed82cdd4dcc1b657b082458fbe01ad3e1f2f8d/python_socketio-5.16.1.tar.gz", hash = "sha256:f863f98eacce81ceea2e742f6388e10ca3cdd0764be21d30d5196470edf5ea89", size = 128508, upload-time = "2026-02-06T23:42:07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/32/b4fb8585d1be0f68bde7e110dffbcf354915f77ad8c778563f0ad9655c02/python_socketio-5.13.0-py3-none-any.whl", hash = "sha256:51f68d6499f2df8524668c24bcec13ba1414117cfb3a90115c559b601ab10caf", size = 77800, upload-time = "2025-04-12T15:46:58.412Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c7/deb8c5e604404dbf10a3808a858946ca3547692ff6316b698945bb72177e/python_socketio-5.16.1-py3-none-any.whl", hash = "sha256:a3eb1702e92aa2f2b5d3ba00261b61f062cce51f1cfb6900bf3ab4d1934d2d35", size = 82054, upload-time = "2026-02-06T23:42:05.772Z" },
 ]
 
 [package.optional-dependencies]
@@ -1957,6 +1957,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "orjson" },
     { name = "ormsgpack" },
+    { name = "psutil" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-core" },
     { name = "pydantic-file-secrets" },
@@ -2009,6 +2010,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.51b0" },
     { name = "orjson", specifier = ">=3.11.2" },
     { name = "ormsgpack", specifier = ">=1.10.0" },
+    { name = "psutil", specifier = ">=6.1.1" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.10.3,<3" },
     { name = "pydantic-core", specifier = ">=2.33.1" },
     { name = "pydantic-file-secrets", specifier = ">=0.4.4" },


### PR DESCRIPTION
Completely overhauls dependency handling such that Retriever is able to catch and report dependency outages and contine trucking without them as best it can.

Highlights:

- Fallback from one tier to another (disableable)
- /asyncquery handling even when job state storage is unavailable
- Optable management when Redis is down
- Warnings all around
- HTTP 424 when an endpoint is truly unavailable (with dependency outage details in response)
- /monitor endpoint for a visual overview of status and jobs
- Various fixes