### PR TITLE
Propagate outages across workers

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -55,6 +55,7 @@ redis:
   shutdown_timeout: 3 # Time in seconds to wait for batched tasks to finish before force-quitting.
   heartbeat_interval_seconds: 60 # Cadence at which workers / background / main re-register their process entry.
   process_ttl_seconds: 300 # TTL on each registered process entry; set to several heartbeat intervals so a single missed refresh doesn't drop the entry.
+  propagate_health: true # Broadcast backend outage/recovery over Redis pub/sub so workers pick up outage quickly; falls back to process-local health when off or Redis is down.
 mongo:
   host: localhost
   port: 27017

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,7 +248,7 @@ reportUnusedCallResult = false # Just makes code look worse; Usually unused resu
 reportMissingTypeStubs = false # Sometimes type stubs aren't available and auto-gen is incorrect
 
 [tool.deptry]
-extend_exclude = ["locustfile.py", "tests"]
+extend_exclude = ["locustfile.py", "tests", "scripts"]
 
 [tool.deptry.per_rule_ignores]
 DEP002 = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,58 @@
+# Outage test proxies
+
+Toggleable HTTP reverse proxies that sit between Retriever and a tier backend,
+so you can make a backend fail (and recover) **while the server is running** —
+without touching the real backend's availability. Use them to exercise any
+behavior that depends on a tier being up or down: fallback routing, `/status`
+reporting, cross-process health propagation, query timeouts, degraded modes,
+error responses, and so on.
+
+- `outage_proxy.py` — the shared proxy (forward / `error` / `hang` modes + control routes).
+- `tier0_proxy.py` — launcher for tier 0 (Gandalf), default port `18080`.
+- `tier1_proxy.py` — launcher for tier 1 (Elasticsearch), default port `18081`.
+
+In `pass` mode each proxy forwards transparently to its `--upstream` (the real
+backend). A control call flips it to fail; another flips it back.
+
+## Setup
+
+Run a proxy pointed at the **real** backend, and point Retriever's tier at the
+proxy instead. Either via env vars:
+
+```sh
+uv run python scripts/tier0_proxy.py --upstream https://your-gandalf-host:443
+export TIER0__GANDALF__HOST=http://127.0.0.1 TIER0__GANDALF__PORT=18080
+
+uv run python scripts/tier1_proxy.py --upstream http://your-es-host:9200
+export TIER1__ELASTICSEARCH__HOST=127.0.0.1 TIER1__ELASTICSEARCH__PORT=18081
+```
+
+…or by setting the same fields in `config/config.yaml`. Then start the server
+as usual and send whatever traffic your test needs.
+
+## Control the outage
+
+```sh
+curl -X POST 'http://127.0.0.1:18080/__outage__/down'            # start failing
+curl -X POST 'http://127.0.0.1:18080/__outage__/down?mode=hang'  # start stalling
+curl -X POST 'http://127.0.0.1:18080/__outage__/up'              # recover
+curl      'http://127.0.0.1:18080/__outage__/state'              # inspect mode + upstream
+```
+
+| Mode      | Control                             | Simulates                             |
+| --------- | ----------------------------------- | ------------------------------------- |
+| `error`   | `POST /__outage__/down` (default)   | backend up but returning 503          |
+| `hang`    | `POST /__outage__/down?mode=hang`   | unreachable — stalls past the timeout |
+| recover   | `POST /__outage__/up`               | backend healthy again                 |
+| (inspect) | `GET /__outage__/state`             | current mode + upstream               |
+
+For a hard connection-refused outage, just Ctrl-C the proxy.
+
+## Notes
+
+- The control routes live under the reserved `/__outage__` prefix so they never
+  collide with backend paths; everything else is proxied.
+- `--hang-seconds` (default 8) sets how long `hang` mode stalls; keep it above
+  the driver's connect timeout (5s) so the outage is actually detected.
+- Cross-process behavior (e.g. health propagation) is only observable with more
+  than one worker, so set `workers` in config when that's what you're testing.

--- a/scripts/outage_proxy.py
+++ b/scripts/outage_proxy.py
@@ -1,0 +1,181 @@
+"""Toggleable HTTP reverse proxy for simulating mid-run backend outages.
+
+Sits between Retriever and a tier backend - both Gandalf (tier 0) and
+Elasticsearch (tier 1) speak HTTP, so the same proxy fronts either. In `pass`
+mode it transparently forwards every request upstream; a control call flips it
+to fail (and another flips it back), so you can make a backend go down and
+recover while the server is running - to exercise whatever depends on a tier
+being up or down: fallback routing, `/status`, health propagation, timeouts.
+
+Point a tier at the proxy instead of the real backend (see tier0_proxy.py /
+tier1_proxy.py for the exact overrides), keep the proxy's `--upstream` aimed at
+the real backend, and drive it with the control routes below.
+
+Control routes (under a reserved prefix that never collides with backend paths):
+
+    POST /__outage__/down?mode=error|hang   start failing
+    POST /__outage__/up                      resume forwarding
+    GET  /__outage__/state                   {"mode": ..., "upstream": ...}
+
+Modes:
+    error  return 503 to every proxied request (backend up but erroring)
+    hang   sleep past the driver's connect timeout, then 504 (unreachable)
+
+For a hard connection-refused outage instead, just Ctrl-C the proxy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Literal, cast
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+
+CONTROL_PREFIX = "/__outage__"
+
+Mode = Literal["pass", "error", "hang"]
+OutageMode = Literal["error", "hang"]
+
+# Connection-level headers that must not be forwarded verbatim.
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+    }
+)
+# httpx already decodes the upstream body and sets a fresh length, so echoing
+# the upstream's own values would corrupt the response.
+_RESP_STRIP = _HOP_BY_HOP | {"content-encoding", "content-length"}
+_REQ_STRIP = _HOP_BY_HOP | {"content-length"}
+
+_PROXY_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+
+
+def build_app(*, upstream: str, name: str, hang_seconds: float) -> FastAPI:
+    """Build the reverse-proxy app forwarding to `upstream`, gated by a mode flag."""
+    upstream = upstream.rstrip("/")
+    state: dict[str, Mode] = {"mode": "pass"}
+    client: httpx.AsyncClient | None = None
+
+    @asynccontextmanager
+    async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+        nonlocal client
+        client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+        print(f"[{name}] forwarding to {upstream}")
+        yield
+        await client.aclose()
+
+    app = FastAPI(lifespan=lifespan, title=f"{name} outage proxy")
+
+    @app.post(f"{CONTROL_PREFIX}/down")
+    async def down(mode: OutageMode = "error") -> Response:
+        state["mode"] = mode
+        print(f"[{name}] >>> OUTAGE (mode={mode})")
+        return JSONResponse({"mode": mode})
+
+    @app.post(f"{CONTROL_PREFIX}/up")
+    async def up() -> Response:
+        state["mode"] = "pass"
+        print(f"[{name}] <<< RECOVERED")
+        return JSONResponse({"mode": "pass"})
+
+    @app.get(f"{CONTROL_PREFIX}/state")
+    async def get_state() -> Response:
+        return JSONResponse({"mode": state["mode"], "upstream": upstream})
+
+    @app.api_route("/{path:path}", methods=_PROXY_METHODS)
+    async def proxy(request: Request, path: str) -> Response:
+        mode = state["mode"]
+        if mode == "error":
+            return Response(b"outage-proxy: simulated outage", status_code=503)
+        if mode == "hang":
+            await asyncio.sleep(hang_seconds)
+            return Response(b"outage-proxy: simulated hang", status_code=504)
+
+        assert client is not None
+        body = await request.body()
+        req = client.build_request(
+            request.method,
+            f"{upstream}/{path}",
+            params=request.url.query,
+            headers=[
+                (k, v)
+                for k, v in request.headers.items()
+                if k.lower() not in _REQ_STRIP
+            ],
+            content=body,
+        )
+        try:
+            upstream_resp = await client.send(req)
+        except httpx.HTTPError as exc:
+            return Response(
+                f"outage-proxy: upstream error: {exc}".encode(), status_code=502
+            )
+        return Response(
+            content=upstream_resp.content,
+            status_code=upstream_resp.status_code,
+            headers={
+                k: v
+                for k, v in upstream_resp.headers.items()
+                if k.lower() not in _RESP_STRIP
+            },
+        )
+
+    return app
+
+
+def run(*, name: str, upstream: str, host: str, port: int, hang_seconds: float) -> None:
+    """Print usage hints and serve the proxy until interrupted."""
+    app = build_app(upstream=upstream, name=name, hang_seconds=hang_seconds)
+    base = f"http://{host}:{port}"
+    print(f"[{name}] outage proxy listening on {base}  ->  {upstream}")
+    print(f"[{name}]   knock it down:  curl -X POST '{base}{CONTROL_PREFIX}/down'")
+    print(
+        f"[{name}]   (or hang mode): curl -X POST '{base}{CONTROL_PREFIX}/down?mode=hang'"
+    )
+    print(f"[{name}]   bring it back:  curl -X POST '{base}{CONTROL_PREFIX}/up'")
+    uvicorn.run(app, host=host, port=port, log_level="warning")
+
+
+def main() -> None:
+    """Generic entrypoint; the tier scripts wrap this with per-tier defaults."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upstream",
+        required=True,
+        help="Base URL of the REAL backend to forward to, e.g. http://localhost:9200",
+    )
+    parser.add_argument("--name", default="proxy", help="Label used in log output.")
+    parser.add_argument("--host", default="127.0.0.1", help="Listen host.")
+    parser.add_argument("--port", type=int, required=True, help="Listen port.")
+    parser.add_argument(
+        "--hang-seconds",
+        type=float,
+        default=8.0,
+        help="Seconds to stall in `hang` mode (keep above the driver's connect timeout).",
+    )
+    args = parser.parse_args()
+    run(
+        name=cast(str, args.name),
+        upstream=cast(str, args.upstream),
+        host=cast(str, args.host),
+        port=cast(int, args.port),
+        hang_seconds=cast(float, args.hang_seconds),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tier0_proxy.py
+++ b/scripts/tier0_proxy.py
@@ -1,0 +1,60 @@
+"""Outage proxy for the tier 0 (Gandalf) backend.
+
+Run it pointed at the real Gandalf endpoint, then point Retriever's tier 0 at
+the proxy:
+
+    uv run python scripts/tier0_proxy.py --upstream https://your-gandalf-host:443
+
+    # In Retriever's environment (the proxy defaults to port 18080):
+    export TIER0__GANDALF__HOST=http://127.0.0.1
+    export TIER0__GANDALF__PORT=18080
+
+Then start the server and, mid-run, toggle the backend to test how Retriever
+behaves while tier 0 is down and when it recovers:
+
+    curl -X POST 'http://127.0.0.1:18080/__outage__/down'   # gandalf goes down
+    curl -X POST 'http://127.0.0.1:18080/__outage__/up'     # gandalf recovers
+
+See scripts/README.md for modes and the full flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from outage_proxy import run  # noqa: E402
+
+DEFAULT_PORT = 18080
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upstream",
+        required=True,
+        help="Base URL of the REAL Gandalf endpoint, e.g. https://your-gandalf-host:443",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Listen host.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Listen port.")
+    parser.add_argument(
+        "--hang-seconds",
+        type=float,
+        default=8.0,
+        help="Seconds to stall in `hang` mode (above the tier-0 connect timeout, 5s).",
+    )
+    args = parser.parse_args()
+    run(
+        name="tier0-gandalf",
+        upstream=args.upstream,
+        host=args.host,
+        port=args.port,
+        hang_seconds=args.hang_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tier1_proxy.py
+++ b/scripts/tier1_proxy.py
@@ -1,0 +1,60 @@
+"""Outage proxy for the tier 1 (Elasticsearch) backend.
+
+Run it pointed at the real Elasticsearch, then point Retriever's tier 1 at the
+proxy:
+
+    uv run python scripts/tier1_proxy.py --upstream http://your-es-host:9200
+
+    # In Retriever's environment (the proxy defaults to port 18081):
+    export TIER1__ELASTICSEARCH__HOST=127.0.0.1
+    export TIER1__ELASTICSEARCH__PORT=18081
+
+Then start the server and, mid-run, toggle the backend to test how Retriever
+behaves while tier 1 is down and when it recovers:
+
+    curl -X POST 'http://127.0.0.1:18081/__outage__/down'   # ES goes down
+    curl -X POST 'http://127.0.0.1:18081/__outage__/up'     # ES recovers
+
+See scripts/README.md for modes and the full flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from outage_proxy import run  # noqa: E402
+
+DEFAULT_PORT = 18081
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upstream",
+        required=True,
+        help="Base URL of the REAL Elasticsearch, e.g. http://your-es-host:9200",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Listen host.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Listen port.")
+    parser.add_argument(
+        "--hang-seconds",
+        type=float,
+        default=8.0,
+        help="Seconds to stall in `hang` mode (above the tier-1 connect timeout, 5s).",
+    )
+    args = parser.parse_args()
+    run(
+        name="tier1-elasticsearch",
+        upstream=args.upstream,
+        host=args.host,
+        port=args.port,
+        hang_seconds=args.hang_seconds,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/retriever/background.py
+++ b/src/retriever/background.py
@@ -16,6 +16,7 @@ from retriever.data_tiers import tier_manager
 from retriever.lookup.subclass import SubclassMapping
 from retriever.metadata.optable import OpTableManager
 from retriever.utils.general import tolerate_init
+from retriever.utils.health_coordinator import HealthCoordinator
 from retriever.utils.logs import add_mongo_sink
 from retriever.utils.mongo import MongoClient, MongoQueue
 from retriever.utils.orphan_detection import periodically_mark_orphans
@@ -59,6 +60,7 @@ async def _background_async() -> None:
     subclass_manager = SubclassMapping()
     subclass_manager.promote_to_leader()
     await tolerate_init("Subclass map build", subclass_manager.initialize())
+    await tolerate_init("Health propagation", HealthCoordinator().start())
     orphan_task = asyncio.create_task(
         periodically_mark_orphans(), name="orphan-detection"
     )
@@ -78,6 +80,8 @@ async def _background_async() -> None:
     orphan_task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await orphan_task
+    # Clear health observers/subscription before dependencies wrap up.
+    await HealthCoordinator().stop()
     # Heartbeat task lives in RedisClient().tasks; cancelled in its wrapup.
     await SubclassMapping().wrapup()
     await metakg_manager.wrapup()

--- a/src/retriever/config/general.py
+++ b/src/retriever/config/general.py
@@ -74,6 +74,12 @@ class RedisSettings(BaseModel):
             description="TTL on each registered process entry; set to several heartbeat intervals so a single missed refresh doesn't drop the entry."
         ),
     ] = 300
+    propagate_health: Annotated[
+        bool,
+        Field(
+            description="Broadcast backend outage/recovery over Redis pub/sub so workers pick up outage quickly; falls back to process-local health when off or Redis is down."
+        ),
+    ] = True
 
 
 class MongoSettings(BaseModel):

--- a/src/retriever/server.py
+++ b/src/retriever/server.py
@@ -45,6 +45,7 @@ from retriever.utils.compression import ZstdRequestMiddleware
 from retriever.utils.examples import EXAMPLE_QUERY
 from retriever.utils.exception_handlers import ensure_cors, http_exception_handler
 from retriever.utils.general import tolerate_init
+from retriever.utils.health_coordinator import HealthCoordinator
 from retriever.utils.logs import (
     add_mongo_sink,
     cleanup,
@@ -116,6 +117,7 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
     if CONFIG.tier0.dump_queries or CONFIG.tier1.dump_queries:
         await query_dumper.initialize()
     await SubqueryDispatcher().initialize()
+    await tolerate_init("Health propagation", HealthCoordinator().start())
 
     yield  # Separates startup/shutdown phase
 
@@ -127,6 +129,8 @@ async def lifespan(_: FastAPI) -> AsyncGenerator[None]:
             "Worker deregistration failed; entry will expire via TTL.",
             no_mongo_log=True,
         )
+    # Clear health observers/subscription before dependencies wrap up.
+    await HealthCoordinator().stop()
     await SubqueryDispatcher().wrapup()
     if query_dumper.initialized:
         await query_dumper.wrapup()

--- a/src/retriever/utils/backend_client.py
+++ b/src/retriever/utils/backend_client.py
@@ -66,6 +66,11 @@ class BackendClient(AsyncDaemon, ABC):
     _client_lock: asyncio.Lock
     """Serializes lazy client (re)builds in `_ensure_client`."""
 
+    _transition_observer: Callable[[Literal["outage", "recovery"]], None] | None
+    """Fired only on locally-detected (ping-driven) transitions, never on
+    remote-applied ones; lets a health coordinator broadcast this process's
+    own detections without echoing states it merely received."""
+
     def __init__(self) -> None:
         """Initialize state. Assume up until failure."""
         super().__init__()
@@ -80,6 +85,18 @@ class BackendClient(AsyncDaemon, ABC):
         self._up_event.set()
         self._callback_tasks = set()
         self._client_lock = asyncio.Lock()
+        self._transition_observer = None
+
+    @property
+    def health_key(self) -> str:
+        """Stable cross-process identity for this backend in health messages."""
+        return type(self).__name__
+
+    def set_transition_observer(
+        self, observer: Callable[[Literal["outage", "recovery"]], None] | None
+    ) -> None:
+        """Register (or clear, with `None`) the local-transition observer."""
+        self._transition_observer = observer
 
     @abstractmethod
     async def ping(self) -> None:
@@ -330,25 +347,72 @@ class BackendClient(AsyncDaemon, ABC):
         return True
 
     def _handle_ping_failure(self, exc: BaseException) -> None:
-        """Record the failure; on first outage fire callbacks."""
-        self.last_error = f"{type(exc).__name__}: {exc}"
-        if self.up:
-            self.up = False
-            self._up_event.clear()
-            self.last_outage = datetime.now().astimezone()
-            logger.warning(f"{type(self).__name__} down: {self.last_error}")
-            self._fire_callbacks(self._outage_callbacks, "outage")
+        """Record a locally-detected ping failure; on first outage fire callbacks."""
+        self._record_outage(f"{type(exc).__name__}: {exc}", local=True)
 
     def _handle_ping_success(self) -> None:
-        """Record recovery and fire on_recover callbacks. Idempotent."""
+        """Record a locally-detected ping success. Idempotent."""
+        self._record_recovery(local=True)
+
+    def note_remote_outage(
+        self, error: str | None = None, occurred_at: datetime | None = None
+    ) -> None:
+        """Apply an outage another process detected; idempotent, never re-broadcast.
+
+        Marks this backend down so callers fall back immediately, then nudges
+        the health loop: for on-demand drivers this wakes the loop out of its
+        parked state so it begins backoff pinging and can self-confirm recovery.
+        """
+        self._record_outage(
+            error or "Reported down by another process",
+            local=False,
+            occurred_at=occurred_at,
+        )
+        self.request_health_check()
+
+    def note_remote_recovery(self, recovered_at: datetime | None = None) -> None:
+        """Apply a recovery another process detected; idempotent, never re-broadcast.
+
+        Optimistically marks this backend up so routing returns to normal at
+        once; a stale trust self-corrects when the next local ping/query fails.
+        The health check confirms promptly.
+        """
+        self._record_recovery(local=False, recovered_at=recovered_at)
+        self.request_health_check()
+
+    def _record_outage(
+        self,
+        error: str,
+        *,
+        local: bool,
+        occurred_at: datetime | None = None,
+    ) -> None:
+        """Transition to down (idempotent), firing callbacks and, if `local`, the observer."""
+        self.last_error = error
+        if not self.up:
+            return
+        self.up = False
+        self._up_event.clear()
+        self.last_outage = occurred_at or datetime.now().astimezone()
+        logger.warning(f"{type(self).__name__} down: {self.last_error}")
+        self._fire_callbacks(self._outage_callbacks, "outage")
+        if local and self._transition_observer is not None:
+            self._transition_observer("outage")
+
+    def _record_recovery(
+        self, *, local: bool, recovered_at: datetime | None = None
+    ) -> None:
+        """Transition to up (idempotent), firing callbacks and, if `local`, the observer."""
         if self.up:
             return
         self.up = True
         self._up_event.set()
-        self.last_recovery = datetime.now().astimezone()
+        self.last_recovery = recovered_at or datetime.now().astimezone()
         self.last_error = None
-        logger.success(f"{type(self).__name__} up: ping succeeded.")
+        logger.success(f"{type(self).__name__} up.")
         self._fire_callbacks(self._recovery_callbacks, "recovery")
+        if local and self._transition_observer is not None:
+            self._transition_observer("recovery")
 
     def _fire_callbacks(
         self,

--- a/src/retriever/utils/health_coordinator.py
+++ b/src/retriever/utils/health_coordinator.py
@@ -1,0 +1,158 @@
+"""Cross-process backend outage/recovery propagation over Redis pub/sub.
+
+Each process publishes only the transitions it detects itself (wired via the
+`BackendClient` transition observer) and applies transitions detected
+elsewhere to its own singletons - flipping a peer to fallback the moment any
+one process sees a backend go down, instead of each waiting to detect it
+independently. Outages are applied immediately (fail-safe); recoveries are
+trusted optimistically and self-correct on the next failed local ping.
+
+When Redis is unavailable nothing is published or received, and every process
+falls back to its own process-local health loop.
+"""
+
+import asyncio
+import contextlib
+import json
+import os
+from collections.abc import Callable
+from datetime import datetime
+from typing import Literal, cast
+
+from loguru import logger
+
+from retriever.config.general import CONFIG
+from retriever.data_tiers import tier_manager
+from retriever.utils.backend_client import BackendClient
+from retriever.utils.general import Singleton
+from retriever.utils.mongo import MongoClient
+from retriever.utils.redis import (
+    BACKEND_HEALTH_CHANNEL,
+    BackendHealthMessage,
+    RedisClient,
+)
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 transition timestamp, tolerating missing/garbage input."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+class HealthCoordinator(metaclass=Singleton):
+    """Propagates tier-driver and Mongo health across processes via Redis.
+
+    One instance per process. `start()` registers a broadcast observer on each
+    tracked client and subscribes to `BACKEND_HEALTH_CHANNEL`; `stop()` tears
+    both down. Redis itself is intentionally untracked - it can't announce its
+    own outage over itself.
+    """
+
+    _clients: dict[str, BackendClient]
+    """Tracked backends keyed by `health_key`; populated on `start()`."""
+
+    _publish_tasks: set[asyncio.Task[None]]
+    """Strong refs to in-flight publish tasks so they aren't GC'd early."""
+
+    _started: bool
+
+    def __init__(self) -> None:
+        """Instantiate with no clients tracked; call `start()` to wire up."""
+        self._clients = {}
+        self._publish_tasks = set()
+        self._started = False
+
+    def _tracked_clients(self) -> tuple[BackendClient, ...]:
+        """The backends whose health is propagated (tier drivers + Mongo)."""
+        return (
+            tier_manager.get_driver(0),
+            tier_manager.get_driver(1),
+            MongoClient(),
+        )
+
+    async def start(self) -> None:
+        """Register observers and subscribe. No-op if disabled or already started."""
+        if self._started or not CONFIG.redis.propagate_health:
+            return
+        self._clients = {
+            client.health_key: client for client in self._tracked_clients()
+        }
+        for client in self._clients.values():
+            client.set_transition_observer(self._make_observer(client))
+        with contextlib.suppress(Exception):
+            await RedisClient().subscribe(BACKEND_HEALTH_CHANNEL, self._on_message)
+        self._started = True
+        logger.info("Backend health propagation enabled.")
+
+    async def stop(self) -> None:
+        """Unsubscribe, clear observers, and cancel in-flight publishes. Idempotent."""
+        if not self._started:
+            return
+        self._started = False
+        with contextlib.suppress(Exception):
+            await RedisClient().unsubscribe(BACKEND_HEALTH_CHANNEL, self._on_message)
+        for client in self._clients.values():
+            client.set_transition_observer(None)
+        self._clients = {}
+        for task in self._publish_tasks:
+            _ = task.cancel()
+        for task in list(self._publish_tasks):
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    def _make_observer(
+        self, client: BackendClient
+    ) -> Callable[[Literal["outage", "recovery"]], None]:
+        """Build a per-client observer that broadcasts this process's own transitions."""
+
+        def _observe(event: Literal["outage", "recovery"]) -> None:
+            task = asyncio.create_task(self._publish(client, event))
+            self._publish_tasks.add(task)
+            _ = task.add_done_callback(self._publish_tasks.discard)
+
+        return _observe
+
+    async def _publish(
+        self, client: BackendClient, event: Literal["outage", "recovery"]
+    ) -> None:
+        """Publish one transition; skipped while Redis is down (process-local fallback)."""
+        redis_client = RedisClient()
+        if not redis_client.up:
+            return
+        message: BackendHealthMessage = {
+            "backend": client.health_key,
+            "event": event,
+            "pid": os.getpid(),
+            "at": datetime.now().astimezone().isoformat(),
+            "error": client.last_error,
+        }
+        try:
+            await redis_client.publish(BACKEND_HEALTH_CHANNEL, json.dumps(message))
+        except Exception:
+            logger.debug(f"Failed to publish {event} for {client.health_key} to Redis.")
+
+    async def _on_message(self, raw: str) -> None:
+        """Apply a peer's transition to the matching local client; ignore own echoes."""
+        try:
+            payload = json.loads(raw)
+        except ValueError:
+            logger.debug("Discarding malformed backend health message.")
+            return
+        if not isinstance(payload, dict):
+            return
+        message = cast(BackendHealthMessage, cast(object, payload))
+        if message.get("pid") == os.getpid():
+            return
+        client = self._clients.get(message.get("backend", ""))
+        if client is None:
+            return
+        occurred_at = _parse_timestamp(message.get("at"))
+        event = message.get("event")
+        if event == "outage":
+            client.note_remote_outage(message.get("error"), occurred_at=occurred_at)
+        elif event == "recovery":
+            client.note_remote_recovery(recovered_at=occurred_at)

--- a/src/retriever/utils/redis.py
+++ b/src/retriever/utils/redis.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from types import CoroutineType, TracebackType
 from typing import (
     Any,
+    Literal,
     Protocol,
     Self,
     TypedDict,
@@ -37,6 +38,11 @@ OP_TABLE_UPDATE_CHANNEL = "op_table:update"
 # Worker -> leader signal for a tier recovery; payload is the tier index as a string.
 TIER_RECOVERED_CHANNEL = "tier:recovered"
 
+# Cross-process backend outage/recovery propagation; payload is a JSON
+# BackendHealthMessage. Lets one process's detected outage flip peers to
+# fallback without each waiting to detect it independently.
+BACKEND_HEALTH_CHANNEL = "backend:health"
+
 # Timestamp keys written alongside published artifacts so /status
 # can show freshness without inferring from TTL.
 OP_TABLE_META_KEY = f"{PREFIX}op_table:meta"
@@ -62,6 +68,19 @@ class FreshnessRecord(TypedDict):
 
     refreshed_at: datetime
     count: int
+
+
+class BackendHealthMessage(TypedDict):
+    """A backend outage/recovery broadcast on `BACKEND_HEALTH_CHANNEL`."""
+
+    backend: str
+    """The originating client's `health_key`."""
+    event: Literal["outage", "recovery"]
+    pid: int
+    """Publisher's PID; receivers drop their own echoes."""
+    at: str
+    """ISO-8601 transition timestamp."""
+    error: str | None
 
 
 class PubSubMessage(TypedDict):

--- a/src/retriever/utils/service_health.py
+++ b/src/retriever/utils/service_health.py
@@ -1,10 +1,13 @@
 """Service-health snapshot and degradation policy.
 
-`Snapshot()` captures a frozen, process-local view of every backend
-dependency's `up`/`error` state at the moment it's constructed; its
-methods answer the per-request questions that follow from that view
-- what HTTP status to return, which tier to route to, what warning
-text to attach. No cross-process consensus.
+`Snapshot()` captures a frozen view of every backend dependency's
+`up`/`error` state at the moment it's constructed; its methods answer
+the per-request questions that follow from that view - what HTTP status
+to return, which tier to route to, what warning text to attach. The
+read is process-local, but tier-driver and Mongo health converge across
+processes via `HealthCoordinator` (Redis pub/sub), so the view is
+consistent between workers except during the brief propagation window
+or while Redis is down.
 """
 
 from __future__ import annotations

--- a/tests/test_utils_backend_client.py
+++ b/tests/test_utils_backend_client.py
@@ -1,0 +1,109 @@
+"""Unit tests for BackendClient's remote-apply API and broadcast observer.
+
+These exercise the state machine that HealthCoordinator drives: locally
+detected transitions fire the observer (and get broadcast), while
+remote-applied ones mutate state without re-broadcasting.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from retriever.utils.backend_client import BackendClient
+from retriever.utils.general import Singleton
+
+
+class _FakeClient(BackendClient):
+    """Minimal concrete BackendClient with a no-op ping for state-machine tests."""
+
+    async def ping(self) -> None:
+        return None
+
+
+@pytest.fixture
+def client() -> _FakeClient:
+    """A fresh _FakeClient, bypassing the Singleton cache for test isolation."""
+    _ = Singleton._instances.pop(_FakeClient, None)
+    return _FakeClient()
+
+
+def test_health_key_defaults_to_class_name(client: _FakeClient) -> None:
+    assert client.health_key == "_FakeClient"
+
+
+def test_remote_outage_marks_down_without_broadcast(client: _FakeClient) -> None:
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+
+    client.note_remote_outage("boom")
+
+    assert client.up is False
+    assert client.last_error == "boom"
+    assert client.last_outage is not None
+    assert not client._up_event.is_set()
+    assert client._check_event.is_set()  # nudged so the health loop takes over
+    observer.assert_not_called()  # remote-applied transitions never re-broadcast
+
+
+def test_remote_outage_is_idempotent(client: _FakeClient) -> None:
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+
+    client.note_remote_outage("first")
+    first_outage = client.last_outage
+    client.note_remote_outage("second")
+
+    assert client.last_outage == first_outage  # still down; timestamp unchanged
+    assert client.last_error == "second"  # error still refreshes
+    observer.assert_not_called()
+
+
+def test_remote_recovery_is_optimistic(client: _FakeClient) -> None:
+    client.note_remote_outage("down")
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+    client._check_event.clear()
+
+    client.note_remote_recovery()
+
+    assert client.up is True
+    assert client._up_event.is_set()
+    assert client.last_recovery is not None
+    assert client.last_error is None
+    assert client._check_event.is_set()  # nudged to confirm promptly
+    observer.assert_not_called()
+
+
+def test_remote_recovery_noop_when_already_up(client: _FakeClient) -> None:
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+
+    assert client.up is True
+    client.note_remote_recovery()
+
+    assert client.up is True
+    assert client.last_recovery is None  # no transition occurred
+    observer.assert_not_called()
+
+
+def test_local_transitions_fire_observer(client: _FakeClient) -> None:
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+
+    client._handle_ping_failure(RuntimeError("down"))
+    observer.assert_called_once_with("outage")
+
+    observer.reset_mock()
+    client._handle_ping_success()
+    observer.assert_called_once_with("recovery")
+
+
+def test_local_transitions_idempotent_observer(client: _FakeClient) -> None:
+    observer = MagicMock()
+    client.set_transition_observer(observer)
+
+    client._handle_ping_failure(RuntimeError("down"))
+    client._handle_ping_failure(RuntimeError("still down"))
+    observer.assert_called_once_with("outage")  # only the first flip broadcasts

--- a/tests/test_utils_health_coordinator.py
+++ b/tests/test_utils_health_coordinator.py
@@ -1,0 +1,179 @@
+"""Unit tests for HealthCoordinator's publish/apply logic.
+
+The Redis client, tier drivers, and Mongo singleton are mocked so the
+propagation decisions can be exercised without a live backend.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from retriever.config.general import CONFIG
+from retriever.utils import health_coordinator as hc
+from retriever.utils.general import Singleton
+from retriever.utils.health_coordinator import HealthCoordinator
+
+
+def _fresh() -> HealthCoordinator:
+    """A fresh coordinator, bypassing the Singleton cache for test isolation."""
+    _ = Singleton._instances.pop(HealthCoordinator, None)
+    return HealthCoordinator()
+
+
+def _message(event: str, *, pid: int, backend: str = "GandalfDriver") -> str:
+    return json.dumps(
+        {
+            "backend": backend,
+            "event": event,
+            "pid": pid,
+            "at": datetime.now().astimezone().isoformat(),
+            "error": "boom" if event == "outage" else None,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_message_applies_remote_outage() -> None:
+    coord = _fresh()
+    driver = MagicMock()
+    coord._clients = {"GandalfDriver": driver}
+
+    await coord._on_message(_message("outage", pid=os.getpid() + 1))
+
+    driver.note_remote_outage.assert_called_once()
+    driver.note_remote_recovery.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_applies_remote_recovery() -> None:
+    coord = _fresh()
+    driver = MagicMock()
+    coord._clients = {"GandalfDriver": driver}
+
+    await coord._on_message(_message("recovery", pid=os.getpid() + 1))
+
+    driver.note_remote_recovery.assert_called_once()
+    driver.note_remote_outage.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_own_echo() -> None:
+    coord = _fresh()
+    driver = MagicMock()
+    coord._clients = {"GandalfDriver": driver}
+
+    await coord._on_message(_message("outage", pid=os.getpid()))
+
+    driver.note_remote_outage.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_unknown_backend() -> None:
+    coord = _fresh()
+    driver = MagicMock()
+    coord._clients = {"GandalfDriver": driver}
+
+    await coord._on_message(
+        _message("outage", pid=os.getpid() + 1, backend="SomethingElse")
+    )
+
+    driver.note_remote_outage.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_on_message_tolerates_malformed_payload() -> None:
+    coord = _fresh()
+    coord._clients = {"GandalfDriver": MagicMock()}
+
+    # Should not raise on non-JSON or non-object payloads.
+    await coord._on_message("not json{")
+    await coord._on_message("42")
+
+
+@pytest.mark.asyncio
+async def test_publish_skips_when_redis_down(monkeypatch: pytest.MonkeyPatch) -> None:
+    coord = _fresh()
+    redis = MagicMock()
+    redis.up = False
+    redis.publish = AsyncMock()
+    monkeypatch.setattr(hc, "RedisClient", lambda: redis)
+
+    client = MagicMock()
+    client.health_key = "MongoClient"
+    client.last_error = None
+    await coord._publish(client, "outage")
+
+    redis.publish.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_publish_sends_when_redis_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    coord = _fresh()
+    redis = MagicMock()
+    redis.up = True
+    redis.publish = AsyncMock()
+    monkeypatch.setattr(hc, "RedisClient", lambda: redis)
+
+    client = MagicMock()
+    client.health_key = "MongoClient"
+    client.last_error = "x"
+    await coord._publish(client, "recovery")
+
+    redis.publish.assert_awaited_once()
+    channel, payload = redis.publish.await_args.args
+    assert channel == hc.BACKEND_HEALTH_CHANNEL
+    body = json.loads(payload)
+    assert body["backend"] == "MongoClient"
+    assert body["event"] == "recovery"
+    assert body["pid"] == os.getpid()
+
+
+@pytest.mark.asyncio
+async def test_start_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    coord = _fresh()
+    monkeypatch.setattr(CONFIG.redis, "propagate_health", False)
+
+    await coord.start()
+
+    assert coord._started is False
+    assert coord._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_start_wires_observers_and_subscribes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coord = _fresh()
+    monkeypatch.setattr(CONFIG.redis, "propagate_health", True)
+
+    redis = MagicMock()
+    redis.subscribe = AsyncMock()
+    monkeypatch.setattr(hc, "RedisClient", lambda: redis)
+
+    d0 = MagicMock()
+    d0.health_key = "GandalfDriver"
+    d1 = MagicMock()
+    d1.health_key = "ElasticSearchDriver"
+    mongo = MagicMock()
+    mongo.health_key = "MongoClient"
+    monkeypatch.setattr(hc.tier_manager, "get_driver", lambda t: {0: d0, 1: d1}[t])
+    monkeypatch.setattr(hc, "MongoClient", lambda: mongo)
+
+    await coord.start()
+
+    assert coord._started is True
+    redis.subscribe.assert_awaited_once()
+    assert redis.subscribe.await_args.args[0] == hc.BACKEND_HEALTH_CHANNEL
+    d0.set_transition_observer.assert_called_once()
+    d1.set_transition_observer.assert_called_once()
+    mongo.set_transition_observer.assert_called_once()
+    assert set(coord._clients) == {
+        "GandalfDriver",
+        "ElasticSearchDriver",
+        "MongoClient",
+    }


### PR DESCRIPTION
Ensures outages are handled uniformly and quickly across workers, with quicker downs and quicker recoveries.

Also adds proxy scripts for outage simulation testing.